### PR TITLE
fix: count client-method permission denials in permission stats

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -37,6 +37,7 @@ import {
   ClaudeAcpSessionCreateTimeoutError,
   CopilotAcpUnsupportedError,
   GeminiAcpStartupTimeoutError,
+  PermissionDeniedError,
   PermissionPromptUnavailableError,
 } from "./errors.js";
 import { FileSystemHandlers } from "./filesystem.js";
@@ -1406,8 +1407,7 @@ export class AcpClient {
     } catch (error) {
       if (error instanceof PermissionPromptUnavailableError) {
         this.notePromptPermissionFailure(params.sessionId, error);
-        this.permissionStats.requested += 1;
-        this.permissionStats.cancelled += 1;
+        this.recordPermissionDecision("cancelled");
         return {
           outcome: {
             outcome: "cancelled",
@@ -1418,14 +1418,7 @@ export class AcpClient {
     }
 
     const decision = classifyPermissionDecision(params, response);
-    this.permissionStats.requested += 1;
-    if (decision === "approved") {
-      this.permissionStats.approved += 1;
-    } else if (decision === "denied") {
-      this.permissionStats.denied += 1;
-    } else {
-      this.permissionStats.cancelled += 1;
-    }
+    this.recordPermissionDecision(decision);
 
     return response;
   }
@@ -1484,16 +1477,19 @@ export class AcpClient {
   }
 
   private async handleReadTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
-    return await this.filesystem.readTextFile(params);
+    try {
+      return await this.filesystem.readTextFile(params);
+    } catch (error) {
+      this.recordPermissionError(params.sessionId, error);
+      throw error;
+    }
   }
 
   private async handleWriteTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
     try {
       return await this.filesystem.writeTextFile(params);
     } catch (error) {
-      if (error instanceof PermissionPromptUnavailableError) {
-        this.notePromptPermissionFailure(params.sessionId, error);
-      }
+      this.recordPermissionError(params.sessionId, error);
       throw error;
     }
   }
@@ -1504,9 +1500,7 @@ export class AcpClient {
     try {
       return await this.terminalManager.createTerminal(params);
     } catch (error) {
-      if (error instanceof PermissionPromptUnavailableError) {
-        this.notePromptPermissionFailure(params.sessionId, error);
-      }
+      this.recordPermissionError(params.sessionId, error);
       throw error;
     }
   }
@@ -1531,6 +1525,30 @@ export class AcpClient {
     params: ReleaseTerminalRequest,
   ): Promise<ReleaseTerminalResponse> {
     return await this.terminalManager.releaseTerminal(params);
+  }
+
+  private recordPermissionDecision(decision: "approved" | "denied" | "cancelled"): void {
+    this.permissionStats.requested += 1;
+    if (decision === "approved") {
+      this.permissionStats.approved += 1;
+      return;
+    }
+    if (decision === "denied") {
+      this.permissionStats.denied += 1;
+      return;
+    }
+    this.permissionStats.cancelled += 1;
+  }
+
+  private recordPermissionError(sessionId: string, error: unknown): void {
+    if (error instanceof PermissionPromptUnavailableError) {
+      this.notePromptPermissionFailure(sessionId, error);
+      this.recordPermissionDecision("cancelled");
+      return;
+    }
+    if (error instanceof PermissionDeniedError) {
+      this.recordPermissionDecision("denied");
+    }
   }
 
   private async handleSessionUpdate(notification: SessionNotification): Promise<void> {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1133,6 +1133,52 @@ test("queued prompt failures remain visible in quiet mode", async () => {
   });
 });
 
+test("non-queued write permission denial exits with code 5", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".acpx", "config.json"),
+      `${JSON.stringify(
+        {
+          agents: {
+            codex: {
+              command: MOCK_AGENT_COMMAND,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const session = await runCli(
+      ["--cwd", cwd, "--format", "json", "codex", "sessions", "new"],
+      homeDir,
+    );
+    assert.equal(session.code, 0, session.stderr);
+
+    const writeResult = await runCli(
+      [
+        "--cwd",
+        cwd,
+        "--format",
+        "quiet",
+        "--approve-reads",
+        "codex",
+        "prompt",
+        `write ${path.join(cwd, "x.txt")} hi`,
+      ],
+      homeDir,
+    );
+
+    assert.equal(writeResult.code, 5);
+    assert.match(writeResult.stdout, /error:\s*Internal error/i);
+  });
+});
+
 test("--json-strict suppresses session banners on stderr", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -3,7 +3,11 @@ import { PassThrough } from "node:stream";
 import test from "node:test";
 import type { RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
 import { AcpClient, buildAgentSpawnOptions } from "../src/client.js";
-import { AuthPolicyError, PermissionPromptUnavailableError } from "../src/errors.js";
+import {
+  AuthPolicyError,
+  PermissionDeniedError,
+  PermissionPromptUnavailableError,
+} from "../src/errors.js";
 
 type ClientInternals = {
   selectAuthMethod?: (methods: Array<{ id: string }>) =>
@@ -20,6 +24,22 @@ type ClientInternals = {
   handlePermissionRequest?: (
     params: RequestPermissionRequest,
   ) => Promise<RequestPermissionResponse>;
+  handleReadTextFile?: (params: {
+    sessionId: string;
+    path: string;
+    line?: number | null;
+    limit?: number | null;
+  }) => Promise<{ content: string }>;
+  handleWriteTextFile?: (params: {
+    sessionId: string;
+    path: string;
+    content: string;
+  }) => Promise<Record<string, never>>;
+  handleCreateTerminal?: (params: {
+    sessionId: string;
+    command: string;
+    args?: string[];
+  }) => Promise<{ terminalId: string }>;
   notePromptPermissionFailure?: (
     sessionId: string,
     error: PermissionPromptUnavailableError,
@@ -34,8 +54,26 @@ type ClientInternals = {
     exitCode: number | null,
     signal: NodeJS.Signals | null,
   ) => void;
+  filesystem?: {
+    readTextFile: (params: {
+      sessionId: string;
+      path: string;
+      line?: number | null;
+      limit?: number | null;
+    }) => Promise<{ content: string }>;
+    writeTextFile: (params: {
+      sessionId: string;
+      path: string;
+      content: string;
+    }) => Promise<Record<string, never>>;
+  };
   terminalManager?: {
     shutdown: () => Promise<void>;
+    createTerminal?: (params: {
+      sessionId: string;
+      command: string;
+      args?: string[];
+    }) => Promise<{ terminalId: string }>;
   };
   cancel?: (sessionId: string) => Promise<void>;
   connection?: unknown;
@@ -214,6 +252,62 @@ test("AcpClient handlePermissionRequest records approved decisions", async () =>
     denied: 0,
     cancelled: 0,
   });
+});
+
+test("AcpClient client-method permission errors update permission stats", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+
+  internals.filesystem = {
+    readTextFile: async () => {
+      throw new PermissionDeniedError("Permission denied for fs/read_text_file");
+    },
+    writeTextFile: async () => {
+      throw new PermissionDeniedError("Permission denied for fs/write_text_file");
+    },
+  };
+  internals.terminalManager = {
+    shutdown: async () => {},
+    createTerminal: async () => {
+      throw new PermissionPromptUnavailableError();
+    },
+  };
+
+  await assert.rejects(
+    async () =>
+      await internals.handleReadTextFile?.({
+        sessionId: "session-read",
+        path: "/tmp/read.txt",
+      }),
+    PermissionDeniedError,
+  );
+  await assert.rejects(
+    async () =>
+      await internals.handleWriteTextFile?.({
+        sessionId: "session-write",
+        path: "/tmp/write.txt",
+        content: "updated",
+      }),
+    PermissionDeniedError,
+  );
+  await assert.rejects(
+    async () =>
+      await internals.handleCreateTerminal?.({
+        sessionId: "session-terminal",
+        command: "echo",
+        args: ["hi"],
+      }),
+    PermissionPromptUnavailableError,
+  );
+
+  assert.deepEqual(client.getPermissionStats(), {
+    requested: 3,
+    approved: 0,
+    denied: 2,
+    cancelled: 1,
+  });
+  const noted = internals.consumePromptPermissionFailure?.("session-terminal");
+  assert(noted instanceof PermissionPromptUnavailableError);
 });
 
 test("AcpClient createSession forwards claudeCode options in _meta", async () => {


### PR DESCRIPTION
## Summary

- Count permission outcomes for client methods (`fs/read_text_file`, `fs/write_text_file`, `terminal/create`) in the same `permissionStats` bucket used by `permission/request`.
- Treat `PermissionDeniedError` as `denied` and `PermissionPromptUnavailableError` as `cancelled` for these client-method paths.
- Centralize permission-stat updates through shared helpers to keep behavior consistent.
- Add coverage for both client-level permission accounting and the CLI regression case.

## Why

`permissionStats` drives CLI exit-code shaping. Before this change, permission failures thrown directly by client methods were not counted, so non-queued permission denials could be surfaced as generic internal errors instead of permission-denied semantics.

## Test Plan

- `pnpm run build:test`
- `node --test dist-test/test/client.test.js --test-name-pattern='client-method permission errors update permission stats'`
- `node --test dist-test/test/cli.test.js --test-name-pattern='non-queued write permission denial exits with code 5'`
- `pnpm run build:test && npx -y node@22 --experimental-test-coverage --test-coverage-lines=83 --test-coverage-branches=76 --test-coverage-functions=86 --test dist-test/test/*.test.js`
