### PR TITLE
feat: generic model selection via ACP session/set_model

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,19 +67,22 @@ Notes:
 
 All global options:
 
-| Option                                   | Description                                    | Details                                                             |
-| ---------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------- |
-| `--agent <command>`                      | Raw ACP agent command (escape hatch)           | Do not combine with positional agent token.                         |
-| `--cwd <dir>`                            | Working directory                              | Defaults to current directory. Stored as absolute path for scoping. |
-| `--approve-all`                          | Auto-approve all permissions                   | Permission mode `approve-all`.                                      |
-| `--approve-reads`                        | Auto-approve reads/searches, prompt for others | Default permission mode.                                            |
-| `--deny-all`                             | Deny all permissions                           | Permission mode `deny-all`.                                         |
-| `--format <fmt>`                         | Output format                                  | `text` (default), `json`, `quiet`.                                  |
-| `--json-strict`                          | Strict JSON mode                               | Requires `--format json`; suppresses non-JSON stderr output.        |
-| `--non-interactive-permissions <policy>` | Non-TTY prompt policy                          | `deny` (default) or `fail` when approval prompt cannot be shown.    |
-| `--timeout <seconds>`                    | Max wait time for agent response               | Must be positive. Decimal seconds allowed.                          |
-| `--ttl <seconds>`                        | Queue owner idle TTL before shutdown           | Default `300`. `0` disables TTL.                                    |
-| `--verbose`                              | Enable verbose logs                            | Prints ACP/debug details to stderr.                                 |
+| Option                                   | Description                                    | Details                                                                                                                                   |
+| ---------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `--agent <command>`                      | Raw ACP agent command (escape hatch)           | Do not combine with positional agent token.                                                                                               |
+| `--cwd <dir>`                            | Working directory                              | Defaults to current directory. Stored as absolute path for scoping.                                                                       |
+| `--approve-all`                          | Auto-approve all permissions                   | Permission mode `approve-all`.                                                                                                            |
+| `--approve-reads`                        | Auto-approve reads/searches, prompt for others | Default permission mode.                                                                                                                  |
+| `--deny-all`                             | Deny all permissions                           | Permission mode `deny-all`.                                                                                                               |
+| `--format <fmt>`                         | Output format                                  | `text` (default), `json`, `quiet`.                                                                                                        |
+| `--json-strict`                          | Strict JSON mode                               | Requires `--format json`; suppresses non-JSON stderr output.                                                                              |
+| `--non-interactive-permissions <policy>` | Non-TTY prompt policy                          | `deny` (default) or `fail` when approval prompt cannot be shown.                                                                          |
+| `--timeout <seconds>`                    | Max wait time for agent response               | Must be positive. Decimal seconds allowed.                                                                                                |
+| `--ttl <seconds>`                        | Queue owner idle TTL before shutdown           | Default `300`. `0` disables TTL.                                                                                                          |
+| `--model <id>`                           | Set agent model                                | Sent via generic ACP `session/set_model` when the agent advertises available models; also sent via `_meta.claudeCode.options` for Claude. |
+| `--allowed-tools <tools>`                | Restrict allowed tools                         | Comma-separated list (e.g. `Read,Grep,Bash`). **Claude-only:** sent via `_meta.claudeCode.options`; no generic ACP equivalent exists.     |
+| `--max-turns <n>`                        | Limit agent turns                              | Maximum number of turns the agent may take. **Claude-only:** sent via `_meta.claudeCode.options`; no generic ACP equivalent exists.       |
+| `--verbose`                              | Enable verbose logs                            | Prints ACP/debug details to stderr.                                                                                                       |
 
 Permission flags are mutually exclusive. Using more than one of `--approve-all`, `--approve-reads`, `--deny-all` is a usage error.
 
@@ -251,6 +254,23 @@ Behavior:
 - Calls ACP `session/set_config_option`.
 - Routes through queue-owner IPC when an owner is active.
 - Falls back to a direct client reconnect when no owner is running.
+- **`set model <id>`**: Intercepted to call `session/set_model` instead. Some agents support `session/set_model` but not `session/set_config_option` for model changes; routing through the dedicated method ensures broad compatibility.
+
+### Reasoning effort
+
+`set thought_level <value>` is the generic ACP path for controlling reasoning effort (e.g. `set thought_level high`). Currently **no agent implements the handler**.
+
+**Workaround:** Pass a reasoning flag directly in the agent command:
+
+```bash
+acpx --agent "<agent-command> -r high" exec 'your prompt'
+```
+
+Caveats:
+
+- Agent-command flags are process-level: they do **not** persist on session resume (the agent must restart).
+- Reasoning flags and `--model` are orthogonal — both work and do not interfere with each other.
+- When agents implement `session/set_config_option` for `thought_level`, `set thought_level <value>` will work without acpx changes.
 
 ## `sessions` subcommand
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -135,12 +135,13 @@ Behavior:
 - Runs a single prompt in a temporary ACP session
 - Does not reuse or save persistent session state
 
-### Cancel / Mode / Config
+### Cancel / Mode / Config / Model
 
 ```bash
 acpx codex cancel
 acpx codex set-mode auto
 acpx codex set thought_level high
+acpx codex set model gpt-5.4
 ```
 
 Behavior:
@@ -150,6 +151,7 @@ Behavior:
 - `set-mode` mode ids are adapter-defined; unsupported values are rejected by the adapter (often `Invalid params`).
 - `set`: calls ACP `session/set_config_option`.
 - For codex, `thought_level` is accepted as a compatibility alias for codex-acp `reasoning_effort`.
+- `set model <id>`: intercepted to call `session/set_model` instead of `session/set_config_option`. This is the generic ACP method for mid-session model switching.
 - `set-mode`/`set` route through queue-owner IPC when active, otherwise reconnect directly.
 
 ### Sessions
@@ -194,6 +196,7 @@ Behavior:
 - `--format <fmt>`: output format (`text`, `json`, `quiet`)
 - `--timeout <seconds>`: max wait time (positive number)
 - `--ttl <seconds>`: queue owner idle TTL before shutdown (default `300`, `0` disables TTL)
+- `--model <id>`: set agent model via generic ACP `session/set_model` when the agent advertises models
 - `--verbose`: verbose ACP/debug logs to stderr
 
 Permission flags are mutually exclusive.

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -975,6 +975,8 @@ async function handleStatus(
     process.stdout.write(`agent: ${agent.agentCommand}\n`);
     process.stdout.write(`pid: -\n`);
     process.stdout.write(`status: no-session\n`);
+    process.stdout.write(`model: -\n`);
+    process.stdout.write(`mode: -\n`);
     process.stdout.write(`uptime: -\n`);
     process.stdout.write(`lastPromptTime: -\n`);
     return;
@@ -987,6 +989,9 @@ async function handleStatus(
     agentCommand: record.agentCommand,
     pid: health.pid ?? record.pid ?? null,
     status: running ? "running" : "dead",
+    model: record.acpx?.current_model_id ?? null,
+    mode: record.acpx?.current_mode_id ?? null,
+    availableModels: record.acpx?.available_models ?? null,
     uptime: running ? (formatUptime(record.agentStartedAt) ?? null) : null,
     lastPromptTime: record.lastPromptAt ?? null,
     exitCode: running ? null : (record.lastAgentExitCode ?? null),
@@ -1000,6 +1005,9 @@ async function handleStatus(
       status: running ? "alive" : "dead",
       pid: payload.pid ?? undefined,
       summary: running ? "queue owner healthy" : "queue owner unavailable",
+      model: payload.model ?? undefined,
+      mode: payload.mode ?? undefined,
+      availableModels: payload.availableModels ?? undefined,
       uptime: payload.uptime ?? undefined,
       lastPromptTime: payload.lastPromptTime ?? undefined,
       exitCode: payload.exitCode ?? undefined,
@@ -1024,6 +1032,8 @@ async function handleStatus(
   process.stdout.write(`agent: ${payload.agentCommand}\n`);
   process.stdout.write(`pid: ${payload.pid ?? "-"}\n`);
   process.stdout.write(`status: ${payload.status}\n`);
+  process.stdout.write(`model: ${payload.model ?? "-"}\n`);
+  process.stdout.write(`mode: ${payload.mode ?? "-"}\n`);
   process.stdout.write(`uptime: ${payload.uptime ?? "-"}\n`);
   process.stdout.write(`lastPromptTime: ${payload.lastPromptTime ?? "-"}\n`);
   if (payload.status === "dead") {

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,7 @@ import {
   type WaitForTerminalExitResponse,
   type WriteTextFileRequest,
   type WriteTextFileResponse,
+  type SessionModelState,
 } from "@agentclientprotocol/sdk";
 import { extractAcpError } from "./acp-error-shapes.js";
 import { isSessionUpdateNotification } from "./acp-jsonrpc.js";
@@ -82,10 +83,14 @@ type LoadSessionOptions = {
 export type SessionCreateResult = {
   sessionId: string;
   agentSessionId?: string;
+  models?: SessionModelState;
+  modelSetSucceeded?: boolean;
 };
 
 export type SessionLoadResult = {
   agentSessionId?: string;
+  models?: SessionModelState;
+  modelSetSucceeded?: boolean;
 };
 
 type AgentDisconnectReason = "process_exit" | "process_close" | "pipe_close" | "connection_close";
@@ -689,7 +694,7 @@ function formatSessionControlAcpSummary(acp: {
 }
 
 function maybeWrapSessionControlError(
-  method: "session/set_mode" | "session/set_config_option",
+  method: "session/set_mode" | "session/set_config_option" | "session/set_model",
   error: unknown,
   context?: string,
 ): unknown {
@@ -1133,9 +1138,18 @@ export class AcpClient {
     }
 
     this.loadedSessionId = result.sessionId;
+
+    const requestedModel = this.options.sessionOptions?.model;
+    const modelSetSucceeded =
+      requestedModel && result.models
+        ? await this.trySetModel(result.sessionId, requestedModel, result.models)
+        : undefined;
+
     return {
       sessionId: result.sessionId,
       agentSessionId: extractRuntimeSessionId(result._meta),
+      models: result.models ?? undefined,
+      modelSetSucceeded,
     };
   }
 
@@ -1175,8 +1189,17 @@ export class AcpClient {
     }
 
     this.loadedSessionId = sessionId;
+
+    const requestedModel = this.options.sessionOptions?.model;
+    const modelSetSucceeded =
+      requestedModel && response?.models
+        ? await this.trySetModel(sessionId, requestedModel, response.models)
+        : undefined;
+
     return {
       agentSessionId: extractRuntimeSessionId(response?._meta),
+      models: response?.models ?? undefined,
+      modelSetSucceeded,
     };
   }
 
@@ -1243,6 +1266,17 @@ export class AcpClient {
     value: string,
   ): Promise<SetSessionConfigOptionResponse> {
     const connection = this.getConnection();
+    // Route "model" through the dedicated session/set_model method.
+    // Droid supports session/set_model but NOT session/set_config_option.
+    if (configId === "model") {
+      try {
+        await connection.unstable_setSessionModel({ sessionId, modelId: value });
+        return { configOptions: [] };
+      } catch (error) {
+        throw maybeWrapSessionControlError("session/set_model", error, `for model="${value}"`);
+      }
+    }
+
     try {
       return await connection.setSessionConfigOption({
         sessionId,
@@ -1255,6 +1289,35 @@ export class AcpClient {
         error,
         `for "${configId}"="${value}"`,
       );
+    }
+  }
+
+  async trySetModel(
+    sessionId: string,
+    modelId: string,
+    models: SessionModelState,
+  ): Promise<boolean> {
+    try {
+      this.log(
+        `available models: ${models.availableModels.map((m) => m.modelId).join(", ")} (current: ${models.currentModelId})`,
+      );
+      if (modelId === models.currentModelId) {
+        this.log(`model already set to ${modelId}`);
+        return true;
+      }
+      const connection = this.getConnection();
+      await connection.unstable_setSessionModel({ sessionId, modelId });
+      this.log(`model set to ${modelId}`);
+      return true;
+    } catch (err) {
+      const acp = extractAcpError(err);
+      const msg = acp
+        ? formatSessionControlAcpSummary(acp)
+        : err instanceof Error
+          ? err.message
+          : String(err);
+      process.stderr.write(`[acpx] warning: failed to set model ${modelId}: ${msg}\n`);
+      return false;
     }
   }
 

--- a/src/session-conversation-model.ts
+++ b/src/session-conversation-model.ts
@@ -454,6 +454,8 @@ export function cloneSessionAcpxState(
   return {
     current_mode_id: state.current_mode_id,
     desired_mode_id: state.desired_mode_id,
+    current_model_id: state.current_model_id,
+    available_models: state.available_models ? [...state.available_models] : undefined,
     available_commands: state.available_commands ? [...state.available_commands] : undefined,
     config_options: state.config_options ? deepClone(state.config_options) : undefined,
   };

--- a/src/session-mode-preference.ts
+++ b/src/session-mode-preference.ts
@@ -28,3 +28,9 @@ export function setDesiredModeId(record: SessionRecord, modeId: string | undefin
 
   record.acpx = acpx;
 }
+
+export function setCurrentModelId(record: SessionRecord, modelId: string): void {
+  const acpx = ensureAcpxState(record.acpx);
+  acpx.current_model_id = modelId;
+  record.acpx = acpx;
+}

--- a/src/session-persistence/parse.ts
+++ b/src/session-persistence/parse.ts
@@ -283,6 +283,14 @@ function parseAcpxState(raw: unknown): SessionAcpxState | undefined {
     state.desired_mode_id = record.desired_mode_id;
   }
 
+  if (typeof record.current_model_id === "string") {
+    state.current_model_id = record.current_model_id;
+  }
+
+  if (isStringArray(record.available_models)) {
+    state.available_models = [...record.available_models];
+  }
+
   if (isStringArray(record.available_commands)) {
     state.available_commands = [...record.available_commands];
   }

--- a/src/session-runtime.ts
+++ b/src/session-runtime.ts
@@ -39,7 +39,7 @@ import {
   type QueueOwnerActiveSessionController,
 } from "./queue-owner-turn-controller.js";
 import { normalizeRuntimeSessionId } from "./runtime-session-id.js";
-import { setDesiredModeId } from "./session-mode-preference.js";
+import { setCurrentModelId, setDesiredModeId } from "./session-mode-preference.js";
 import { connectAndLoadSession } from "./session-runtime/connect-load.js";
 import { applyConversation, applyLifecycleSnapshotToRecord } from "./session-runtime/lifecycle.js";
 import {
@@ -807,6 +807,8 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
         });
         let sessionId: string;
         let agentSessionId: string | undefined;
+        let sessionModels: import("./client.js").SessionCreateResult["models"];
+        let modelSetSucceeded: boolean | undefined;
 
         if (options.resumeSessionId) {
           if (!client.supportsLoadSession()) {
@@ -822,6 +824,8 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
             );
             sessionId = options.resumeSessionId;
             agentSessionId = normalizeRuntimeSessionId(loadedSession.agentSessionId);
+            sessionModels = loadedSession.models;
+            modelSetSucceeded = loadedSession.modelSetSucceeded;
           } catch (error) {
             throw new Error(
               `Failed to resume ACP session ${options.resumeSessionId}: ${formatErrorMessage(error)}`,
@@ -837,8 +841,19 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
           );
           sessionId = createdSession.sessionId;
           agentSessionId = normalizeRuntimeSessionId(createdSession.agentSessionId);
+          sessionModels = createdSession.models;
+          modelSetSucceeded = createdSession.modelSetSucceeded;
         }
         const lifecycle = client.getAgentLifecycleSnapshot();
+
+        const acpx: SessionRecord["acpx"] = {};
+        if (sessionModels) {
+          acpx.current_model_id = sessionModels.currentModelId;
+          acpx.available_models = sessionModels.availableModels.map((m) => m.modelId);
+        }
+        if (options.sessionOptions?.model && sessionModels && modelSetSucceeded) {
+          acpx.current_model_id = options.sessionOptions.model;
+        }
 
         const now = isoNow();
         const record: SessionRecord = {
@@ -861,7 +876,7 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
           protocolVersion: client.initializeResult?.protocolVersion,
           agentCapabilities: client.initializeResult?.agentCapabilities,
           ...createSessionConversation(now),
-          acpx: {},
+          acpx,
         };
 
         await writeSessionRecord(record);
@@ -1197,6 +1212,9 @@ export async function setSessionConfigOption(
     const record = await resolveSessionRecord(options.sessionId);
     if (options.configId === "mode") {
       setDesiredModeId(record, options.value);
+      await writeSessionRecord(record);
+    } else if (options.configId === "model") {
+      setCurrentModelId(record, options.value);
       await writeSessionRecord(record);
     }
     return {

--- a/src/session-runtime/prompt-runner.ts
+++ b/src/session-runtime/prompt-runner.ts
@@ -1,6 +1,6 @@
 import { AcpClient } from "../client.js";
 import type { QueueOwnerActiveSessionController } from "../queue-owner-turn-controller.js";
-import { setDesiredModeId } from "../session-mode-preference.js";
+import { setCurrentModelId, setDesiredModeId } from "../session-mode-preference.js";
 import {
   absolutePath,
   isoNow,
@@ -205,6 +205,8 @@ export async function runSessionSetConfigOptionDirect(
       );
       if (options.configId === "mode") {
         setDesiredModeId(record, options.value);
+      } else if (options.configId === "model") {
+        setCurrentModelId(record, options.value);
       }
       return response;
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,6 +279,8 @@ export type SessionConversation = {
 export type SessionAcpxState = {
   current_mode_id?: string;
   desired_mode_id?: string;
+  current_model_id?: string;
+  available_models?: string[];
   available_commands?: string[];
   config_options?: SessionConfigOption[];
 };

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -169,6 +169,262 @@ test("integration: exec forwards model, allowed-tools, and max-turns in session/
   });
 });
 
+test("integration: exec --model calls session/set_model when agent advertises models", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const modelAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-models`;
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "--model",
+          "fast-model",
+          "exec",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const setModelRequest = payloads.find((payload) => payload.method === "session/set_model") as
+        | { params?: { modelId?: string } }
+        | undefined;
+      assert(setModelRequest, "expected session/set_model request in JSON-RPC output");
+      assert.equal(setModelRequest.params?.modelId, "fast-model");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: exec --model skips session/set_model when agent does not advertise models", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const result = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "--model", "sonnet", "exec", "echo hello"],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+
+      // _meta.claudeCode.options.model should still be sent
+      const createRequest = payloads.find((payload) => payload.method === "session/new") as
+        | { params?: { _meta?: Record<string, unknown> } }
+        | undefined;
+      assert(createRequest, "expected session/new request");
+      assert.deepEqual((createRequest.params?._meta as Record<string, unknown>)?.claudeCode, {
+        options: { model: "sonnet" },
+      });
+
+      // session/set_model should NOT be called
+      const setModelRequest = payloads.find((payload) => payload.method === "session/set_model");
+      assert.equal(setModelRequest, undefined, "session/set_model should not be called");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: exec --model warns on session/set_model failure but session continues", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const failModelAgentCommand = `${MOCK_AGENT_COMMAND} --set-session-model-fails`;
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          failModelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "quiet",
+          "--model",
+          "bad-model",
+          "exec",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      // Session should still succeed
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /hello/);
+      // Warning should appear in stderr
+      assert.match(result.stderr, /warning: failed to set model bad-model/);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: set model routes through session/set_model and succeeds", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const modelAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-models`;
+
+    try {
+      // Create session
+      const created = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      // Switch model mid-session via set command (uses session/set_model internally)
+      const setResult = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "set", "model", "gpt-5.4"],
+        homeDir,
+      );
+      assert.equal(setResult.code, 0, setResult.stderr);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: set model rejects with clear error on ACP invalid params", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const invalidModelAgentCommand = `${MOCK_AGENT_COMMAND} --set-session-model-invalid-params`;
+
+    try {
+      // Create session
+      const created = await runCli(
+        ["--agent", invalidModelAgentCommand, "--approve-all", "--cwd", cwd, "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      // Attempt model switch — should fail with enriched error
+      const setResult = await runCli(
+        [
+          "--agent",
+          invalidModelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "set",
+          "model",
+          "bad-model",
+        ],
+        homeDir,
+      );
+      assert.notEqual(setResult.code, 0, "expected non-zero exit");
+      assert.match(setResult.stderr, /rejected session\/set_model/i);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: status shows model after session creation with --model", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const modelAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-models`;
+
+    try {
+      // Create session with --model
+      const created = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--model",
+          "gpt-5.4",
+          "sessions",
+          "new",
+        ],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      // Check status JSON
+      const status = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "--format", "json", "status"],
+        homeDir,
+      );
+      assert.equal(status.code, 0, status.stderr);
+
+      const statusPayload = JSON.parse(status.stdout.trim()) as {
+        model?: string;
+        mode?: string;
+        availableModels?: string[];
+      };
+      assert.equal(statusPayload.model, "gpt-5.4");
+      assert(Array.isArray(statusPayload.availableModels), "expected availableModels array");
+
+      // Check status text
+      const statusText = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "status"],
+        homeDir,
+      );
+      assert.equal(statusText.code, 0, statusText.stderr);
+      assert.match(statusText.stdout, /model: gpt-5\.4/);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: status shows updated model after set model", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const modelAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-models`;
+
+    try {
+      // Create session with --model
+      const created = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--model",
+          "fast-model",
+          "sessions",
+          "new",
+        ],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      // Switch model
+      const setResult = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "set", "model", "gpt-5.4"],
+        homeDir,
+      );
+      assert.equal(setResult.code, 0, setResult.stderr);
+
+      // Check status JSON — should show updated model
+      const status = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "--format", "json", "status"],
+        homeDir,
+      );
+      assert.equal(status.code, 0, status.stderr);
+
+      const statusPayload = JSON.parse(status.stdout.trim()) as { model?: string };
+      assert.equal(statusPayload.model, "gpt-5.4");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: perf metrics capture writes ndjson records for CLI runs", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -19,8 +19,11 @@ import {
   type SessionId,
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
+  type SetSessionModelRequest,
+  type SetSessionModelResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
+  type SessionModelState,
 } from "@agentclientprotocol/sdk";
 
 type ParsedCommand = {
@@ -38,6 +41,9 @@ type MockAgentOptions = {
   setSessionModeFails: boolean;
   setSessionModeInvalidParams: boolean;
   setSessionConfigInvalidParams: boolean;
+  setSessionModelFails: boolean;
+  setSessionModelInvalidParams: boolean;
+  advertiseModels: boolean;
   replayLoadSessionUpdates: boolean;
   loadReplayText: string;
   ignoreSigterm: boolean;
@@ -47,6 +53,7 @@ type SessionState = {
   pendingPrompt?: AbortController;
   hasCompletedPrompt: boolean;
   modeId: string;
+  modelId: string;
   configValues: Record<string, string>;
 };
 
@@ -293,6 +300,9 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let setSessionModeFails = false;
   let setSessionModeInvalidParams = false;
   let setSessionConfigInvalidParams = false;
+  let setSessionModelFails = false;
+  let setSessionModelInvalidParams = false;
+  let advertiseModels = false;
   let replayLoadSessionUpdates = false;
   let loadReplayText = "replayed load session update";
   let ignoreSigterm = false;
@@ -330,6 +340,23 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
 
     if (token === "--set-session-config-invalid-params") {
       setSessionConfigInvalidParams = true;
+      continue;
+    }
+
+    if (token === "--set-session-model-fails") {
+      setSessionModelFails = true;
+      advertiseModels = true;
+      continue;
+    }
+
+    if (token === "--set-session-model-invalid-params") {
+      setSessionModelInvalidParams = true;
+      advertiseModels = true;
+      continue;
+    }
+
+    if (token === "--advertise-models") {
+      advertiseModels = true;
       continue;
     }
 
@@ -385,9 +412,22 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     setSessionModeFails,
     setSessionModeInvalidParams,
     setSessionConfigInvalidParams,
+    setSessionModelFails,
+    setSessionModelInvalidParams,
+    advertiseModels,
     replayLoadSessionUpdates,
     loadReplayText,
     ignoreSigterm,
+  };
+}
+
+const DEFAULT_MODEL_ID = "default-model";
+const AVAILABLE_MODELS = ["default-model", "fast-model", "smart-model"];
+
+function buildModelsState(currentModelId: string): SessionModelState {
+  return {
+    currentModelId,
+    availableModels: AVAILABLE_MODELS.map((id) => ({ modelId: id, name: id })),
   };
 }
 
@@ -395,6 +435,7 @@ function createSessionState(hasCompletedPrompt = false): SessionState {
   return {
     hasCompletedPrompt,
     modeId: "auto",
+    modelId: DEFAULT_MODEL_ID,
     configValues: {
       reasoning_effort: "medium",
     },
@@ -463,14 +504,17 @@ class MockAgent implements Agent {
     const sessionId = randomUUID();
     this.sessions.set(sessionId, createSessionState(false));
 
+    const response: NewSessionResponse = { sessionId };
+
     if (this.options.newSessionMeta) {
-      return {
-        sessionId,
-        _meta: { ...this.options.newSessionMeta },
-      };
+      response._meta = { ...this.options.newSessionMeta };
     }
 
-    return { sessionId };
+    if (this.options.advertiseModels) {
+      response.models = buildModelsState(DEFAULT_MODEL_ID);
+    }
+
+    return response;
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
@@ -503,13 +547,18 @@ class MockAgent implements Agent {
       await this.sendAssistantMessage(params.sessionId, this.options.loadReplayText);
     }
 
+    const response: LoadSessionResponse = {};
+
     if (this.options.loadSessionMeta) {
-      return {
-        _meta: { ...this.options.loadSessionMeta },
-      };
+      response._meta = { ...this.options.loadSessionMeta };
     }
 
-    return {};
+    if (this.options.advertiseModels) {
+      const session = this.sessions.get(params.sessionId);
+      response.models = buildModelsState(session?.modelId ?? DEFAULT_MODEL_ID);
+    }
+
+    return response;
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
@@ -570,6 +619,30 @@ class MockAgent implements Agent {
       throw new Error("setSessionMode failed");
     }
     session.modeId = params.modeId;
+    return {};
+  }
+
+  async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
+    const session = this.ensureSession(params.sessionId);
+    if (this.options.setSessionModelInvalidParams) {
+      const error = new Error("Invalid params") as Error & {
+        code: number;
+        data: {
+          method: string;
+          modelId: string;
+        };
+      };
+      error.code = -32602;
+      error.data = {
+        method: "session/set_model",
+        modelId: params.modelId,
+      };
+      throw error;
+    }
+    if (this.options.setSessionModelFails) {
+      throw new Error("setSessionModel failed");
+    }
+    session.modelId = params.modelId;
     return {};
   }
 


### PR DESCRIPTION
## Summary

- `--model <id>` at session creation calls `session/set_model` when agent advertises models
- `acpx <agent> set model <id>` mid-session routes through `session/set_model` instead of `session/set_config_option`
- Model state tracking, caching, and status enrichment
- Graceful degradation: agents without model support skip silently; ACP-coded rejections produce clear errors
- Model cache only updated on successful set

## Test plan

- [x] Integration tests: 8 model-related tests pass (spawn-time set, mid-session set, invalid params rejection, status enrichment)
- [x] Smoke tested against live Droid and Gemini CLI agents
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Pre-commit hooks pass (lint, format, build)

Closes #148
Partially addresses #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)