### PR TITLE
feat: add --session-meta and --claude-agent CLI options

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -533,6 +533,7 @@ export class AcpClient {
     const result = await connection.newSession({
       cwd: asAbsoluteCwd(cwd),
       mcpServers: [],
+      ...(this.options.sessionMeta ? { _meta: this.options.sessionMeta } : {}),
     });
     return {
       sessionId: result.sessionId,

--- a/src/session-runtime.ts
+++ b/src/session-runtime.ts
@@ -94,6 +94,7 @@ export type RunOnceOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  sessionMeta?: Record<string, unknown>;
   outputFormatter: OutputFormatter;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
@@ -107,6 +108,7 @@ export type SessionCreateOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  sessionMeta?: Record<string, unknown>;
   verbose?: boolean;
 } & TimedRunOptions;
 
@@ -134,6 +136,7 @@ export type SessionEnsureOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  sessionMeta?: Record<string, unknown>;
   verbose?: boolean;
   walkBoundary?: string;
 } & TimedRunOptions;
@@ -785,6 +788,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    sessionMeta: options.sessionMeta,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     onSessionUpdate: (notification) => output.onSessionUpdate(notification),
@@ -832,6 +836,7 @@ export async function createSession(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    sessionMeta: options.sessionMeta,
     verbose: options.verbose,
   });
 
@@ -904,6 +909,7 @@ export async function ensureSession(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    sessionMeta: options.sessionMeta,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,6 +245,7 @@ export type AcpClientOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  sessionMeta?: Record<string, unknown>;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   onSessionUpdate?: (notification: SessionNotification) => void;


### PR DESCRIPTION
## Summary

- Add `--session-meta <json>` global option to pass arbitrary `_meta` to ACP `newSession` requests, enabling adapter-specific configuration from the CLI
- Add `--claude-agent <name>` global option as syntactic sugar for `claude-agent-acp`, automatically building `{ claudeCode: { options: { agent: "<name>" } } }`
- Both options can be combined; `--claude-agent` deep-merges into `--session-meta`

### Motivation

`claude-agent-acp` supports the `agent` parameter via `_meta.claudeCode.options` (which maps to Claude Code's `--agent` flag for loading `.claude/agents/<name>.md`), but there was no way to set `_meta` from the acpx CLI. This feature enables role-based agent dispatch (e.g., `research`, `implement`, `check`) through acpx.

### Usage

```bash
# One-shot with a specific agent role
acpx --claude-agent research exec "Find where mobile top bar is rendered"

# Generic _meta passthrough
acpx --session-meta '{"claudeCode":{"options":{"agent":"research"}}}' exec "..."

# Create a session with agent config, then reuse with prompt
acpx --claude-agent implement sessions new -s my-task
acpx prompt -s my-task "Add logout button to sidebar"
```

### Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `sessionMeta` to `AcpClientOptions` |
| `src/client.ts` | Pass `sessionMeta` as `_meta` in `newSession()` |
| `src/session-runtime.ts` | Thread `sessionMeta` through `RunOnceOptions`, `SessionCreateOptions`, `SessionEnsureOptions` |
| `src/cli.ts` | Add `--session-meta` and `--claude-agent` global options with JSON parsing, validation, and deep merge |

### Scope

Supported on `exec`, `sessions new`, and `sessions ensure` commands. The `prompt` command uses detached queue owners which would require additional plumbing — left as a potential follow-up.

## Test plan

- [ ] `acpx --claude-agent research exec "hello"` creates session with correct `_meta`
- [ ] `acpx --session-meta '{"foo":"bar"}' exec "hello"` passes raw JSON as `_meta`
- [ ] `--session-meta` with invalid JSON throws `InvalidArgumentError`
- [ ] `--claude-agent` and `--session-meta` can be combined (deep merge)
- [ ] `acpx --claude-agent research sessions new` creates a session with agent config
- [ ] All checks pass: `typecheck`, `lint`, `format:check`, `build`