### PR TITLE
feat: add sessions read command to show full session history

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1118,7 +1118,9 @@ function printSessionHistoryByFormat(
   format: OutputFormat,
 ): void {
   const history = record.turnHistory ?? [];
-  const visible = history.slice(Math.max(0, history.length - limit));
+  // limit === 0 means show all entries
+  const visible =
+    limit === 0 ? history : history.slice(Math.max(0, history.length - limit));
 
   if (format === "json") {
     process.stdout.write(
@@ -1428,6 +1430,29 @@ function registerSessionsCommand(
       flags: SessionsHistoryFlags,
     ) {
       await handleSessionsHistory(explicitAgentName, name, flags, this, config);
+    });
+
+  sessionsCommand
+    .command("read")
+    .description("Read full session content (all history entries)")
+    .argument("[name]", "Session name", parseSessionName)
+    .option(
+      "--tail <count>",
+      "Show only the last N entries instead of all",
+      parseHistoryLimit,
+    )
+    .action(async function (
+      this: Command,
+      name: string | undefined,
+      flags: { tail?: number },
+    ) {
+      await handleSessionsHistory(
+        explicitAgentName,
+        name,
+        { limit: flags.tail ?? 0 },
+        this,
+        config,
+      );
     });
 }
 


### PR DESCRIPTION
## Summary

Closes #16

Adds `acpx <agent> sessions read` as a user-friendly command to read the full session history without resuming the agent interactively.

## Problem

Users asked for a way to see what the agent already did (`sessions read` or `sessions history --tail`). While `sessions history` exists, it defaults to the last 20 entries and has a less intuitive name for the "read my session" use case.

## Changes

- Adds `sessions read [name]` subcommand that shows **all** history entries by default
- Supports `--tail <N>` flag to restrict output to the last N entries (mirrors the `tail` UX from the issue)
- Updates `printSessionHistoryByFormat` to treat `limit === 0` as "show all entries"
- Reuses the existing `handleSessionsHistory` handler — no logic duplication

## Usage

```
# Show all history for the current cwd session
acpx codex sessions read

# Show all history for a named session
acpx codex sessions read backend

# Show only the last 5 entries
acpx codex sessions read --tail 5

# JSON output
acpx codex sessions read --format json
```

---
🤖 Generated with Claude Code