### PR TITLE
feat: add --terminal flag to control clientCapabilities.terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/claude: add `--system-prompt <text>` and `--append-system-prompt <text>` global flags that forward through ACP `_meta.systemPrompt` on `session/new`, letting callers replace or append to the Claude Code system prompt without dropping out of persistent acpx sessions. The value is persisted in `session_options.system_prompt` so ensure/reuse flows keep the override. Codex and other agents ignore the field. (#229) Thanks @Vercantez.
 - CLI/sessions: add `sessions prune` with `--dry-run`, age filters, and `--include-history` so closed session records and optional event streams can be cleaned up explicitly. (#227) Thanks @coder999999999.
+- CLI/ACP: add `--no-terminal` to disable advertised ACP terminal capability for new agent clients. (#155) Thanks @DMQ.
 - Runtime/embedding: add `startTurn(...)` turn handles so embedders can observe live runtime events separately from terminal completion, cancel a turn, or close only the event stream while preserving `runTurn(...)` compatibility. (#262) Thanks @enki.
 
 ### Breaking

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -112,6 +112,7 @@ All global options:
 | `--format <fmt>`                         | Output format                                  | `text` (default), `json`, `quiet`.                                                                                                                              |
 | `--suppress-reads`                       | Suppress read file contents                    | Replaces raw read payloads with `[read output suppressed]`.                                                                                                     |
 | `--json-strict`                          | Strict JSON mode                               | Requires `--format json`; suppresses non-JSON stderr output.                                                                                                    |
+| `--no-terminal`                          | Disable ACP terminal capability                | Advertises `clientCapabilities.terminal: false` during ACP initialize for new agent clients.                                                                    |
 | `--non-interactive-permissions <policy>` | Non-TTY prompt policy                          | `deny` (default) or `fail` when approval prompt cannot be shown.                                                                                                |
 | `--timeout <seconds>`                    | Max wait time for agent response               | Must be positive. Decimal seconds allowed.                                                                                                                      |
 | `--ttl <seconds>`                        | Queue owner idle TTL before shutdown           | Default `300`. `0` disables TTL.                                                                                                                                |
@@ -131,6 +132,7 @@ acpx --non-interactive-permissions fail codex 'fail fast when prompt cannot be s
 acpx --cwd ~/repos/api codex 'review auth middleware'
 acpx --format json codex exec 'summarize open TODO items'
 acpx --format json --json-strict codex exec 'machine-safe JSON output'
+acpx --no-terminal codex exec 'summarize without terminal capability'
 acpx --timeout 120 codex 'investigate flaky test failures'
 acpx --ttl 30 codex 'keep queue owner warm for quick follow-up'
 acpx --verbose codex 'debug adapter startup issues'

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -351,6 +351,7 @@ export class AcpClient {
   updateRuntimeOptions(options: {
     permissionMode?: PermissionMode;
     nonInteractivePermissions?: NonInteractivePermissionPolicy;
+    terminal?: boolean;
     suppressSdkConsoleErrors?: boolean;
     verbose?: boolean;
   }): void {
@@ -359,6 +360,9 @@ export class AcpClient {
     }
     if (options.nonInteractivePermissions !== undefined) {
       this.options.nonInteractivePermissions = options.nonInteractivePermissions;
+    }
+    if (options.terminal !== undefined) {
+      this.options.terminal = options.terminal;
     }
     if (options.permissionMode || options.nonInteractivePermissions !== undefined) {
       this.filesystem.updatePermissionPolicy(
@@ -524,7 +528,7 @@ export class AcpClient {
                 readTextFile: true,
                 writeTextFile: true,
               },
-              terminal: true,
+              terminal: this.options.terminal !== false,
             },
             clientInfo: {
               name: "acpx",

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -223,6 +223,7 @@ export async function handlePrompt(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     outputFormatter,
     errorEmissionPolicy: {
       queueErrorAlreadyEmitted: outputPolicy.queueErrorAlreadyEmitted,
@@ -306,6 +307,7 @@ export async function handleExec(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     outputFormatter,
     suppressSdkConsoleErrors: outputPolicy.suppressSdkConsoleErrors,
     timeoutMs: globalFlags.timeout,
@@ -463,6 +465,7 @@ export async function handleSetMode(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     timeoutMs: globalFlags.timeout,
     verbose: globalFlags.verbose,
   });
@@ -497,6 +500,7 @@ export async function handleSetModel(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     timeoutMs: globalFlags.timeout,
     verbose: globalFlags.verbose,
   });
@@ -538,6 +542,7 @@ export async function handleSetConfigOption(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     timeoutMs: globalFlags.timeout,
     verbose: globalFlags.verbose,
   });
@@ -630,6 +635,7 @@ export async function handleSessionsNew(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     timeoutMs: globalFlags.timeout,
     verbose: globalFlags.verbose,
     sessionOptions: {
@@ -671,6 +677,7 @@ export async function handleSessionsEnsure(
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     authCredentials: config.auth,
     authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
     timeoutMs: globalFlags.timeout,
     verbose: globalFlags.verbose,
     sessionOptions: {

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -36,6 +36,7 @@ export type GlobalFlags = PermissionFlags & {
   nonInteractivePermissions: NonInteractivePermissionPolicy;
   jsonStrict?: boolean;
   suppressReads?: boolean;
+  terminal?: boolean;
   timeout?: number;
   ttl: number;
   verbose?: boolean;
@@ -289,6 +290,7 @@ export function addGlobalFlags(command: Command): Command {
       "--json-strict",
       "Strict JSON mode: requires --format json and suppresses non-JSON stderr output",
     )
+    .option("--no-terminal", "Do not advertise ACP terminal capability")
     .option("--timeout <seconds>", "Maximum time to wait for agent response", parseTimeoutSeconds)
     .option(
       "--ttl <seconds>",
@@ -364,6 +366,7 @@ export function resolveGlobalFlags(command: Command, config: ResolvedAcpxConfig)
     nonInteractivePermissions: opts.nonInteractivePermissions ?? config.nonInteractivePermissions,
     jsonStrict,
     suppressReads: opts.suppressReads === true,
+    terminal: opts.terminal === false ? false : undefined,
     timeout: opts.timeout ?? config.timeoutMs,
     ttl: opts.ttl ?? config.ttlMs ?? DEFAULT_QUEUE_OWNER_TTL_MS,
     verbose,

--- a/src/cli/queue/owner-env.ts
+++ b/src/cli/queue/owner-env.ts
@@ -59,6 +59,10 @@ export function parseQueueOwnerPayload(raw: string): QueueOwnerRuntimeOptions {
     options.authPolicy = record.authPolicy;
   }
 
+  if (typeof record.terminal === "boolean") {
+    options.terminal = record.terminal;
+  }
+
   if (typeof record.suppressSdkConsoleErrors === "boolean") {
     options.suppressSdkConsoleErrors = record.suppressSdkConsoleErrors;
   }

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -44,6 +44,7 @@ export type RunOnceOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   outputFormatter: OutputFormatter;
   onAcpMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
   onSessionUpdate?: (notification: SessionNotification) => void;
@@ -64,6 +65,7 @@ export type SessionCreateOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   verbose?: boolean;
   sessionOptions?: SessionAgentOptions;
 } & TimedRunOptions;
@@ -77,6 +79,7 @@ export type SessionSendOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   outputFormatter: OutputFormatter;
   onAcpMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
   onSessionUpdate?: (notification: SessionNotification) => void;
@@ -102,6 +105,7 @@ export type SessionEnsureOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   verbose?: boolean;
   walkBoundary?: string;
   sessionOptions?: SessionAgentOptions;
@@ -124,6 +128,7 @@ export type SessionSetModeOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   verbose?: boolean;
 } & TimedRunOptions;
 
@@ -134,6 +139,7 @@ export type SessionSetModelOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   verbose?: boolean;
 } & TimedRunOptions;
 
@@ -145,6 +151,7 @@ export type SessionSetConfigOptionOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   verbose?: boolean;
 } & TimedRunOptions;
 

--- a/src/cli/session/prompt-runner.ts
+++ b/src/cli/session/prompt-runner.ts
@@ -28,6 +28,7 @@ export type RunSessionSetModeDirectOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   timeoutMs?: number;
   verbose?: boolean;
   onClientAvailable?: (controller: ActiveSessionController) => void;
@@ -42,6 +43,7 @@ export type RunSessionSetConfigOptionDirectOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   timeoutMs?: number;
   verbose?: boolean;
   onClientAvailable?: (controller: ActiveSessionController) => void;
@@ -55,6 +57,7 @@ export type RunSessionSetModelDirectOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   timeoutMs?: number;
   verbose?: boolean;
   onClientAvailable?: (controller: ActiveSessionController) => void;
@@ -72,6 +75,7 @@ export async function runSessionSetModeDirect(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
     onClientAvailable: (controller: FullConnectedSessionController) => {
@@ -102,6 +106,7 @@ export async function runSessionSetModelDirect(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
     onClientAvailable: (controller: FullConnectedSessionController) => {
@@ -133,6 +138,7 @@ export async function runSessionSetConfigOptionDirect(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
     onClientAvailable: (controller: FullConnectedSessionController) => {

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -15,6 +15,7 @@ export type QueueOwnerRuntimeOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   ttlMs?: number;
@@ -30,6 +31,7 @@ type SessionSendLike = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   ttlMs?: number;
@@ -129,6 +131,7 @@ export function queueOwnerRuntimeOptionsFromSend(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     ttlMs: options.ttlMs,

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -80,6 +80,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     sessionOptions: mergeSessionOptions(
@@ -102,6 +103,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
         nonInteractivePermissions: options.nonInteractivePermissions,
         authCredentials: options.authCredentials,
         authPolicy: options.authPolicy,
+        terminal: options.terminal,
         timeoutMs,
         verbose: options.verbose,
       });
@@ -114,6 +116,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
         nonInteractivePermissions: options.nonInteractivePermissions,
         authCredentials: options.authCredentials,
         authPolicy: options.authPolicy,
+        terminal: options.terminal,
         timeoutMs,
         verbose: options.verbose,
       });
@@ -127,6 +130,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
         nonInteractivePermissions: options.nonInteractivePermissions,
         authCredentials: options.authCredentials,
         authPolicy: options.authPolicy,
+        terminal: options.terminal,
         timeoutMs,
         verbose: options.verbose,
       });

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -64,6 +64,7 @@ type RunSessionPromptOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   outputFormatter: OutputFormatter;
   onAcpMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
   onSessionUpdate?: (notification: SessionNotification) => void;
@@ -434,6 +435,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       nonInteractivePermissions: options.nonInteractivePermissions,
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
+      terminal: options.terminal,
       suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
       verbose: options.verbose,
       sessionOptions,
@@ -441,6 +443,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
   client.updateRuntimeOptions({
     permissionMode: options.permissionMode,
     nonInteractivePermissions: options.nonInteractivePermissions,
+    terminal: options.terminal,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
   });
@@ -728,6 +731,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     onAcpMessage: options.onAcpMessage,
@@ -828,6 +832,7 @@ export async function sendSessionDirect(options: SessionSendOptions): Promise<Se
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     outputFormatter: options.outputFormatter,
     onAcpMessage: options.onAcpMessage,
     onSessionUpdate: options.onSessionUpdate,

--- a/src/cli/session/session-control.ts
+++ b/src/cli/session/session-control.ts
@@ -70,6 +70,7 @@ export async function setSessionMode(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
   });
@@ -102,6 +103,7 @@ export async function setSessionModel(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
   });
@@ -138,6 +140,7 @@ export async function setSessionConfigOption(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
   });

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -194,6 +194,7 @@ export async function createSessionWithClient(
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     verbose: options.verbose,
     sessionOptions: options.sessionOptions,
   });
@@ -245,6 +246,7 @@ export async function ensureSession(options: SessionEnsureOptions): Promise<Sess
         nonInteractivePermissions: options.nonInteractivePermissions,
         authCredentials: options.authCredentials,
         authPolicy: options.authPolicy,
+        terminal: options.terminal,
         timeoutMs: options.timeoutMs,
         verbose: options.verbose,
       });
@@ -266,6 +268,7 @@ export async function ensureSession(options: SessionEnsureOptions): Promise<Sess
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
+    terminal: options.terminal,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
     sessionOptions: options.sessionOptions,

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -41,6 +41,7 @@ export type WithConnectedSessionOptions<T> = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   resumePolicy?: SessionResumePolicy;
   timeoutMs?: number;
   verbose?: boolean;
@@ -91,6 +92,7 @@ export async function withConnectedSession<T>(
       nonInteractivePermissions: options.nonInteractivePermissions,
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
+      terminal: options.terminal,
       verbose: options.verbose,
       sessionOptions: sessionOptionsFromRecord(record),
     }) ??
@@ -102,6 +104,7 @@ export async function withConnectedSession<T>(
       nonInteractivePermissions: options.nonInteractivePermissions,
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
+      terminal: options.terminal,
       verbose: options.verbose,
       sessionOptions: sessionOptionsFromRecord(record),
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,7 @@ export type AcpClientOptions = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
   authPolicy?: AuthPolicy;
+  terminal?: boolean;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   sessionOptions?: {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -216,6 +216,7 @@ test("global passthrough flags are present in help output", async () => {
     assert.match(result.stdout, /--max-turns <count>/);
     assert.match(result.stdout, /text, json, quiet/);
     assert.match(result.stdout, /--suppress-reads/);
+    assert.match(result.stdout, /--no-terminal/);
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -911,6 +911,29 @@ test("integration: exec forwards model, allowed-tools, and max-turns in session/
   });
 });
 
+test("integration: exec --no-terminal disables advertised terminal capability", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const result = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "--no-terminal", "exec", "echo hello"],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const initializeRequest = payloads.find((payload) => payload.method === "initialize") as
+        | { params?: { clientCapabilities?: { terminal?: unknown } } }
+        | undefined;
+      assert(initializeRequest, result.stdout);
+      assert.equal(initializeRequest.params?.clientCapabilities?.terminal, false);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec --model calls session/set_model when agent advertises models", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/queue-owner-env.test.ts
+++ b/test/queue-owner-env.test.ts
@@ -23,6 +23,7 @@ describe("parseQueueOwnerPayload", () => {
         ],
         ttlMs: 1234,
         maxQueueDepth: 7,
+        terminal: false,
         sessionOptions: {
           model: "fast-model",
           allowedTools: ["Read"],
@@ -35,6 +36,7 @@ describe("parseQueueOwnerPayload", () => {
     assert.equal(parsed.permissionMode, "approve-reads");
     assert.equal(parsed.ttlMs, 1234);
     assert.equal(parsed.maxQueueDepth, 7);
+    assert.equal(parsed.terminal, false);
     assert.deepEqual(parsed.mcpServers, [
       {
         name: "linear-http",

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import {
   buildQueueOwnerArgOverride,
+  queueOwnerRuntimeOptionsFromSend,
   resolveQueueOwnerSpawnArgs,
   sanitizeQueueOwnerExecArgv,
 } from "../src/cli/session/queue-owner-process.js";
@@ -109,5 +110,17 @@ describe("buildQueueOwnerArgOverride", () => {
       buildQueueOwnerArgOverride("/tmp/cli.js", ["--import", "tsx"]),
       JSON.stringify(["--import", "tsx", "/tmp/cli.js", "__queue-owner"]),
     );
+  });
+});
+
+describe("queueOwnerRuntimeOptionsFromSend", () => {
+  it("preserves terminal capability preference", () => {
+    const options = queueOwnerRuntimeOptionsFromSend({
+      sessionId: "session-1",
+      permissionMode: "approve-reads",
+      terminal: false,
+    });
+
+    assert.equal(options.terminal, false);
   });
 });


### PR DESCRIPTION
Add a new command-line flag --terminal (default: true) that allows users to control whether the terminal capability is enabled in clientCapabilities during ACP initialization.

Usage:
  acpx --terminal=false codex exec "list files"
  acpx --no-terminal codex exec "list files"

Changes:
- Add terminal option to AcpClientOptions in types.ts
- Add --terminal flag to CLI in cli/flags.ts
- Pass terminal option through all session runtime functions
- Use terminal option in ACP client initialization