### PR TITLE
CLI: add dynamic --version resolution

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import {
   sendSession,
 } from "./session.js";
 import { normalizeAgentSessionId } from "./agent-session-id.js";
+import { getAcpxVersion } from "./version.js";
 import {
   AUTH_POLICIES,
   EXIT_CODES,
@@ -1858,6 +1859,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
   program
     .name("acpx")
     .description("Headless CLI client for the Agent Client Protocol")
+    .version(getAcpxVersion())
     .enablePositionalOptions()
     .showHelpAfterError();
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,7 @@ import {
 import { FileSystemHandlers } from "./filesystem.js";
 import { classifyPermissionDecision, resolvePermissionRequest } from "./permissions.js";
 import { extractAgentSessionId } from "./agent-session-id.js";
+import { getAcpxVersion } from "./version.js";
 import { TerminalManager } from "./terminal.js";
 import type { AcpClientOptions, PermissionStats } from "./types.js";
 
@@ -511,7 +512,7 @@ export class AcpClient {
         },
         clientInfo: {
           name: "acpx",
-          version: "0.1.0",
+          version: getAcpxVersion(),
         },
       });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const UNKNOWN_VERSION = "0.0.0-unknown";
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+let cachedVersion: string | null = null;
+
+function parseVersion(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readPackageVersion(packageJsonPath: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      version?: unknown;
+    };
+    return parseVersion(parsed.version);
+  } catch {
+    return null;
+  }
+}
+
+function resolveVersionFromAncestors(startDir: string): string | null {
+  let current = startDir;
+  while (true) {
+    const packageVersion = readPackageVersion(path.join(current, "package.json"));
+    if (packageVersion) {
+      return packageVersion;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+export function resolveAcpxVersion(params?: {
+  env?: NodeJS.ProcessEnv;
+  packageJsonPath?: string;
+}): string {
+  const envVersion = parseVersion((params?.env ?? process.env).npm_package_version);
+  if (envVersion) {
+    return envVersion;
+  }
+
+  if (params?.packageJsonPath) {
+    return readPackageVersion(params.packageJsonPath) ?? UNKNOWN_VERSION;
+  }
+
+  return resolveVersionFromAncestors(MODULE_DIR) ?? UNKNOWN_VERSION;
+}
+
+export function getAcpxVersion(): string {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+  cachedVersion = resolveAcpxVersion();
+  return cachedVersion;
+}

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveAcpxVersion } from "../src/version.js";
+
+test("resolveAcpxVersion prefers npm_package_version from env", () => {
+  const version = resolveAcpxVersion({
+    env: { npm_package_version: "9.9.9-ci" },
+    packageJsonPath: "/definitely/missing/package.json",
+  });
+  assert.equal(version, "9.9.9-ci");
+});
+
+test("resolveAcpxVersion reads version from package.json when env is unset", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-version-test-"));
+  try {
+    const packagePath = path.join(tmpDir, "package.json");
+    await fs.writeFile(
+      packagePath,
+      `${JSON.stringify({ name: "acpx", version: "1.2.3" }, null, 2)}\n`,
+      "utf8",
+    );
+    const version = resolveAcpxVersion({
+      env: {},
+      packageJsonPath: packagePath,
+    });
+    assert.equal(version, "1.2.3");
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAcpxVersion falls back to unknown when version cannot be resolved", () => {
+  const version = resolveAcpxVersion({
+    env: {},
+    packageJsonPath: "/definitely/missing/package.json",
+  });
+  assert.equal(version, "0.0.0-unknown");
+});


### PR DESCRIPTION
## Summary
- add a canonical runtime version resolver in `src/version.ts`
- wire CLI `--version` to that resolver (`src/cli.ts`)
- stop hardcoding ACP `clientInfo.version`; use the same resolver (`src/client.ts`)
- add tests for CLI/version resolution (`test/cli.test.ts`, `test/version.test.ts`)

## Why
`acpx --version` should work without hardcoded values and should reflect the CI/build-assigned package version. This also keeps ACP `clientInfo.version` consistent with the CLI version.

## Validation
- `npm run build:test && node --test dist-test/test/version.test.js dist-test/test/cli.test.js`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- manual: `npm run dev -- --version`
- manual: `node dist/cli.js --version`
