### PR TITLE
feat: add built-in Trae agent command mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Built-ins:
 | `kiro`     | native (`kiro-cli acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
 | `opencode` | `npx -y opencode-ai acp`                                               | [OpenCode](https://opencode.ai)                                                                                 |
 | `qwen`     | native (`qwen --acp`)                                                  | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
+| `trae`     | native (`trae-cli acp serve`)                                          | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
 
 `factory-droid` and `factorydroid` also resolve to the built-in `droid` adapter.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -16,6 +16,7 @@ Built-in agents:
 - `kiro -> kiro-cli acp`
 - `opencode -> npx -y opencode-ai acp`
 - `qwen -> qwen --acp`
+- `trae -> trae-cli acp serve`
 
 Harness-specific docs in this directory:
 
@@ -30,3 +31,4 @@ Harness-specific docs in this directory:
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli acp`
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`
+- [Trae](Trae.md): built-in `trae -> trae-cli acp serve`

--- a/agents/Trae.md
+++ b/agents/Trae.md
@@ -1,0 +1,5 @@
+# Trae
+
+- Built-in name: `trae`
+- Default command: `trae-cli acp serve`
+- Upstream: https://docs.trae.cn/cli

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -19,6 +19,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   kiro: "kiro-cli acp",
   opencode: "npx -y opencode-ai acp",
   qwen: "qwen --acp",
+  trae: "trae-cli acp serve",
 };
 
 const AGENT_ALIASES: Record<string, string> = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -52,6 +52,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
     "kiro",
     "opencode",
     "qwen",
+    "trae",
   ]);
 });
 


### PR DESCRIPTION
## Summary
- add built-in `trae` agent mapping to `trae-cli acp serve`
- document Trae in built-in agent docs (`README.md`, `agents/README.md`)
- add dedicated `agents/Trae.md`
- update registry test expectations to include `trae`

## Why
Today users must manually add Trae in config:

```json
{
  "agents": {
    "trae": { "command": "trae-cli acp serve" }
  }
}
```

Making Trae built-in aligns with other ACP-capable CLIs and reduces setup friction for OpenClaw/acpx orchestrations.

## Validation
- `pnpm -s run build:test && node --test dist-test/test/agent-registry.test.js`
- verified `trae-cli acp serve` command availability locally (`trae-cli acp --help`)

## Team verification plan
- Runtime team: run acpx prompt/exec/session flows with `trae`
- Docs team: verify built-in list and Trae page consistency
- Integration team: validate OpenClaw `sessions_spawn(runtime="acp", agentId="trae")` end-to-end
