### PR TITLE
fix: clarify Codex read-only mode boundaries and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,23 @@ acpx --ttl 30 codex 'keep queue owner alive for quick follow-ups'
 acpx --verbose codex 'debug why adapter startup is failing'
 ```
 
+## Permission layers and Codex read-only mode
+
+`acpx` permission flags and adapter sandbox modes are different controls:
+
+- `--approve-all`, `--approve-reads`, and `--deny-all` control `acpx` client-side permission handling for ACP client methods (for example `fs/*` and `terminal/*`).
+- `set-mode` controls adapter-defined session modes via ACP `session/set_mode` (for example Codex `read-only`, `auto`, `full-access`).
+- These controls are independent by design, so `--approve-all` does not imply `set-mode full-access`.
+
+If Codex still reports read-only sandbox behavior, set the session mode explicitly:
+
+```bash
+acpx codex sessions ensure
+acpx codex set-mode auto
+# or
+acpx codex set-mode full-access
+```
+
 ## Configuration files
 
 `acpx` reads config in this order (later wins):

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -474,6 +474,27 @@ Non-interactive prompt policy:
 - `--non-interactive-permissions deny`: deny non-read/search prompts when no TTY (default)
 - `--non-interactive-permissions fail`: fail with `PERMISSION_PROMPT_UNAVAILABLE`
 
+### Permission flags vs adapter session modes
+
+`acpx` permission flags and adapter sandbox modes are separate controls:
+
+- `--approve-all`, `--approve-reads`, and `--deny-all` affect `acpx` client-side permission handling.
+- `set-mode` affects the connected adapter session mode through ACP `session/set_mode`.
+- They are intentionally not auto-mapped, so `--approve-all` does not automatically switch adapter sandbox mode.
+
+### Troubleshooting Codex read-only behavior
+
+If Codex reports read-only sandbox behavior even when running with `--approve-all`, explicitly set the Codex session mode:
+
+```bash
+acpx codex sessions ensure
+acpx codex set-mode auto
+# or
+acpx codex set-mode full-access
+```
+
+`set-mode` values are adapter-defined; unsupported values are rejected by the adapter.
+
 ## Exit codes
 
 | Code  | Meaning                                                                                    |

--- a/src/error-normalization.ts
+++ b/src/error-normalization.ts
@@ -20,6 +20,8 @@ import {
 
 const AUTH_REQUIRED_ACP_CODES = new Set([-32000]);
 const QUERY_CLOSED_BEFORE_RESPONSE_DETAIL = "query closed before response received";
+const READ_ONLY_HINT_TEXT =
+  "Hint: acpx permission flags (--approve-all/--approve-reads/--deny-all) control client-side approvals, not adapter sandbox mode. If Codex remains read-only, run `acpx codex set-mode auto` or `acpx codex set-mode full-access`.";
 
 type ErrorMeta = {
   outputCode?: OutputErrorCode;
@@ -66,6 +68,54 @@ function isAuthRequiredMessage(value: string | undefined): boolean {
     normalized.includes("credentials required") ||
     normalized.includes("token required") ||
     normalized.includes("login required")
+  );
+}
+
+function readStringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function containsReadOnlySandboxSignal(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.toLowerCase();
+  if (normalized.includes("read-only sandbox")) {
+    return true;
+  }
+  if (normalized.includes("readonly sandbox")) {
+    return true;
+  }
+  return normalized.includes("read-only") && normalized.includes("sandbox");
+}
+
+function shouldAppendReadOnlyHint(
+  message: string,
+  acp: OutputErrorAcpPayload | undefined,
+): boolean {
+  if (message.includes("acpx permission flags")) {
+    return false;
+  }
+  if (containsReadOnlySandboxSignal(message)) {
+    return true;
+  }
+
+  if (!acp) {
+    return false;
+  }
+  if (containsReadOnlySandboxSignal(acp.message)) {
+    return true;
+  }
+
+  const data = asRecord(acp.data);
+  if (!data) {
+    return false;
+  }
+  return (
+    containsReadOnlySandboxSignal(readStringField(data, "details")) ||
+    containsReadOnlySandboxSignal(readStringField(data, "detail")) ||
+    containsReadOnlySandboxSignal(readStringField(data, "reason"))
   );
 }
 
@@ -216,9 +266,13 @@ export function normalizeOutputError(
     (error instanceof AuthPolicyError || isAcpAuthRequiredPayload(acp)
       ? "AUTH_REQUIRED"
       : undefined);
+  const baseMessage = formatErrorMessage(error);
+  const message = shouldAppendReadOnlyHint(baseMessage, acp)
+    ? `${baseMessage}\n${READ_ONLY_HINT_TEXT}`
+    : baseMessage;
   return {
     code,
-    message: formatErrorMessage(error),
+    message,
     detailCode,
     origin: meta.origin ?? options.origin,
     retryable: meta.retryable ?? options.retryable,

--- a/test/error-normalization.test.ts
+++ b/test/error-normalization.test.ts
@@ -122,6 +122,33 @@ test("normalizeOutputError infers AUTH_REQUIRED detail from ACP payload", () => 
   assert.equal(normalized.acp?.code, -32000);
 });
 
+test("normalizeOutputError appends guidance for read-only sandbox errors", () => {
+  const normalized = normalizeOutputError(
+    new Error("I am in a read-only sandbox and cannot apply this change."),
+  );
+
+  assert.equal(normalized.code, "RUNTIME");
+  assert.match(normalized.message, /read-only sandbox/i);
+  assert.match(normalized.message, /acpx permission flags/i);
+  assert.match(normalized.message, /set-mode auto/i);
+  assert.match(normalized.message, /set-mode full-access/i);
+});
+
+test("normalizeOutputError appends guidance when ACP details report read-only sandbox", () => {
+  const normalized = normalizeOutputError({
+    error: {
+      code: -32603,
+      message: "Internal error",
+      data: {
+        details: "Operation denied in read-only sandbox",
+      },
+    },
+  });
+
+  assert.equal(normalized.code, "RUNTIME");
+  assert.match(normalized.message, /acpx permission flags/i);
+});
+
 test("exitCodeForOutputErrorCode maps machine codes to stable exits", () => {
   assert.equal(exitCodeForOutputErrorCode("USAGE"), 2);
   assert.equal(exitCodeForOutputErrorCode("TIMEOUT"), 3);


### PR DESCRIPTION
## Summary

- document that acpx permission flags (`--approve-all`, `--approve-reads`, `--deny-all`) and adapter sandbox/session modes are separate controls
- add explicit Codex read-only troubleshooting steps in `README.md` and `docs/CLI.md`
- append a targeted runtime hint when error payloads indicate read-only sandbox behavior, so users get the next command to run immediately
- add coverage for the new read-only hint behavior in `error-normalization` tests

References openclaw/acpx#115.

## Test plan

- `pnpm run check:docs`
- `pnpm run build:test && node --test dist-test/test/error-normalization.test.js`
