### PR TITLE
fix: enable shell for terminal spawn on Windows

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcess, type ChildProcessByStdio } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import {
@@ -46,6 +45,7 @@ import { classifyPermissionDecision, resolvePermissionRequest } from "./permissi
 import { textPrompt } from "./prompt-content.js";
 import { extractRuntimeSessionId } from "./runtime-session-id.js";
 import { TimeoutError, withTimeout } from "./session-runtime-helpers.js";
+import { buildSpawnCommandOptions } from "./spawn-command-options.js";
 import { TerminalManager } from "./terminal.js";
 import type {
   AcpClientOptions,
@@ -54,6 +54,8 @@ import type {
   PermissionStats,
   PromptInput,
 } from "./types.js";
+
+export { buildSpawnCommandOptions };
 
 type CommandParts = {
   command: string;
@@ -299,79 +301,6 @@ function isClaudeAcpCommand(command: string, args: readonly string[]): boolean {
 
 function isCopilotAcpCommand(command: string, args: readonly string[]): boolean {
   return basenameToken(command) === "copilot" && args.includes("--acp");
-}
-
-function readWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
-  const matchedKey = Object.keys(env).find((entry) => entry.toUpperCase() === key);
-  return matchedKey ? env[matchedKey] : undefined;
-}
-
-function resolveWindowsCommand(
-  command: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  const extensions = (readWindowsEnvValue(env, "PATHEXT") ?? ".COM;.EXE;.BAT;.CMD")
-    .split(";")
-    .map((value) => value.trim().toLowerCase())
-    .filter((value) => value.length > 0);
-  const commandExtension = path.extname(command);
-  const candidates =
-    commandExtension.length > 0
-      ? [command]
-      : extensions.map((extension) => `${command}${extension}`);
-  const hasPath = command.includes("/") || command.includes("\\") || path.isAbsolute(command);
-
-  if (hasPath) {
-    return candidates.find((candidate) => fs.existsSync(candidate));
-  }
-
-  const pathValue = readWindowsEnvValue(env, "PATH");
-  if (!pathValue) {
-    return undefined;
-  }
-
-  for (const directory of pathValue.split(";")) {
-    const trimmedDirectory = directory.trim();
-    if (trimmedDirectory.length === 0) {
-      continue;
-    }
-    for (const candidate of candidates) {
-      const resolved = path.join(trimmedDirectory, candidate);
-      if (fs.existsSync(resolved)) {
-        return resolved;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function shouldUseWindowsBatchShell(
-  command: string,
-  platform: NodeJS.Platform = process.platform,
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  if (platform !== "win32") {
-    return false;
-  }
-  const resolvedCommand = resolveWindowsCommand(command, env) ?? command;
-  const ext = path.extname(resolvedCommand).toLowerCase();
-  return ext === ".cmd" || ext === ".bat";
-}
-
-export function buildSpawnCommandOptions(
-  command: string,
-  options: Parameters<typeof spawn>[2],
-  platform: NodeJS.Platform = process.platform,
-  env: NodeJS.ProcessEnv = process.env,
-): Parameters<typeof spawn>[2] {
-  if (!shouldUseWindowsBatchShell(command, platform, env)) {
-    return options;
-  }
-  return {
-    ...options,
-    shell: true,
-  };
 }
 
 function resolveGeminiAcpStartupTimeoutMs(): number {

--- a/src/spawn-command-options.ts
+++ b/src/spawn-command-options.ts
@@ -1,0 +1,76 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+function readWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const matchedKey = Object.keys(env).find((entry) => entry.toUpperCase() === key);
+  return matchedKey ? env[matchedKey] : undefined;
+}
+
+function resolveWindowsCommand(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const extensions = (readWindowsEnvValue(env, "PATHEXT") ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0);
+  const commandExtension = path.extname(command);
+  const candidates =
+    commandExtension.length > 0
+      ? [command]
+      : extensions.map((extension) => `${command}${extension}`);
+  const hasPath = command.includes("/") || command.includes("\\") || path.isAbsolute(command);
+
+  if (hasPath) {
+    return candidates.find((candidate) => fs.existsSync(candidate));
+  }
+
+  const pathValue = readWindowsEnvValue(env, "PATH");
+  if (!pathValue) {
+    return undefined;
+  }
+
+  for (const directory of pathValue.split(";")) {
+    const trimmedDirectory = directory.trim();
+    if (trimmedDirectory.length === 0) {
+      continue;
+    }
+    for (const candidate of candidates) {
+      const resolved = path.join(trimmedDirectory, candidate);
+      if (fs.existsSync(resolved)) {
+        return resolved;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function shouldUseWindowsBatchShell(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (platform !== "win32") {
+    return false;
+  }
+  const resolvedCommand = resolveWindowsCommand(command, env) ?? command;
+  const ext = path.extname(resolvedCommand).toLowerCase();
+  return ext === ".cmd" || ext === ".bat";
+}
+
+export function buildSpawnCommandOptions(
+  command: string,
+  options: Parameters<typeof spawn>[2],
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Parameters<typeof spawn>[2] {
+  if (!shouldUseWindowsBatchShell(command, platform, env)) {
+    return options;
+  }
+  return {
+    ...options,
+    shell: true,
+  };
+}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,6 +15,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import { PermissionDeniedError, PermissionPromptUnavailableError } from "./errors.js";
 import { promptForPermission } from "./permission-prompt.js";
+import { buildSpawnCommandOptions } from "./spawn-command-options.js";
 import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } from "./types.js";
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
@@ -40,6 +41,14 @@ export type TerminalManagerOptions = {
   killGraceMs?: number;
 };
 
+type TerminalSpawnOptions = {
+  cwd: string;
+  env: NodeJS.ProcessEnv | undefined;
+  stdio: ["ignore", "pipe", "pipe"];
+  shell?: true;
+  windowsHide: true;
+};
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -62,22 +71,24 @@ function toEnvObject(env: CreateTerminalRequest["env"]): NodeJS.ProcessEnv | und
 }
 
 export function buildTerminalSpawnOptions(
+  command: string,
   cwd: string,
   env: CreateTerminalRequest["env"],
-): {
-  cwd: string;
-  env: NodeJS.ProcessEnv | undefined;
-  stdio: ["ignore", "pipe", "pipe"];
-  shell: boolean;
-  windowsHide: true;
-} {
-  return {
+  platform: NodeJS.Platform = process.platform,
+): TerminalSpawnOptions {
+  const resolvedEnv = toEnvObject(env);
+  const options: TerminalSpawnOptions = {
     cwd,
-    env: toEnvObject(env),
+    env: resolvedEnv,
     stdio: ["ignore", "pipe", "pipe"],
-    shell: process.platform === "win32",
     windowsHide: true,
   };
+  return buildSpawnCommandOptions(
+    command,
+    options,
+    platform,
+    resolvedEnv ?? process.env,
+  ) as TerminalSpawnOptions;
 }
 
 function trimToUtf8Boundary(buffer: Buffer, limit: number): Buffer {
@@ -182,7 +193,7 @@ export class TerminalManager {
       const proc = spawn(
         params.command,
         params.args ?? [],
-        buildTerminalSpawnOptions(params.cwd ?? this.cwd, params.env),
+        buildTerminalSpawnOptions(params.command, params.cwd ?? this.cwd, params.env),
       );
       await waitForSpawn(proc);
 

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -19,7 +19,7 @@ test("buildAgentSpawnOptions hides Windows console windows and preserves auth en
 });
 
 test("buildTerminalSpawnOptions hides Windows console windows and maps env entries", () => {
-  const options = buildTerminalSpawnOptions("/tmp/acpx-terminal", [
+  const options = buildTerminalSpawnOptions("node", "/tmp/acpx-terminal", [
     { name: "TMUX", value: "/tmp/tmux-1000/default,123,0" },
     { name: "TERM", value: "screen-256color" },
   ]);
@@ -102,9 +102,50 @@ test("buildSpawnCommandOptions keeps shell disabled for non-batch commands", asy
   }
 });
 
-test("buildTerminalSpawnOptions enables shell on Windows for PATH resolution", () => {
-  const options = buildTerminalSpawnOptions("/tmp/acpx-terminal", []);
+test("buildTerminalSpawnOptions enables shell for PATH-resolved .cmd wrappers on Windows", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-windows-spawn-"));
 
-  // shell should be set based on the current platform
-  assert.equal(typeof options.shell, "boolean");
+  try {
+    await fs.writeFile(path.join(tempDir, "npx.cmd"), "@echo off\r\n");
+
+    const options = buildTerminalSpawnOptions(
+      "npx",
+      "/tmp/acpx-terminal",
+      [
+        { name: "PATH", value: tempDir },
+        { name: "PATHEXT", value: ".COM;.EXE;.BAT;.CMD" },
+      ],
+      "win32",
+    );
+
+    assert.equal(options.shell, true);
+    assert.deepEqual(options.stdio, ["ignore", "pipe", "pipe"]);
+    assert.equal(options.windowsHide, true);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("buildTerminalSpawnOptions keeps shell disabled for non-batch commands", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-windows-spawn-"));
+
+  try {
+    await fs.writeFile(path.join(tempDir, "node.exe"), "");
+
+    const options = buildTerminalSpawnOptions(
+      "node",
+      "/tmp/acpx-terminal",
+      [
+        { name: "PATH", value: tempDir },
+        { name: "PATHEXT", value: ".COM;.EXE;.BAT;.CMD" },
+      ],
+      "win32",
+    );
+
+    assert.equal(options.shell, undefined);
+    assert.deepEqual(options.stdio, ["ignore", "pipe", "pipe"]);
+    assert.equal(options.windowsHide, true);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- Add `shell: process.platform === "win32"` to `buildTerminalSpawnOptions()` so terminal commands resolve from PATH on Windows
- On Windows, `child_process.spawn()` without `shell: true` doesn't use `cmd.exe` for PATH resolution, causing every terminal command to fail with `ENOENT`
- Linux/macOS handle this in the kernel during `execve()`, so `shell` is only enabled on Windows

## Test plan

- [x] Added test in `spawn-options.test.ts` verifying `shell` is always a boolean
- [x] All existing spawn-options tests pass
- [x] `oxlint`, `oxfmt`, and `tsc --noEmit` clean
- [x] Verified on Windows 11 — git, node, and other PATH commands now resolve correctly

Closes #169