### PR TITLE
feat: add Kiro CLI as built-in agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The only prerequisite is the underlying coding agent you want to use:
 - `acpx gemini` -> Gemini CLI: https://github.com/google/gemini-cli
 - `acpx openclaw` -> OpenClaw ACP bridge: https://github.com/openclaw/openclaw
 - `acpx opencode` -> OpenCode: https://opencode.ai
+- `acpx kiro` -> Kiro CLI: https://kiro.dev
 - `acpx pi` -> Pi Coding Agent: https://github.com/mariozechner/pi
 
 ## Usage examples

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -5,6 +5,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   gemini: "gemini --experimental-acp",
   openclaw: "openclaw acp",
   opencode: "npx -y opencode-ai acp",
+  kiro: "kiro-cli acp",
   pi: "npx pi-acp",
 };
 

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -14,6 +14,7 @@ test("resolveAgentCommand maps known agents to commands", () => {
     ["gemini", "gemini --experimental-acp"],
     ["openclaw", "openclaw acp"],
     ["opencode", "npx -y opencode-ai acp"],
+    ["kiro", "kiro-cli acp"],
     ["pi", "npx pi-acp"],
   ]);
 
@@ -28,10 +29,10 @@ test("resolveAgentCommand returns raw value for unknown agents", () => {
 
 test("listBuiltInAgents returns exactly all 7 registered agent names", () => {
   const agents = listBuiltInAgents();
-  assert.equal(agents.length, 7);
+  assert.equal(agents.length, 8);
   assert.deepEqual(
     new Set(agents),
-    new Set(["copilot", "codex", "claude", "gemini", "openclaw", "opencode", "pi"]),
+    new Set(["copilot", "codex", "claude", "gemini", "openclaw", "opencode", "kiro", "pi"]),
   );
 });
 


### PR DESCRIPTION
## Summary

Add [Kiro CLI](https://kiro.dev) as a built-in agent in the agent registry.

Kiro CLI supports ACP since [v1.25](https://kiro.dev/changelog/cli/1-25/) via `kiro-cli acp`, which starts Kiro as an ACP-compliant agent communicating over stdin/stdout using JSON-RPC.

## Changes

- Add `kiro: "kiro-cli acp"` to `AGENT_REGISTRY` in `src/agent-registry.ts`
- Update `test/agent-registry.test.ts` to include kiro (5 → 6 agents)
- Add `acpx kiro` to README built-in agents list

## Usage

```bash
acpx kiro "fix the tests"
acpx kiro sessions new
```

## References

- Kiro CLI ACP docs: https://kiro.dev/docs/cli/acp/
- Kiro CLI v1.25 changelog: https://kiro.dev/changelog/cli/1-25/