### PR TITLE
version: ignore foreign npm_package_version in npx contexts

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -45,8 +45,10 @@ export function resolveAcpxVersion(params?: {
   env?: NodeJS.ProcessEnv;
   packageJsonPath?: string;
 }): string {
-  const envVersion = parseVersion((params?.env ?? process.env).npm_package_version);
-  if (envVersion) {
+  const env = params?.env ?? process.env;
+  const envPackageName = parseVersion(env.npm_package_name);
+  const envVersion = parseVersion(env.npm_package_version);
+  if (envPackageName === "acpx" && envVersion) {
     return envVersion;
   }
 

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -5,12 +5,37 @@ import path from "node:path";
 import test from "node:test";
 import { resolveAcpxVersion } from "../src/version.js";
 
-test("resolveAcpxVersion prefers npm_package_version from env", () => {
+test("resolveAcpxVersion prefers npm_package_version from env when package name is acpx", () => {
   const version = resolveAcpxVersion({
-    env: { npm_package_version: "9.9.9-ci" },
+    env: {
+      npm_package_name: "acpx",
+      npm_package_version: "9.9.9-ci",
+    },
     packageJsonPath: "/definitely/missing/package.json",
   });
   assert.equal(version, "9.9.9-ci");
+});
+
+test("resolveAcpxVersion ignores npm_package_version from non-acpx package env", async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-version-test-"));
+  try {
+    const packagePath = path.join(tmpDir, "package.json");
+    await fs.writeFile(
+      packagePath,
+      `${JSON.stringify({ name: "acpx", version: "1.2.3" }, null, 2)}\n`,
+      "utf8",
+    );
+    const version = resolveAcpxVersion({
+      env: {
+        npm_package_name: "openclaw",
+        npm_package_version: "2026.2.25",
+      },
+      packageJsonPath: packagePath,
+    });
+    assert.equal(version, "1.2.3");
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("resolveAcpxVersion reads version from package.json when env is unset", async () => {


### PR DESCRIPTION
## Summary
- fix `acpx --version` when invoked via `npx` inside another repo
- only trust `npm_package_version` if `npm_package_name === "acpx"`
- otherwise resolve version from acpx package metadata (or fallback)
- add regression tests for foreign npm env leakage

## Root cause
`npm exec`/`npx` can expose caller-project env variables (for example `npm_package_name=openclaw`, `npm_package_version=2026.2.25`).
Our resolver previously trusted `npm_package_version` unconditionally, which could make `acpx --version` print the wrong project version.

## Validation
- `npm run build:test && node --test dist-test/test/version.test.js`
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- repro check from another repo context:
  - `npm_package_name=openclaw npm_package_version=999.999.999 npm exec --yes --package /home/bob/repos/acpx -- acpx --version`
  - result: `0.1.0` (acpx version), not caller env version
