### PR TITLE
Align CI/test setup with SimpleDoc and expand coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
+          check-latest: true
           cache: npm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsup src/cli.ts --format esm --dts --clean",
     "build:test": "tsc -p tsconfig.test.json",
-    "test": "npm run build:test && find dist-test/test -name '*.test.js' -exec node --experimental-test-module-mocks --test {} +",
+    "test": "npm run build:test && node --test dist-test/test/*.test.js",
     "prepare": "husky",
     "precommit": "npm exec -- lint-staged && npm run -s build",
     "prepack": "npm run build",

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -24,8 +24,9 @@ test("resolveAgentCommand returns raw value for unknown agents", () => {
   assert.equal(resolveAgentCommand("custom-acp-server"), "custom-acp-server");
 });
 
-test("listBuiltInAgents returns all registered agent names", () => {
+test("listBuiltInAgents returns exactly all 5 registered agent names", () => {
   const agents = listBuiltInAgents();
+  assert.equal(agents.length, 5);
   assert.deepEqual(
     new Set(agents),
     new Set(["codex", "claude", "gemini", "opencode", "pi"]),


### PR DESCRIPTION
## Summary
- switch CI Node runtime to 24 with check-latest enabled
- simplify test script to Node 24 glob runner
- add/expand tests for ttl parsing, sessions new help surface, ttl normalization edge cases, and explicit 5-agent registry coverage
- remove module-mock-dependent session test path so tests run without experimental flags

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- npm test