### PR TITLE
docs: clarify set-mode mode ids are adapter-defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ acpx codex --file prompt.md                    # prompt from file
 acpx codex --file - "extra context"            # explicit stdin + appended args
 acpx codex --no-wait 'draft test migration plan' # enqueue without waiting if session is busy
 acpx codex cancel                               # cooperative cancel of in-flight prompt
-acpx codex set-mode plan                        # session/set_mode
+acpx codex set-mode auto                        # session/set_mode (adapter-defined mode id)
 acpx codex set approval_policy conservative     # session/set_config_option
 acpx exec 'summarize this repo'                # default agent shortcut (codex)
 acpx codex exec 'what does this repo do?'      # one-shot, no saved session
@@ -296,6 +296,7 @@ acpx --agent ./my-custom-acp-server 'do something'
 - `--no-wait` submits to that queue and returns immediately.
 - `cancel` sends cooperative `session/cancel` to the running queue owner process and returns success when no prompt is running (`nothing to cancel`).
 - `set-mode` and `set` route through queue-owner IPC when active, otherwise they reconnect directly to apply `session/set_mode` and `session/set_config_option`.
+- `<mode>` values for `set-mode` are adapter-defined; unsupported values are rejected by the adapter (commonly `Invalid params`).
 - `exec` is always one-shot and does not reuse saved sessions.
 - Session metadata is stored under `~/.acpx/sessions/`.
 - Each successful prompt appends lightweight turn history previews (`role`, `timestamp`, `textPreview`) to session metadata.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,6 +207,8 @@ acpx [global_options] set-mode <mode> [-s <name>]   # defaults to codex
 Behavior:
 
 - Calls ACP `session/set_mode`.
+- `<mode>` values are adapter-defined (not globally standardized across all ACP adapters).
+- Unsupported mode ids are rejected by the adapter (often as `Invalid params`).
 - Routes through queue-owner IPC when an owner is active.
 - Falls back to a direct client reconnect when no owner is running.
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -131,7 +131,7 @@ Behavior:
 
 ```bash
 acpx codex cancel
-acpx codex set-mode plan
+acpx codex set-mode auto
 acpx codex set approval_policy conservative
 ```
 
@@ -139,6 +139,7 @@ Behavior:
 
 - `cancel`: sends cooperative `session/cancel` through queue-owner IPC.
 - `set-mode`: calls ACP `session/set_mode`.
+- `set-mode` mode ids are adapter-defined; unsupported values are rejected by the adapter (often `Invalid params`).
 - `set`: calls ACP `session/set_config_option`.
 - `set-mode`/`set` route through queue-owner IPC when active, otherwise reconnect directly.
 


### PR DESCRIPTION
## Summary
This docs update clarifies that `set-mode` values are **adapter-defined** and not guaranteed to be portable across all ACP adapters.

## Changes
- `README.md`
  - Replace `acpx codex set-mode plan` example with `acpx codex set-mode auto`.
  - Add note that unsupported mode ids are rejected by adapters (commonly `Invalid params`).
- `docs/CLI.md`
  - Add behavior notes under `set-mode` explaining adapter-defined mode ids and rejection semantics.
- `skills/acpx/SKILL.md`
  - Align example and behavior note with the same clarification.

## Why
Users can copy examples like `set-mode plan` and reasonably expect universal behavior. In reality, whether `plan` is accepted depends on the selected adapter's exposed modes.

This keeps examples practical and reduces confusion without changing runtime behavior.
