### PR TITLE
fix(windows): support .cmd/.bat agent commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Repo: https://github.com/openclaw/acpx
 
 - ACP/prompt blocks: preserve structured ACP prompt blocks instead of flattening them during prompt handling to support images and non-text. (#103) Thanks @vincentkoc.
 - Images/prompt validation: validate structured image prompt block MIME types and base64 payloads, emit human-readable CLI usage errors, and add an explicit non-CI live Cursor ACP smoke test path. Thanks @vincentkoc.
+- Windows/process spawning: detect PATH-resolved batch wrappers such as `npx` on Windows and enable shell mode only for those commands. (#90) Thanks @lynnzc.
 
 ## 2026.3.10 (v0.1.16)
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess, type ChildProcessByStdio } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import {
@@ -288,14 +289,61 @@ function isCopilotAcpCommand(command: string, args: readonly string[]): boolean 
   return basenameToken(command) === "copilot" && args.includes("--acp");
 }
 
+function readWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const matchedKey = Object.keys(env).find((entry) => entry.toUpperCase() === key);
+  return matchedKey ? env[matchedKey] : undefined;
+}
+
+function resolveWindowsCommand(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const extensions = (readWindowsEnvValue(env, "PATHEXT") ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+  const commandExtension = path.extname(command);
+  const candidates =
+    commandExtension.length > 0
+      ? [command]
+      : extensions.map((extension) => `${command}${extension}`);
+  const hasPath = command.includes("/") || command.includes("\\") || path.isAbsolute(command);
+
+  if (hasPath) {
+    return candidates.find((candidate) => fs.existsSync(candidate));
+  }
+
+  const pathValue = readWindowsEnvValue(env, "PATH");
+  if (!pathValue) {
+    return undefined;
+  }
+
+  for (const directory of pathValue.split(";")) {
+    const trimmedDirectory = directory.trim();
+    if (trimmedDirectory.length === 0) {
+      continue;
+    }
+    for (const candidate of candidates) {
+      const resolved = path.join(trimmedDirectory, candidate);
+      if (fs.existsSync(resolved)) {
+        return resolved;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 function shouldUseWindowsBatchShell(
   command: string,
   platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   if (platform !== "win32") {
     return false;
   }
-  const ext = path.extname(command).toLowerCase();
+  const resolvedCommand = resolveWindowsCommand(command, env) ?? command;
+  const ext = path.extname(resolvedCommand).toLowerCase();
   return ext === ".cmd" || ext === ".bat";
 }
 
@@ -303,8 +351,9 @@ export function buildSpawnCommandOptions(
   command: string,
   options: Parameters<typeof spawn>[2],
   platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
 ): Parameters<typeof spawn>[2] {
-  if (!shouldUseWindowsBatchShell(command, platform)) {
+  if (!shouldUseWindowsBatchShell(command, platform, env)) {
     return options;
   }
   return {

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { buildAgentSpawnOptions, buildSpawnCommandOptions } from "../src/client.js";
 import { buildQueueOwnerSpawnOptions } from "../src/session-runtime/queue-owner-process.js";
@@ -52,19 +55,49 @@ test("buildSpawnCommandOptions enables shell for .cmd/.bat on Windows", () => {
   assert.equal(cmdOptions.windowsHide, true);
 });
 
-test("buildSpawnCommandOptions keeps shell disabled for non-batch commands", () => {
+test("buildSpawnCommandOptions enables shell for PATH-resolved .cmd wrappers on Windows", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-windows-spawn-"));
+  const env = {
+    PATH: tempDir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  };
   const base = {
     stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"],
     windowsHide: true,
   };
 
-  const linuxOptions = buildSpawnCommandOptions("/usr/bin/npx", base, "linux");
-  const windowsExeOptions = buildSpawnCommandOptions(
-    "C:\\Program Files\\nodejs\\node.exe",
-    base,
-    "win32",
-  );
+  try {
+    await fs.writeFile(path.join(tempDir, "npx.cmd"), "@echo off\r\n");
 
-  assert.equal(linuxOptions.shell, undefined);
-  assert.equal(windowsExeOptions.shell, undefined);
+    const options = buildSpawnCommandOptions("npx", base, "win32", env);
+    assert.equal(options.shell, true);
+    assert.deepEqual(options.stdio, base.stdio);
+    assert.equal(options.windowsHide, true);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("buildSpawnCommandOptions keeps shell disabled for non-batch commands", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-windows-spawn-"));
+  const env = {
+    PATH: tempDir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  };
+  const base = {
+    stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  };
+
+  try {
+    await fs.writeFile(path.join(tempDir, "node.exe"), "");
+
+    const linuxOptions = buildSpawnCommandOptions("/usr/bin/npx", base, "linux");
+    const windowsExeOptions = buildSpawnCommandOptions("node", base, "win32", env);
+
+    assert.equal(linuxOptions.shell, undefined);
+    assert.equal(windowsExeOptions.shell, undefined);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

This PR fixes Windows agent command spawning for batch wrappers (`.cmd`/`.bat`) such as `npx.cmd`.

`child_process.spawn(..., { shell: false })` cannot execute Windows batch files directly, so ACPX failed with spawn errors in those cases.

## What changed

- Added `shouldUseWindowsBatchShell(command, platform)` to detect Windows batch wrappers.
- Added `buildSpawnCommandOptions(command, options, platform)` to enable `shell: true` only when needed (`win32` + `.cmd`/`.bat`).
- Applied this behavior to agent command spawns in `src/client.ts`.
- Added tests in `test/spawn-options.test.ts` for:
  - `.cmd/.bat` on Windows => `shell` enabled.
  - non-batch commands => `shell` remains disabled.

## Why this approach

- Keeps default spawn behavior unchanged for Linux/macOS and non-batch commands.
- Minimizes security/surface change by enabling shell only for the Windows batch case that requires it.

## Testing

Fully tested locally:

- `pnpm check`
- `pnpm run build:test`
- `node --test dist-test/test/spawn-options.test.js dist-test/test/client.test.js`

## Issue

Closes #90
