### PR TITLE
fix: add windowsHide to all spawn calls to prevent console flash on Windows

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -403,6 +403,7 @@ export class AcpClient {
       cwd: this.options.cwd,
       env: buildAgentEnvironment(this.options.authCredentials),
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     try {

--- a/src/session-runtime/queue-owner-process.ts
+++ b/src/session-runtime/queue-owner-process.ts
@@ -53,6 +53,7 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): void 
   const child = spawn(process.execPath, resolveQueueOwnerSpawnArgs(), {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
     env: {
       ...process.env,
       ACPX_QUEUE_OWNER_PAYLOAD: payload,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -156,6 +156,7 @@ export class TerminalManager {
         cwd: params.cwd ?? this.cwd,
         env: toEnvObject(params.env),
         stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
       });
       await waitForSpawn(proc);
 


### PR DESCRIPTION
Adds `windowsHide: true` to three `child_process.spawn()` calls:

- **Tool execution spawn** in `terminal.ts`
- **Agent spawn** in `client.ts`
- **Queue owner spawn** in `queue-owner-process.ts`

This prevents visible cmd.exe windows from flashing on every ACP message on Windows desktop environments. No-op on macOS/Linux.

Fixes openclaw/openclaw#40340