### PR TITLE
fix: handle -32601/-32602 in session/load fallback

### DIFF
--- a/src/session-runtime/connect-load.ts
+++ b/src/session-runtime/connect-load.ts
@@ -36,12 +36,21 @@ export type ConnectAndLoadSessionResult = {
   loadError?: string;
 };
 
+// JSON-RPC codes that indicate the agent does not support session/load.
+// -32601 = Method not found, -32602 = Invalid params.
+const SESSION_LOAD_UNSUPPORTED_CODES = new Set([-32601, -32602]);
+
 function shouldFallbackToNewSession(error: unknown, record: SessionRecord): boolean {
   if (error instanceof TimeoutError || error instanceof InterruptedError) {
     return false;
   }
 
   if (isAcpResourceNotFoundError(error)) {
+    return true;
+  }
+
+  const acp = extractAcpError(error);
+  if (acp && SESSION_LOAD_UNSUPPORTED_CODES.has(acp.code)) {
     return true;
   }
 
@@ -52,7 +61,6 @@ function shouldFallbackToNewSession(error: unknown, record: SessionRecord): bool
       return true;
     }
 
-    const acp = extractAcpError(error);
     if (acp?.code === -32603) {
       return true;
     }

--- a/test/connect-load.test.ts
+++ b/test/connect-load.test.ts
@@ -215,6 +215,114 @@ test("connectAndLoadSession falls back to createSession for empty sessions on ad
   });
 });
 
+test("connectAndLoadSession falls back to session/new on -32602 Invalid params", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const record = makeSessionRecord({
+      acpxRecordId: "invalid-params-record",
+      acpSessionId: "invalid-params-session",
+      agentCommand: "agent",
+      cwd,
+      messages: [
+        {
+          Agent: {
+            content: [{ Text: "has history" }],
+            tool_results: {},
+          },
+        },
+      ],
+    });
+
+    const client: FakeClient = {
+      hasReusableSession: () => false,
+      start: async () => {},
+      getAgentLifecycleSnapshot: () => ({
+        running: true,
+      }),
+      supportsLoadSession: () => true,
+      loadSessionWithOptions: async () => {
+        throw {
+          error: {
+            code: -32602,
+            message: "Invalid params",
+          },
+        };
+      },
+      createSession: async () => ({
+        sessionId: "fallback-from-32602",
+        agentSessionId: "fallback-runtime",
+      }),
+      setSessionMode: async () => {},
+    };
+
+    const result = await connectAndLoadSession({
+      client: client as never,
+      record,
+      activeController: ACTIVE_CONTROLLER,
+    });
+
+    assert.equal(result.sessionId, "fallback-from-32602");
+    assert.equal(result.resumed, false);
+    assert.equal(record.acpSessionId, "fallback-from-32602");
+  });
+});
+
+test("connectAndLoadSession falls back to session/new on -32601 Method not found", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const record = makeSessionRecord({
+      acpxRecordId: "method-not-found-record",
+      acpSessionId: "method-not-found-session",
+      agentCommand: "agent",
+      cwd,
+      messages: [
+        {
+          Agent: {
+            content: [{ Text: "has history" }],
+            tool_results: {},
+          },
+        },
+      ],
+    });
+
+    const client: FakeClient = {
+      hasReusableSession: () => false,
+      start: async () => {},
+      getAgentLifecycleSnapshot: () => ({
+        running: true,
+      }),
+      supportsLoadSession: () => true,
+      loadSessionWithOptions: async () => {
+        throw {
+          error: {
+            code: -32601,
+            message: "Method not found",
+          },
+        };
+      },
+      createSession: async () => ({
+        sessionId: "fallback-from-32601",
+        agentSessionId: "fallback-runtime",
+      }),
+      setSessionMode: async () => {},
+    };
+
+    const result = await connectAndLoadSession({
+      client: client as never,
+      record,
+      activeController: ACTIVE_CONTROLLER,
+    });
+
+    assert.equal(result.sessionId, "fallback-from-32601");
+    assert.equal(result.resumed, false);
+    assert.equal(record.acpSessionId, "fallback-from-32601");
+  });
+});
+
 test("connectAndLoadSession rethrows load failures that should not create a new session", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");


### PR DESCRIPTION
## Summary

- `shouldFallbackToNewSession()` now handles JSON-RPC `-32601` (Method not found) and `-32602` (Invalid params) unconditionally, falling back to `session/new` instead of crashing
- These codes indicate the agent doesn't properly support `session/load` (e.g., cursor-agent returns `-32602`), so fallback should happen regardless of whether the session has prior agent messages
- The `extractAcpError()` call is hoisted above the `sessionHasAgentMessages` guard to cache the result and avoid redundant extraction

## Test plan

- [x] Added test: `-32602` with agent messages triggers fallback (was crashing before)
- [x] Added test: `-32601` with agent messages triggers fallback
- [x] All 8 connect-load tests pass
- [x] Existing `-32603` behavior unchanged (still gated behind `sessionHasAgentMessages`)
- [x] `tsc --noEmit`, `oxlint`, `oxfmt` clean

Closes #152