### PR TITLE
fix: restore CI release bump flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,22 +91,43 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm run build
 
-      # Fetch latest version from npm, bump it, write to package.json.
-      # Nothing is committed — the bumped version lives only in the CI
-      # runner's working directory. release-it tags + publishes from it.
+      # Sync the working tree to the currently published version, then let
+      # release-it perform the requested bump from that baseline.
       - name: Bump version from npm registry
         run: |
           LATEST=$(npm view acpx version 2>/dev/null || echo "0.0.0")
           echo "Latest on npm: $LATEST"
+          TARGET=$(node - "$LATEST" "${{ inputs.increment }}" <<'NODE'
+          const [version, increment] = process.argv.slice(2);
+          const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+          if (!match) {
+            throw new Error(`Unsupported semver: ${version}`);
+          }
+          const [major, minor, patch] = match.slice(1).map(Number);
+
+          if (increment === "patch") {
+            console.log(`${major}.${minor}.${patch + 1}`);
+            process.exit(0);
+          }
+          if (increment === "minor") {
+            console.log(`${major}.${minor + 1}.0`);
+            process.exit(0);
+          }
+          if (increment === "major") {
+            console.log(`${major + 1}.0.0`);
+            process.exit(0);
+          }
+
+          throw new Error(`Unsupported increment: ${increment}`);
+          NODE
+          )
           npm version --no-git-tag-version "$LATEST" --allow-same-version
-          npm version --no-git-tag-version ${{ inputs.increment }}
-          VERSION=$(node -p 'require("./package.json").version')
-          echo "Releasing: $VERSION"
+          echo "VERSION=$TARGET" >> "$GITHUB_ENV"
+          echo "Releasing: $TARGET"
 
       - name: Release
         run: |
-          VERSION=$(node -p 'require("./package.json").version')
-          pnpm run release:ci -- --increment "$VERSION"
+          pnpm exec release-it "$VERSION" --ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acpx",
-  "version": "0.1.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acpx",
-      "version": "0.1.3",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acpx",
-  "version": "0.1.3",
+  "version": "0.1.0",
   "description": "Headless CLI client for the Agent Client Protocol (ACP) — talk to coding agents from the command line",
   "keywords": [
     "acp",


### PR DESCRIPTION
## Summary
- fix the release workflow so CI syncs to the latest published npm version and lets `release-it` perform the requested bump
- reset committed repo version metadata in `package.json` and `package-lock.json` to `0.1.0`

## Verification
- `pnpm run format:check`
- dry-run of the release flow in an isolated clone on branch `main`
  - synced `package.json` to npm latest (`0.1.15`)
  - ran `pnpm exec release-it 0.1.16 --ci --dry-run`
  - confirmed `release-it` performed the release path instead of returning `No new version to release`