### PR TITLE
fix: stream thinking output immediately

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -554,7 +554,7 @@ class TextOutputFormatter implements OutputFormatter {
       }
       case "agent_thought_chunk": {
         if (update.content.type === "text") {
-          this.thoughtBuffer += update.content.text;
+          this.writeThoughtChunk(update.content.text);
         }
         return;
       }
@@ -653,6 +653,14 @@ class TextOutputFormatter implements OutputFormatter {
     }
     this.section = "assistant";
     this.write(text);
+  }
+
+  private writeThoughtChunk(text: string): void {
+    if (!text) {
+      return;
+    }
+    this.beginSection("thought");
+    this.writeLine(this.dim(`[thinking] ${truncate(collapseWhitespace(text), MAX_THOUGHT_CHARS)}`));
   }
 
   private flushThoughtBuffer(): void {

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -53,18 +53,22 @@ function doneResult(stopReason: string): unknown {
   };
 }
 
-test("text formatter batches thought chunks from ACP notifications", () => {
+test("text formatter streams thought chunks from ACP notifications immediately", () => {
   const writer = new CaptureWriter();
   const formatter = createOutputFormatter("text", { stdout: writer });
 
   formatter.onAcpMessage(thoughtChunk("Investigating ") as never);
+  assert.match(writer.toString(), /\[thinking\] Investigating/);
+
   formatter.onAcpMessage(thoughtChunk("the issue") as never);
+  assert.equal((writer.toString().match(/\[thinking\]/g) ?? []).length, 2);
+
   formatter.onAcpMessage(messageChunk("Done.") as never);
   formatter.onAcpMessage(doneResult("end_turn") as never);
 
   const output = writer.toString();
-  assert.equal((output.match(/\[thinking\]/g) ?? []).length, 1);
-  assert.match(output, /\[thinking\] Investigating the issue/);
+  assert.match(output, /\[thinking\] Investigating/);
+  assert.match(output, /\[thinking\] the issue/);
   assert.match(output, /\[done\] end_turn/);
 });
 


### PR DESCRIPTION
## Summary

This change makes text-mode thinking output render as soon as each `agent_thought_chunk` arrives, instead of buffering until the next non-thought update.

## Problem

The text formatter currently accumulates thought chunks in `thoughtBuffer` and only flushes them when a later non-thought update or prompt result arrives. In practice this means thinking output appears blocked, even when the agent is streaming it incrementally.

## Changes

- render each incoming `agent_thought_chunk` immediately in text mode
- remove the behavioral dependency on a later non-thought update before thought becomes visible
- add a regression test proving that thought text is visible after the first chunk arrives

## Why this should be separate

This PR only changes the output timing. It does not change thought formatting or whitespace handling.

## Testing

- `./node_modules/.bin/tsc -p tsconfig.test.json`
- `node --test dist-test/test/output.test.js`
