### PR TITLE
fix: restore --version and staged adapter shutdown fallback

### DIFF
--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -74,6 +74,7 @@ import {
   type SessionAgentContent,
   type SessionUserContent,
 } from "./types.js";
+import { getAcpxVersion } from "./version.js";
 import { runQueueOwnerFromEnv } from "./queue-owner-env.js";
 
 class NoSessionError extends Error {
@@ -1433,6 +1434,7 @@ export async function main(argv: string[] = process.argv): Promise<void> {
   program
     .name("acpx")
     .description("Headless CLI client for the Agent Client Protocol")
+    .version(getAcpxVersion())
     .enablePositionalOptions()
     .showHelpAfterError();
 


### PR DESCRIPTION
## Summary
Restore two regressions introduced during the `#28` refactor:

- bring back CLI `--version` output
- restore staged adapter shutdown fallback in `AcpClient.close()`
  - close stdin first
  - wait briefly
  - send `SIGTERM` and wait
  - force `SIGKILL` if still running

## Details
### `--version`
- reconnected commander version wiring with `getAcpxVersion()` in `src/cli-core.ts`
- restored regression test asserting `acpx --version` prints `package.json` version

### Graceful shutdown fallback
- restored shutdown helpers in `src/client.ts`:
  - process-running detection
  - bounded wait-for-exit
  - staged signal escalation
- kept explicit stdio handle destruction to avoid hung CLI exits
- only `unref()` when process still has not exited after escalation
- reintroduced mock-agent `--ignore-sigterm` mode and added CLI regression test verifying `sessions ensure` exits cleanly in that case

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
