### PR TITLE
fix: add --experimental-acp flag to Gemini CLI adapter

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -1,7 +1,7 @@
 export const AGENT_REGISTRY: Record<string, string> = {
   codex: "npx @zed-industries/codex-acp",
   claude: "npx -y @zed-industries/claude-agent-acp",
-  gemini: "gemini",
+  gemini: "gemini --experimental-acp",
   opencode: "npx -y opencode-ai acp",
   pi: "npx pi-acp",
 };


### PR DESCRIPTION
## Summary

Add `--experimental-acp` flag to the Gemini CLI adapter in AGENT_REGISTRY.

## Problem

Gemini CLI requires the `--experimental-acp` flag to enable ACP (Agent Client Protocol) mode. Without this flag, ACP initialization hangs indefinitely.

## Fix

Changed `gemini: "gemini"` to `gemini: "gemini --experimental-acp"` in `src/agent-registry.ts`.

## Testing

Verified that after this fix, `acpx gemini exec "Say hi"` works correctly and returns the expected response instead of hanging.

## Related

- Issue #44