### PR TITLE
docs(agents): refocus contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,28 @@ npx acpx@latest --help
 - `pnpm run check:docs` — docs format and markdown lint
 - `pnpm run perf:report` — performance reporting helper
 
+## Fundamental acpx Calls
+
+Use these examples when you need the most basic `acpx` flows while developing
+or validating the CLI:
+
+```bash
+acpx codex sessions new
+acpx codex 'fix the failing test'
+acpx codex prompt 'rewrite AGENTS.md for contributors'
+acpx codex exec 'summarize this repo'
+acpx exec 'summarize this repo'                  # defaults to codex
+acpx codex sessions list
+acpx codex sessions show
+acpx codex status
+acpx codex cancel
+acpx codex sessions new --name docs
+acpx codex -s docs 'rewrite CLI docs'
+acpx config show
+acpx config init
+acpx --format json codex exec 'review changed files'
+```
+
 ## When To Run Checks
 
 - Docs-only changes in `docs/**`, [`README.md`](README.md), or [`CONTRIBUTING.md`](CONTRIBUTING.md):


### PR DESCRIPTION
## TL;DR
"agents md shouldn't contain so much technical docs. it should contain info about how to deveop, build, install, test, ci/cd, when to run tests, github repo, etc."
"contain important parts from the vision doc verbatim inside agents md, like scrutinizing, overall vision, it should be thin and such"

## Summary
- Rewrite `AGENTS.md` around contributor workflow: setup, local development, build, install, testing, CI, release, and key repo references.
- Keep the important product-direction constraints in the file verbatim from `VISION.md`.
- Link readers to the actual in-repo technical references instead of keeping `AGENTS.md` as a long technical spec.

## Review focus
- Confirm the new `AGENTS.md` strikes the right balance between contributor workflow and product-direction guardrails.
- Confirm the linked technical references are the right ones to send contributors to for implementation details.

## Test plan
- [x] `pnpm exec oxfmt --check AGENTS.md`
- [x] `pnpm exec markdownlint-cli2 AGENTS.md`
- [x] `git commit` hook completed a local build successfully
- [ ] Full `pnpm run check` not run locally