### PR TITLE
chore: restore openclaw package metadata for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,49 @@ jobs:
       - run: git config user.name "github-actions[bot]"
       - run: git config user.email "github-actions[bot]@users.noreply.github.com"
       - run: npm ci
+      - name: Validate package metadata for trusted publishing
+        run: |
+          node - <<'NODE'
+          const { readFileSync } = require("node:fs");
+
+          const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+          const expectedAuthor = "OpenClaw Team <dev@openclaw.ai>";
+          const expectedRepoUrl = "https://github.com/openclaw/acpx";
+
+          const normalizeRepoUrl = (value) =>
+            String(value ?? "")
+              .trim()
+              .replace(/^git\+/, "")
+              .replace(/\.git$/i, "")
+              .replace(/\/+$/, "");
+
+          const actualRepoUrl = normalizeRepoUrl(pkg?.repository?.url);
+          const expectedRepoUrlNormalized = normalizeRepoUrl(expectedRepoUrl);
+
+          const errors = [];
+          if (actualRepoUrl !== expectedRepoUrlNormalized) {
+            errors.push(
+              `package.json repository.url must resolve to ${expectedRepoUrlNormalized}; found ${actualRepoUrl || "<missing>"}`
+            );
+          }
+          if ((pkg?.author ?? "") !== expectedAuthor) {
+            errors.push(
+              `package.json author must be exactly "${expectedAuthor}"; found "${pkg?.author ?? ""}"`
+            );
+          }
+
+          if (errors.length > 0) {
+            for (const err of errors) {
+              console.error(err);
+            }
+            process.exit(1);
+          }
+
+          console.log("Package metadata validated.");
+          NODE
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run build
       # Fetch latest version from npm, bump it, write to package.json.
       # Nothing is committed — the bumped version lives only in the CI
       # runner's working directory. release-it tags + publishes from it.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openclaw/acpx.git"
+    "url": "https://github.com/openclaw/acpx"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
Restore and harden release metadata so trusted publishing works out of the box.

- set `author` to `OpenClaw Team <dev@openclaw.ai>`
- set `repository.url` to canonical `https://github.com/openclaw/acpx`
- add release workflow validation that fails fast if `author` or `repository.url` drift
- run `npm run build` in release workflow before publish to ensure artifacts are present

## Why
Recent release failed at `npm publish` with `E422` due provenance mismatch:
- provenance repo: `https://github.com/openclaw/acpx`
- package metadata repo: `git+https://github.com/janitrai/acpx.git`

This PR fixes the mismatch and adds guardrails so it does not regress.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
