### PR TITLE
fix(ci): keep releases on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,12 @@ env:
 
 jobs:
   release:
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    # DO NOT change this job back to a self-hosted runner.
+    # npm trusted publishing + provenance for GitHub Actions releases
+    # requires a GitHub-hosted runner, and publishing fails on self-hosted
+    # environments with:
+    # "Unsupported GitHub Actions runner environment: self-hosted".
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "OpenClaw Team <dev@openclaw.ai>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/openclaw/acpx"
+    "url": "git+https://github.com/openclaw/acpx.git"
   },
   "bin": {
     "acpx": "dist/cli.js"


### PR DESCRIPTION
## Summary
- keep the release workflow on `ubuntu-latest` and add an explicit warning comment not to move it back to self-hosted runners
- fix `package.json` repository metadata so npm no longer auto-corrects it during publish

## Why
The failing run at https://github.com/openclaw/acpx/actions/runs/22893656912/job/66422303505 failed during `npm publish` with:

> Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.

## Verification
- `pnpm run format:check`
- `npm publish --dry-run`
  - publish warning about `repository.url` is gone
  - the remaining failure is only the expected version collision for already-published `0.1.0`