### PR TITLE
feat: add built-in trae agent backed by trae-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Built-ins:
 | `kiro`     | native (`kiro-cli acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
 | `opencode` | `npx -y opencode-ai acp`                                               | [OpenCode](https://opencode.ai)                                                                                 |
 | `qwen`     | native (`qwen --acp`)                                                  | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
-| `trae`     | native (`trae-cli acp serve`)                                          | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
+| `trae`     | native (`traecli acp serve`)                                           | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
 
 `factory-droid` and `factorydroid` also resolve to the built-in `droid` adapter.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -16,7 +16,7 @@ Built-in agents:
 - `kiro -> kiro-cli acp`
 - `opencode -> npx -y opencode-ai acp`
 - `qwen -> qwen --acp`
-- `trae -> trae-cli acp serve`
+- `trae -> traecli acp serve`
 
 Harness-specific docs in this directory:
 
@@ -31,4 +31,4 @@ Harness-specific docs in this directory:
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli acp`
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`
-- [Trae](Trae.md): built-in `trae -> trae-cli acp serve`
+- [Trae](Trae.md): built-in `trae -> traecli acp serve`

--- a/agents/Trae.md
+++ b/agents/Trae.md
@@ -1,5 +1,5 @@
 # Trae
 
 - Built-in name: `trae`
-- Default command: `trae-cli acp serve`
+- Default command: `traecli acp serve`
 - Upstream: https://docs.trae.cn/cli

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -85,7 +85,7 @@ Friendly agent names resolve to commands:
 - `kiro` -> `kiro-cli acp`
 - `opencode` -> `npx -y opencode-ai acp`
 - `qwen` -> `qwen --acp`
-- `trae` -> `trae-cli acp serve`
+- `trae` -> `traecli acp serve`
 
 Rules:
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -19,7 +19,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   kiro: "kiro-cli acp",
   opencode: "npx -y opencode-ai acp",
   qwen: "qwen --acp",
-  trae: "trae-cli acp serve",
+  trae: "traecli acp serve",
 };
 
 const AGENT_ALIASES: Record<string, string> = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -32,6 +32,11 @@ test("resolveAgentCommand prefers explicit alias overrides over built-in alias m
   );
 });
 
+test("trae built-in uses the standard traecli executable", () => {
+  assert.equal(AGENT_REGISTRY.trae, "traecli acp serve");
+  assert.equal(resolveAgentCommand("trae"), "traecli acp serve");
+});
+
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {
   const agents = listBuiltInAgents();
   assert.deepEqual(agents, Object.keys(AGENT_REGISTRY));


### PR DESCRIPTION
## Summary

- add built-in agent id `trae` with command `trae-cli acp serve`
- document Trae CLI in built-in agent docs (`README.md`, `agents/README.md`)
- add `agents/Trae.md`
- update registry tests to include `trae`

## Why

Today users must manually configure Trae CLI in `~/.acpx/config.json`.
Making it built-in reduces setup friction and aligns with existing built-in agent UX.

## Changes

- `src/agent-registry.ts`
  - add: `trae: "trae-cli acp serve"`
- `README.md`
  - built-in agents table adds Trae row
- `agents/README.md`
  - built-in list and docs index include Trae
- `agents/Trae.md`
  - new agent doc page
- `test/agent-registry.test.ts`
  - expected built-in list includes `trae`

## Validation

- `pnpm -s run build:test && node --test dist-test/test/agent-registry.test.js`
- local runtime checks:
  - `acpx --cwd /tmp --approve-all trae exec "Reply exactly: TRAE_ACPX_EXEC_TMP_OK"`
  - session flow (`sessions new` / prompt / `sessions history`)
  - file write tool path test (`TRAE_FILE_OK`)
  - no-custom-config check:
    - remove `agents.trae` from `~/.acpx/config.json`
    - run local packed build: `npx --yes ./acpx-0.3.1.tgz --cwd /tmp --approve-all trae exec "Reply exactly: LOCAL_PUBLISH_TRAE_OK"`

## ~/.acpx/config.json migration note

For users on this PR (or after release), `agents.trae` becomes optional.

Before:

```json
{
  "agents": {
    "trae": { "command": "trae-cli acp serve" }
  }
}
```

After (optional cleanup):

```json
{
  "agents": {
    "claude": { "command": "..." }
  }
}
```

If users want custom behavior, keeping an override is still supported:

```json
{
  "agents": {
    "trae": { "command": "trae-cli acp serve" }
  }
}
```

## Notes

- built-in agent id remains `trae` for compatibility
- underlying executable is `trae-cli`
