### PR TITLE
fix(session): recognize Gemini CLI 'Invalid session identifier' as session-not-found

### DIFF
--- a/src/acp-error-shapes.ts
+++ b/src/acp-error-shapes.ts
@@ -95,7 +95,8 @@ function isSessionNotFoundText(value: unknown): boolean {
     normalized.includes("resource_not_found") ||
     normalized.includes("resource not found") ||
     normalized.includes("session not found") ||
-    normalized.includes("unknown session")
+    normalized.includes("unknown session") ||
+    normalized.includes("invalid session identifier")
   );
 }
 


### PR DESCRIPTION
## Problem

When acpx reconnects a Gemini session, it sends `session/load` with acpx's
own session UUID. Gemini CLI does not know this UUID and returns:

    Invalid session identifier "2f8f4712-..."

with JSON-RPC error code -32603. `isSessionNotFoundText()` did not match
this text, so `shouldFallbackToNewSession()` returned false and the error
was thrown instead of falling back to `session/new`.

This caused every `acpx gemini prompt --session` to fail with
`[error] RUNTIME: Internal error`, while `acpx gemini exec` worked fine.

## Fix

Add `"invalid session identifier"` to the pattern list in
`isSessionNotFoundText()`.

## Test
acpx gemini sessions newecho "Say hello" | acpx --verbose gemini prompt --file -
Before: [error] RUNTIME: Internal error
After: [acpx] loadSession failed, started fresh session → prompt succeeds