### PR TITLE
feat: add per-agent env override support to spawn layer

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -651,8 +651,18 @@ function buildClaudeCodeOptionsMeta(
 
 function buildAgentEnvironment(
   authCredentials: Record<string, string> | undefined,
+  envOverrides: Record<string, string> | undefined,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
+
+  if (envOverrides) {
+    for (const [key, value] of Object.entries(envOverrides)) {
+      if (typeof value === "string") {
+        env[key] = value;
+      }
+    }
+  }
+
   if (!authCredentials) {
     return env;
   }
@@ -684,6 +694,7 @@ function buildAgentEnvironment(
 export function buildAgentSpawnOptions(
   cwd: string,
   authCredentials: Record<string, string> | undefined,
+  envOverrides?: Record<string, string>,
 ): {
   cwd: string;
   env: NodeJS.ProcessEnv;
@@ -692,7 +703,7 @@ export function buildAgentSpawnOptions(
 } {
   return {
     cwd,
-    env: buildAgentEnvironment(authCredentials),
+    env: buildAgentEnvironment(authCredentials, envOverrides),
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   };
@@ -879,7 +890,11 @@ export class AcpClient {
       args,
       buildSpawnCommandOptions(
         command,
-        buildAgentSpawnOptions(this.options.cwd, this.options.authCredentials),
+        buildAgentSpawnOptions(
+          this.options.cwd,
+          this.options.authCredentials,
+          this.options.envOverrides,
+        ),
       ),
     ) as ChildProcessByStdio<Writable, Readable, Readable>;
 

--- a/src/queue-owner-env.ts
+++ b/src/queue-owner-env.ts
@@ -52,6 +52,15 @@ export function parseQueueOwnerPayload(raw: string): QueueOwnerRuntimeOptions {
     options.authCredentials = Object.fromEntries(entries);
   }
 
+  if (record.envOverrides && typeof record.envOverrides === "object") {
+    const entries = Object.entries(record.envOverrides as UnknownRecord).filter(
+      ([, value]) => typeof value === "string",
+    ) as Array<[string, string]>;
+    if (entries.length > 0) {
+      options.envOverrides = Object.fromEntries(entries);
+    }
+  }
+
   if (record.authPolicy === "skip" || record.authPolicy === "fail") {
     options.authPolicy = record.authPolicy;
   }

--- a/src/session-runtime.ts
+++ b/src/session-runtime.ts
@@ -112,6 +112,7 @@ export type RunOnceOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   outputFormatter: OutputFormatter;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
@@ -128,6 +129,7 @@ export type SessionCreateOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   verbose?: boolean;
   sessionOptions?: SessionAgentOptions;
 } & TimedRunOptions;
@@ -140,6 +142,7 @@ export type SessionSendOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   outputFormatter: OutputFormatter;
   errorEmissionPolicy?: OutputErrorEmissionPolicy;
   suppressSdkConsoleErrors?: boolean;
@@ -159,6 +162,7 @@ export type SessionEnsureOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   verbose?: boolean;
   walkBoundary?: string;
   sessionOptions?: SessionAgentOptions;
@@ -215,6 +219,7 @@ type RunSessionPromptOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   outputFormatter: OutputFormatter;
   timeoutMs?: number;
   suppressSdkConsoleErrors?: boolean;
@@ -311,6 +316,7 @@ async function runQueuedTask(
     nonInteractivePermissions?: NonInteractivePermissionPolicy;
     authCredentials?: Record<string, string>;
     authPolicy?: AuthPolicy;
+    envOverrides?: Record<string, string>;
     suppressSdkConsoleErrors?: boolean;
     onClientAvailable?: (controller: ActiveSessionController) => void;
     onClientClosed?: () => void;
@@ -331,6 +337,7 @@ async function runQueuedTask(
         task.nonInteractivePermissions ?? options.nonInteractivePermissions,
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
+      envOverrides: options.envOverrides,
       outputFormatter,
       timeoutMs: task.timeoutMs,
       suppressSdkConsoleErrors: task.suppressSdkConsoleErrors ?? options.suppressSdkConsoleErrors,
@@ -428,6 +435,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       nonInteractivePermissions: options.nonInteractivePermissions,
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
+      envOverrides: options.envOverrides,
       suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
       verbose: options.verbose,
     });
@@ -636,6 +644,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    envOverrides: options.envOverrides,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     onAcpOutputMessage: (_direction, message) => output.onAcpMessage(message),
@@ -685,6 +694,7 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    envOverrides: options.envOverrides,
     verbose: options.verbose,
     sessionOptions: options.sessionOptions,
   });
@@ -841,6 +851,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    envOverrides: options.envOverrides,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
   });
@@ -973,6 +984,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
             nonInteractivePermissions: options.nonInteractivePermissions,
             authCredentials: options.authCredentials,
             authPolicy: options.authPolicy,
+            envOverrides: options.envOverrides,
             suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
             onClientAvailable: setActiveController,
             onClientClosed: clearActiveController,

--- a/src/session-runtime/queue-owner-process.ts
+++ b/src/session-runtime/queue-owner-process.ts
@@ -14,6 +14,7 @@ export type QueueOwnerRuntimeOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   ttlMs?: number;
@@ -27,6 +28,7 @@ type SessionSendLike = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   ttlMs?: number;
@@ -52,6 +54,7 @@ export function queueOwnerRuntimeOptionsFromSend(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    envOverrides: options.envOverrides,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     ttlMs: options.ttlMs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,7 @@ export type AcpClientOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  envOverrides?: Record<string, string>;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   sessionOptions?: {

--- a/test/queue-owner-env.test.ts
+++ b/test/queue-owner-env.test.ts
@@ -23,12 +23,17 @@ describe("parseQueueOwnerPayload", () => {
         ],
         ttlMs: 1234,
         maxQueueDepth: 7,
+        envOverrides: { ANTHROPIC_API_KEY: "sk-agent-1", CUSTOM_FLAG: "on" },
       }),
     );
     assert.equal(parsed.sessionId, "session-1");
     assert.equal(parsed.permissionMode, "approve-reads");
     assert.equal(parsed.ttlMs, 1234);
     assert.equal(parsed.maxQueueDepth, 7);
+    assert.deepEqual(parsed.envOverrides, {
+      ANTHROPIC_API_KEY: "sk-agent-1",
+      CUSTOM_FLAG: "on",
+    });
     assert.deepEqual(parsed.mcpServers, [
       {
         name: "linear-http",

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -18,6 +18,18 @@ test("buildAgentSpawnOptions hides Windows console windows and preserves auth en
   assert.equal(options.env.ACPX_AUTH_TOKEN, "secret-token");
 });
 
+test("buildAgentSpawnOptions applies envOverrides to the spawned environment", () => {
+  const options = buildAgentSpawnOptions(
+    "/tmp/acpx-agent",
+    { ACPX_AUTH_TOKEN: "secret-token" },
+    { ANTHROPIC_API_KEY: "sk-override", CUSTOM_VAR: "custom-value" },
+  );
+
+  assert.equal(options.env.ACPX_AUTH_TOKEN, "secret-token");
+  assert.equal(options.env.ANTHROPIC_API_KEY, "sk-override");
+  assert.equal(options.env.CUSTOM_VAR, "custom-value");
+});
+
 test("buildTerminalSpawnOptions hides Windows console windows and maps env entries", () => {
   const options = buildTerminalSpawnOptions("/tmp/acpx-terminal", [
     { name: "TMUX", value: "/tmp/tmux-1000/default,123,0" },


### PR DESCRIPTION
## Summary

- Add `envOverrides?: Record<string, string>` field to `QueueOwnerRuntimeOptions`, `AcpClientOptions`, and all session option types (`SessionSendOptions`, `RunOnceOptions`, `SessionCreateOptions`, `SessionEnsureOptions`)
- Thread `envOverrides` through the full spawn chain: caller → queue-owner payload → `parseQueueOwnerPayload` → `AcpClient` → `buildAgentEnvironment` → spawned agent process
- Apply env overrides in `buildAgentEnvironment` before auth credential mapping, so callers can inject per-agent credentials (e.g. `ANTHROPIC_API_KEY`) that take effect in the CC child process

## Motivation

The OpenClaw ACP spawn chain needs to pass per-agent env overrides to acpx-spawned processes. Currently the queue-owner process spawns with `{ ...process.env }`, inheriting whatever env the parent had, with no way for the caller to specify per-session env overrides that get forwarded to the CC child process.

## Test plan

- [x] Existing tests pass (239/239)
- [x] New test: `buildAgentSpawnOptions applies envOverrides to the spawned environment`
- [x] Updated test: `parseQueueOwnerPayload` now validates `envOverrides` round-trip through payload serialization