### PR TITLE
chore: bump codex and claude ACP adapter ranges

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -1,7 +1,7 @@
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.22",
-  codex: "^0.9.5",
-  claude: "^0.22.0",
+  codex: "^0.10.0",
+  claude: "^0.23.1",
 } as const;
 
 export const AGENT_REGISTRY: Record<string, string> = {


### PR DESCRIPTION
## Problem

The built-in ACP adapter ranges for Codex and Claude were behind the latest npm releases.

As of March 28, 2026, npm reports:

- `@zed-industries/codex-acp`: `0.10.0`
- `@zed-industries/claude-agent-acp`: `0.23.1`

## Fix

Update the built-in adapter package ranges in `src/agent-registry.ts`:

- `codex`: `^0.9.5` -> `^0.10.0`
- `claude`: `^0.21.0` -> `^0.23.1`

## Verification

- `npm view @zed-industries/codex-acp dist-tags --json`
- `npm view @zed-industries/claude-agent-acp dist-tags --json`
- `pnpm run build`
- `pnpm exec tsx --test test/agent-registry.test.ts`
- `pnpm exec tsx --test test/version.test.ts`

## Notes

`pnpm run build:test` is currently failing on this branch due to an existing ACP SDK typing mismatch unrelated to this adapter-range change:

- `src/client.ts`: missing `KillTerminalRequest` / `KillTerminalResponse` exports from `@agentclientprotocol/sdk`
- `src/terminal.ts`: missing `KillTerminalRequest` / `KillTerminalResponse` exports from `@agentclientprotocol/sdk`