### PR TITLE
perf: reuse queue-owner acp clients

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -43,7 +43,12 @@ import { classifyPermissionDecision, resolvePermissionRequest } from "./permissi
 import { extractRuntimeSessionId } from "./runtime-session-id.js";
 import { TimeoutError, withTimeout } from "./session-runtime-helpers.js";
 import { TerminalManager } from "./terminal.js";
-import type { AcpClientOptions, PermissionStats } from "./types.js";
+import type {
+  AcpClientOptions,
+  NonInteractivePermissionPolicy,
+  PermissionMode,
+  PermissionStats,
+} from "./types.js";
 
 type CommandParts = {
   command: string;
@@ -525,10 +530,15 @@ export function buildAgentSpawnOptions(
 }
 
 export class AcpClient {
-  private readonly options: AcpClientOptions;
+  private options: AcpClientOptions;
   private connection?: ClientSideConnection;
   private agent?: ChildProcessByStdio<Writable, Readable, Readable>;
   private initResult?: InitializeResponse;
+  private loadedSessionId?: string;
+  private eventHandlers: Pick<
+    AcpClientOptions,
+    "onAcpMessage" | "onAcpOutputMessage" | "onSessionUpdate" | "onClientOperation"
+  >;
   private readonly permissionStats: PermissionStats = {
     requested: 0,
     approved: 0,
@@ -559,19 +569,28 @@ export class AcpClient {
       cwd: asAbsoluteCwd(options.cwd),
       authPolicy: options.authPolicy ?? "skip",
     };
+    this.eventHandlers = {
+      onAcpMessage: this.options.onAcpMessage,
+      onAcpOutputMessage: this.options.onAcpOutputMessage,
+      onSessionUpdate: this.options.onSessionUpdate,
+      onClientOperation: this.options.onClientOperation,
+    };
 
-    const emitOperation = this.options.onClientOperation;
     this.filesystem = new FileSystemHandlers({
       cwd: this.options.cwd,
       permissionMode: this.options.permissionMode,
       nonInteractivePermissions: this.options.nonInteractivePermissions,
-      onOperation: emitOperation,
+      onOperation: (operation) => {
+        this.eventHandlers.onClientOperation?.(operation);
+      },
     });
     this.terminalManager = new TerminalManager({
       cwd: this.options.cwd,
       permissionMode: this.options.permissionMode,
       nonInteractivePermissions: this.options.nonInteractivePermissions,
-      onOperation: emitOperation,
+      onOperation: (operation) => {
+        this.eventHandlers.onClientOperation?.(operation);
+      },
     });
   }
 
@@ -606,6 +625,58 @@ export class AcpClient {
     return Boolean(this.initResult?.agentCapabilities?.loadSession);
   }
 
+  setEventHandlers(
+    handlers: Pick<
+      AcpClientOptions,
+      "onAcpMessage" | "onAcpOutputMessage" | "onSessionUpdate" | "onClientOperation"
+    >,
+  ): void {
+    this.eventHandlers = { ...handlers };
+  }
+
+  clearEventHandlers(): void {
+    this.eventHandlers = {};
+  }
+
+  updateRuntimeOptions(options: {
+    permissionMode?: PermissionMode;
+    nonInteractivePermissions?: NonInteractivePermissionPolicy;
+    suppressSdkConsoleErrors?: boolean;
+    verbose?: boolean;
+  }): void {
+    if (options.permissionMode) {
+      this.options.permissionMode = options.permissionMode;
+    }
+    if (options.nonInteractivePermissions !== undefined) {
+      this.options.nonInteractivePermissions = options.nonInteractivePermissions;
+    }
+    if (options.permissionMode || options.nonInteractivePermissions !== undefined) {
+      this.filesystem.updatePermissionPolicy(
+        this.options.permissionMode,
+        this.options.nonInteractivePermissions,
+      );
+      this.terminalManager.updatePermissionPolicy(
+        this.options.permissionMode,
+        this.options.nonInteractivePermissions,
+      );
+    }
+    if (options.suppressSdkConsoleErrors !== undefined) {
+      this.options.suppressSdkConsoleErrors = options.suppressSdkConsoleErrors;
+    }
+    if (options.verbose !== undefined) {
+      this.options.verbose = options.verbose;
+    }
+  }
+
+  hasReusableSession(sessionId: string): boolean {
+    return (
+      this.connection != null &&
+      this.agent != null &&
+      isChildProcessRunning(this.agent) &&
+      this.loadedSessionId === sessionId
+    );
+  }
+
   hasActivePrompt(sessionId?: string): boolean {
     if (!this.activePrompt) {
       return false;
@@ -617,8 +688,11 @@ export class AcpClient {
   }
 
   async start(): Promise<void> {
-    if (this.connection && this.agent) {
+    if (this.connection && this.agent && isChildProcessRunning(this.agent)) {
       return;
+    }
+    if (this.connection || this.agent) {
+      await this.close();
     }
 
     const { command, args } = splitCommandLine(this.options.agentCommand);
@@ -749,12 +823,8 @@ export class AcpClient {
     readable: ReadableStream<AnyMessage>;
     writable: WritableStream<AnyMessage>;
   } {
-    const onAcpMessage = this.options.onAcpMessage;
-    const onAcpOutputMessage = this.options.onAcpOutputMessage;
-
-    if (!onAcpMessage && !onAcpOutputMessage) {
-      return base;
-    }
+    const onAcpMessage = () => this.eventHandlers.onAcpMessage;
+    const onAcpOutputMessage = () => this.eventHandlers.onAcpOutputMessage;
 
     const shouldSuppressInboundReplaySessionUpdate = (message: AnyMessage): boolean => {
       return this.suppressReplaySessionUpdateMessages && isSessionUpdateNotification(message);
@@ -773,8 +843,8 @@ export class AcpClient {
               continue;
             }
             if (!shouldSuppressInboundReplaySessionUpdate(value)) {
-              onAcpOutputMessage?.("inbound", value);
-              onAcpMessage?.("inbound", value);
+              onAcpOutputMessage()?.("inbound", value);
+              onAcpMessage()?.("inbound", value);
             }
             controller.enqueue(value);
           }
@@ -787,8 +857,8 @@ export class AcpClient {
 
     const writable = new WritableStream<AnyMessage>({
       async write(message) {
-        onAcpOutputMessage?.("outbound", message);
-        onAcpMessage?.("outbound", message);
+        onAcpOutputMessage()?.("outbound", message);
+        onAcpMessage()?.("outbound", message);
         const writer = base.writable.getWriter();
         try {
           await writer.write(message);
@@ -825,6 +895,7 @@ export class AcpClient {
       throw error;
     }
 
+    this.loadedSessionId = result.sessionId;
     return {
       sessionId: result.sessionId,
       agentSessionId: extractRuntimeSessionId(result._meta),
@@ -866,6 +937,7 @@ export class AcpClient {
       this.suppressReplaySessionUpdateMessages = previousReplaySuppression;
     }
 
+    this.loadedSessionId = sessionId;
     return {
       agentSessionId: extractRuntimeSessionId(response?._meta),
     };
@@ -1014,6 +1086,8 @@ export class AcpClient {
     this.activePrompt = undefined;
     this.cancellingSessionIds.clear();
     this.promptPermissionFailures.clear();
+    this.loadedSessionId = undefined;
+    this.initResult = undefined;
     this.connection = undefined;
     this.agent = undefined;
   }
@@ -1295,7 +1369,7 @@ export class AcpClient {
     this.sessionUpdateChain = this.sessionUpdateChain.then(async () => {
       try {
         if (!this.suppressSessionUpdates) {
-          this.options.onSessionUpdate?.(notification);
+          this.eventHandlers.onSessionUpdate?.(notification);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -61,8 +61,8 @@ function canPromptForPermission(): boolean {
 
 export class FileSystemHandlers {
   private readonly rootDir: string;
-  private readonly permissionMode: PermissionMode;
-  private readonly nonInteractivePermissions: NonInteractivePermissionPolicy;
+  private permissionMode: PermissionMode;
+  private nonInteractivePermissions: NonInteractivePermissionPolicy;
   private readonly onOperation?: (operation: ClientOperation) => void;
   private readonly usesDefaultConfirmWrite: boolean;
   private readonly confirmWrite: (filePath: string, preview: string) => Promise<boolean>;
@@ -74,6 +74,14 @@ export class FileSystemHandlers {
     this.onOperation = options.onOperation;
     this.usesDefaultConfirmWrite = options.confirmWrite == null;
     this.confirmWrite = options.confirmWrite ?? defaultConfirmWrite;
+  }
+
+  updatePermissionPolicy(
+    permissionMode: PermissionMode,
+    nonInteractivePermissions?: NonInteractivePermissionPolicy,
+  ): void {
+    this.permissionMode = permissionMode;
+    this.nonInteractivePermissions = nonInteractivePermissions ?? "deny";
   }
 
   async readTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {

--- a/src/session-runtime.ts
+++ b/src/session-runtime.ts
@@ -201,6 +201,7 @@ type RunSessionPromptOptions = {
   onClientAvailable?: (controller: ActiveSessionController) => void;
   onClientClosed?: () => void;
   onPromptActive?: () => Promise<void> | void;
+  client?: AcpClient;
 };
 
 type ActiveSessionController = QueueOwnerActiveSessionController;
@@ -283,6 +284,7 @@ async function runQueuedTask(
   sessionRecordId: string,
   task: QueueTask,
   options: {
+    sharedClient?: AcpClient;
     verbose?: boolean;
     nonInteractivePermissions?: NonInteractivePermissionPolicy;
     authCredentials?: Record<string, string>;
@@ -313,6 +315,7 @@ async function runQueuedTask(
       onClientAvailable: options.onClientAvailable,
       onClientClosed: options.onClientClosed,
       onPromptActive: options.onPromptActive,
+      client: options.sharedClient,
     });
 
     if (task.waitForCompletion) {
@@ -391,15 +394,26 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     });
   };
 
-  const client = new AcpClient({
-    agentCommand: record.agentCommand,
-    cwd: absolutePath(record.cwd),
+  const ownClient = options.client == null;
+  const client =
+    options.client ??
+    new AcpClient({
+      agentCommand: record.agentCommand,
+      cwd: absolutePath(record.cwd),
+      permissionMode: options.permissionMode,
+      nonInteractivePermissions: options.nonInteractivePermissions,
+      authCredentials: options.authCredentials,
+      authPolicy: options.authPolicy,
+      suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
+      verbose: options.verbose,
+    });
+  client.updateRuntimeOptions({
     permissionMode: options.permissionMode,
     nonInteractivePermissions: options.nonInteractivePermissions,
-    authCredentials: options.authCredentials,
-    authPolicy: options.authPolicy,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
+  });
+  client.setEventHandlers({
     onAcpMessage: (_direction, message) => {
       sawAcpMessage = true;
       pendingMessages.push(message);
@@ -558,7 +572,9 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
         await flushPendingMessages(false).catch(() => {
           // best effort while process is being interrupted
         });
-        await client.close();
+        if (ownClient) {
+          await client.close();
+        }
       },
     );
   } finally {
@@ -570,7 +586,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     if (notifiedClientAvailable) {
       options.onClientClosed?.();
     }
-    await client.close();
+    client.clearEventHandlers();
+    if (ownClient) {
+      await client.close();
+    }
     applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
     applyConversation(record, conversation);
     record.acpx = acpxState;
@@ -755,8 +774,19 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     return;
   }
 
+  const sessionRecord = await resolveSessionRecord(options.sessionId);
   let owner: SessionQueueOwner | undefined;
   let heartbeatTimer: NodeJS.Timeout | undefined;
+  const sharedClient = new AcpClient({
+    agentCommand: sessionRecord.agentCommand,
+    cwd: absolutePath(sessionRecord.cwd),
+    permissionMode: "approve-reads",
+    nonInteractivePermissions: options.nonInteractivePermissions,
+    authCredentials: options.authCredentials,
+    authPolicy: options.authPolicy,
+    suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
+    verbose: options.verbose,
+  });
   const ttlMs = normalizeQueueOwnerTtlMs(options.ttlMs);
   const maxQueueDepth = Math.max(1, Math.round(options.maxQueueDepth ?? 16));
   const taskPollTimeoutMs = ttlMs === 0 ? undefined : ttlMs;
@@ -878,6 +908,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
       await runPromptTurn(async () => {
         try {
           await runQueuedTask(options.sessionId, task, {
+            sharedClient,
             verbose: options.verbose,
             nonInteractivePermissions: options.nonInteractivePermissions,
             authCredentials: options.authCredentials,
@@ -902,6 +933,16 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     turnController.beginClosing();
     if (owner) {
       await owner.close();
+    }
+    await sharedClient.close().catch(() => {
+      // best effort while queue owner is shutting down
+    });
+    try {
+      const record = await resolveSessionRecord(options.sessionId);
+      applyLifecycleSnapshotToRecord(record, sharedClient.getAgentLifecycleSnapshot());
+      await writeSessionRecord(record);
+    } catch {
+      // best effort — session may already be cleaned up
     }
     await releaseQueueOwnerLease(lease);
 

--- a/src/session-runtime/connect-load.ts
+++ b/src/session-runtime/connect-load.ts
@@ -5,6 +5,7 @@ import {
   isAcpQueryClosedBeforeResponseError,
   isAcpResourceNotFoundError,
 } from "../error-normalization.js";
+import { incrementPerfCounter } from "../perf-metrics.js";
 import { isProcessAlive } from "../queue-ipc.js";
 import type { QueueOwnerActiveSessionController } from "../queue-owner-turn-controller.js";
 import { getDesiredModeId } from "../session-mode-preference.js";
@@ -81,7 +82,12 @@ export async function connectAndLoadSession(
     }
   }
 
-  await withTimeout(client.start(), options.timeoutMs);
+  const reusingLoadedSession = client.hasReusableSession(record.acpSessionId);
+  if (reusingLoadedSession) {
+    incrementPerfCounter("runtime.connect_and_load.reused_session");
+  } else {
+    await withTimeout(client.start(), options.timeoutMs);
+  }
   options.onClientAvailable?.(options.activeController);
   applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
   record.closed = false;
@@ -93,7 +99,9 @@ export async function connectAndLoadSession(
   let sessionId = record.acpSessionId;
   let createdFreshSession = false;
 
-  if (client.supportsLoadSession()) {
+  if (reusingLoadedSession) {
+    resumed = true;
+  } else if (client.supportsLoadSession()) {
     try {
       const loadResult = await withTimeout(
         client.loadSessionWithOptions(record.acpSessionId, record.cwd, {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -131,8 +131,8 @@ function waitMs(ms: number): Promise<void> {
 
 export class TerminalManager {
   private readonly cwd: string;
-  private readonly permissionMode: PermissionMode;
-  private readonly nonInteractivePermissions: NonInteractivePermissionPolicy;
+  private permissionMode: PermissionMode;
+  private nonInteractivePermissions: NonInteractivePermissionPolicy;
   private readonly onOperation?: (operation: ClientOperation) => void;
   private readonly usesDefaultConfirmExecute: boolean;
   private readonly confirmExecute: (commandLine: string) => Promise<boolean>;
@@ -147,6 +147,14 @@ export class TerminalManager {
     this.usesDefaultConfirmExecute = options.confirmExecute == null;
     this.confirmExecute = options.confirmExecute ?? defaultConfirmExecute;
     this.killGraceMs = Math.max(0, Math.round(options.killGraceMs ?? DEFAULT_KILL_GRACE_MS));
+  }
+
+  updatePermissionPolicy(
+    permissionMode: PermissionMode,
+    nonInteractivePermissions?: NonInteractivePermissionPolicy,
+  ): void {
+    this.permissionMode = permissionMode;
+    this.nonInteractivePermissions = nonInteractivePermissions ?? "deny";
   }
 
   async createTerminal(params: CreateTerminalRequest): Promise<CreateTerminalResponse> {

--- a/test/connect-load.test.ts
+++ b/test/connect-load.test.ts
@@ -9,6 +9,7 @@ import { connectAndLoadSession } from "../src/session-runtime/connect-load.js";
 import type { SessionRecord } from "../src/types.js";
 
 type FakeClient = {
+  hasReusableSession: (sessionId: string) => boolean;
   start: () => Promise<void>;
   getAgentLifecycleSnapshot: () => {
     pid?: number;
@@ -58,6 +59,7 @@ test("connectAndLoadSession resumes an existing load-capable session", async () 
     let connectedRecordCalls = 0;
     let resolvedSessionId: string | undefined;
     const client: FakeClient = {
+      hasReusableSession: () => false,
       start: async () => {},
       getAgentLifecycleSnapshot: () => ({
         pid: 777,
@@ -123,6 +125,7 @@ test("connectAndLoadSession falls back to createSession when load returns resour
     });
 
     const client: FakeClient = {
+      hasReusableSession: () => false,
       start: async () => {},
       getAgentLifecycleSnapshot: () => ({
         running: true,
@@ -175,6 +178,7 @@ test("connectAndLoadSession falls back to createSession for empty sessions on ad
     });
 
     const client: FakeClient = {
+      hasReusableSession: () => false,
       start: async () => {},
       getAgentLifecycleSnapshot: () => ({
         running: true,
@@ -228,6 +232,7 @@ test("connectAndLoadSession rethrows load failures that should not create a new 
     });
 
     const client: FakeClient = {
+      hasReusableSession: () => false,
       start: async () => {},
       getAgentLifecycleSnapshot: () => ({
         running: true,
@@ -263,6 +268,54 @@ test("connectAndLoadSession rethrows load failures that should not create a new 
         return true;
       },
     );
+  });
+});
+
+test("connectAndLoadSession reuses an already loaded client session", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const record = makeSessionRecord({
+      acpxRecordId: "reused-record",
+      acpSessionId: "reused-session",
+      agentCommand: "agent",
+      cwd,
+    });
+
+    let started = false;
+    let loaded = false;
+    const client: FakeClient = {
+      hasReusableSession: (sessionId) => sessionId === "reused-session",
+      start: async () => {
+        started = true;
+      },
+      getAgentLifecycleSnapshot: () => ({
+        pid: 888,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        running: true,
+      }),
+      supportsLoadSession: () => true,
+      loadSessionWithOptions: async () => {
+        loaded = true;
+        return {};
+      },
+      createSession: async () => {
+        throw new Error("createSession should not be called");
+      },
+    };
+
+    const result = await connectAndLoadSession({
+      client: client as never,
+      record,
+      activeController: ACTIVE_CONTROLLER,
+    });
+
+    assert.equal(started, false);
+    assert.equal(loaded, false);
+    assert.equal(result.resumed, true);
+    assert.equal(result.sessionId, "reused-session");
+    assert.equal(record.pid, 888);
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -651,7 +651,7 @@ test("integration: terminal kill leaves no orphan sleep process", async () => {
   });
 });
 
-test("integration: prompt reuses warm queue owner pid across turns", async () => {
+test("integration: prompt reuses warm queue owner and agent pid across turns", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
 
@@ -666,6 +666,12 @@ test("integration: prompt reuses warm queue owner pid across turns", async () =>
       };
       const sessionId = createdEvent.acpxRecordId;
       assert.equal(typeof sessionId, "string");
+      const sessionRecordPath = path.join(
+        homeDir,
+        ".acpx",
+        "sessions",
+        `${encodeURIComponent(sessionId as string)}.json`,
+      );
 
       const first = await runCli(
         [...baseAgentArgs(cwd), "--format", "quiet", "prompt", "echo first"],
@@ -673,6 +679,10 @@ test("integration: prompt reuses warm queue owner pid across turns", async () =>
       );
       assert.equal(first.code, 0, first.stderr);
       assert.ok(first.stdout.trim().length > 0, "first quiet prompt output should not be empty");
+      const firstRecord = JSON.parse(await fs.readFile(sessionRecordPath, "utf8")) as {
+        pid?: number;
+      };
+      assert.equal(Number.isInteger(firstRecord.pid) && (firstRecord.pid ?? 0) > 0, true);
 
       const { lockPath } = queuePaths(homeDir, sessionId as string);
       const lockOne = JSON.parse(await fs.readFile(lockPath, "utf8")) as {
@@ -686,6 +696,10 @@ test("integration: prompt reuses warm queue owner pid across turns", async () =>
       );
       assert.equal(second.code, 0, second.stderr);
       assert.ok(second.stdout.trim().length > 0, "second quiet prompt output should not be empty");
+      const secondRecord = JSON.parse(await fs.readFile(sessionRecordPath, "utf8")) as {
+        pid?: number;
+      };
+      assert.equal(secondRecord.pid, firstRecord.pid);
 
       const lockTwo = JSON.parse(await fs.readFile(lockPath, "utf8")) as {
         pid?: number;


### PR DESCRIPTION
## Summary
- keep a reusable ACP client alive inside the queue owner across warm prompt turns
- swap per-turn ACP/output/session handlers on the shared client instead of respawning the adapter each turn
- preserve exit bookkeeping on queue-owner shutdown and add coverage for reused-session behavior

## Why
Warm prompt turns were still paying adapter spawn, ACP initialize, and `loadSession` cost even when the detached queue owner was already warm. This changes the queue-owner path to reuse the loaded ACP client/session for subsequent turns.

## Testing
- `pnpm test`
