### PR TITLE
Add built-in Qoder ACP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Repo: https://github.com/openclaw/acpx
 - Flows/replay: store flow runs as trace bundles with `manifest.json`, `flow.json`, `trace.ndjson`, projections, bundled session replay data, and per-attempt ACP/action receipts for later inspection. Thanks @osolmaz.
 - Flows/replay viewer: add a React Flow-based replay viewer example that replays saved run bundles and shows the bundled ACP session beside the graph. Thanks @osolmaz.
 - Flows/permissions: let flows declare explicit required permission modes, fail fast when a flow requires an explicit `--approve-all` grant, and preserve the granted mode through persistent ACP queue-owner paths. Thanks @osolmaz.
+- Agents/qoder: add built-in Qoder CLI ACP support via `qoder -> qodercli --acp` and document Qoder-specific auth notes.
+- Agents/qoder: forward `--allowed-tools` and `--max-turns` session options into Qoder CLI startup flags, including persisted session reuse, without requiring a raw `--agent` override.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Built-ins:
 | `kimi`     | native (`kimi acp`)                                                    | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`     | native (`kiro-cli acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
 | `opencode` | `npx -y opencode-ai acp`                                               | [OpenCode](https://opencode.ai)                                                                                 |
+| `qoder`    | native (`qodercli --acp`)                                              | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`     | native (`qwen --acp`)                                                  | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
 | `trae`     | native (`traecli acp serve`)                                           | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
 

--- a/agents/Qoder.md
+++ b/agents/Qoder.md
@@ -1,0 +1,9 @@
+# Qoder
+
+- Built-in name: `qoder`
+- Default command: `qodercli --acp`
+- Upstream: https://docs.qoder.com/cli/acp
+
+`acpx qoder` uses the same login state as Qoder CLI. For non-interactive runs, Qoder documents `QODER_PERSONAL_ACCESS_TOKEN` as the supported environment variable for authentication.
+
+`acpx qoder` also forwards `--max-turns` and `--allowed-tools` into Qoder CLI startup flags when those session options are set. This makes those Qoder-native startup settings available without using a raw `--agent` override.

--- a/agents/README.md
+++ b/agents/README.md
@@ -15,6 +15,7 @@ Built-in agents:
 - `kimi -> kimi acp`
 - `kiro -> kiro-cli acp`
 - `opencode -> npx -y opencode-ai acp`
+- `qoder -> qodercli --acp`
 - `qwen -> qwen --acp`
 - `trae -> traecli acp serve`
 
@@ -30,5 +31,6 @@ Harness-specific docs in this directory:
 - [Kimi](Kimi.md): built-in `kimi -> kimi acp`
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli acp`
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
+- [Qoder](Qoder.md): built-in `qoder -> qodercli --acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`
 - [Trae](Trae.md): built-in `trae -> traecli acp serve`

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -84,6 +84,8 @@ Friendly agent names resolve to commands:
 - `kimi` -> `kimi acp`
 - `kiro` -> `kiro-cli acp`
 - `opencode` -> `npx -y opencode-ai acp`
+- `qoder` -> `qodercli --acp`
+  Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.
 - `qwen` -> `qwen --acp`
 - `trae` -> `traecli acp serve`
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -18,6 +18,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   kimi: "kimi acp",
   kiro: "kiro-cli acp",
   opencode: "npx -y opencode-ai acp",
+  qoder: "qodercli --acp",
   qwen: "qwen --acp",
   trae: "traecli acp serve",
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,6 @@ import { Readable, Writable } from "node:stream";
 import {
   ClientSideConnection,
   PROTOCOL_VERSION,
-  ndJsonStream,
   type AnyMessage,
   type AuthMethod,
   type CreateTerminalRequest,
@@ -65,7 +64,8 @@ type CommandParts = {
 const REPLAY_IDLE_MS = 80;
 const REPLAY_DRAIN_TIMEOUT_MS = 5_000;
 const DRAIN_POLL_INTERVAL_MS = 20;
-const AGENT_CLOSE_AFTER_STDIN_END_MS = 100;
+const DEFAULT_AGENT_CLOSE_AFTER_STDIN_END_MS = 100;
+const QODER_AGENT_CLOSE_AFTER_STDIN_END_MS = 750;
 const AGENT_CLOSE_TERM_GRACE_MS = 1_500;
 const AGENT_CLOSE_KILL_GRACE_MS = 1_000;
 const GEMINI_ACP_STARTUP_TIMEOUT_MS = 15_000;
@@ -119,6 +119,10 @@ export type AgentLifecycleSnapshot = {
 };
 
 type ConsoleErrorMethod = typeof console.error;
+const QODER_BENIGN_STDOUT_LINES = new Set([
+  "Received interrupt signal. Cleaning up resources...",
+  "Cleanup completed. Exiting...",
+]);
 
 function shouldSuppressSdkConsoleError(args: unknown[]): boolean {
   if (args.length === 0) {
@@ -284,6 +288,83 @@ function basenameToken(value: string): string {
     .replace(/\.(cmd|exe|bat)$/u, "");
 }
 
+export function resolveAgentCloseAfterStdinEndMs(agentCommand: string): number {
+  const { command } = splitCommandLine(agentCommand);
+  return basenameToken(command) === "qodercli"
+    ? QODER_AGENT_CLOSE_AFTER_STDIN_END_MS
+    : DEFAULT_AGENT_CLOSE_AFTER_STDIN_END_MS;
+}
+
+export function shouldIgnoreNonJsonAgentOutputLine(
+  agentCommand: string,
+  trimmedLine: string,
+): boolean {
+  const { command } = splitCommandLine(agentCommand);
+  return basenameToken(command) === "qodercli" && QODER_BENIGN_STDOUT_LINES.has(trimmedLine);
+}
+
+function createNdJsonMessageStream(
+  agentCommand: string,
+  output: WritableStream<Uint8Array>,
+  input: ReadableStream<Uint8Array>,
+): {
+  readable: ReadableStream<AnyMessage>;
+  writable: WritableStream<AnyMessage>;
+} {
+  const textEncoder = new TextEncoder();
+  const textDecoder = new TextDecoder();
+
+  const readable = new ReadableStream<AnyMessage>({
+    async start(controller) {
+      let content = "";
+      const reader = input.getReader();
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (!value) {
+            continue;
+          }
+          content += textDecoder.decode(value, { stream: true });
+          const lines = content.split("\n");
+          content = lines.pop() || "";
+          for (const line of lines) {
+            const trimmedLine = line.trim();
+            if (!trimmedLine || shouldIgnoreNonJsonAgentOutputLine(agentCommand, trimmedLine)) {
+              continue;
+            }
+            try {
+              const message = JSON.parse(trimmedLine) as AnyMessage;
+              controller.enqueue(message);
+            } catch (err) {
+              console.error("Failed to parse JSON message:", trimmedLine, err);
+            }
+          }
+        }
+      } finally {
+        reader.releaseLock();
+        controller.close();
+      }
+    },
+  });
+
+  const writable = new WritableStream<AnyMessage>({
+    async write(message) {
+      const content = JSON.stringify(message) + "\n";
+      const writer = output.getWriter();
+      try {
+        await writer.write(textEncoder.encode(content));
+      } finally {
+        writer.releaseLock();
+      }
+    },
+  });
+
+  return { readable, writable };
+}
+
 function isGeminiAcpCommand(command: string, args: readonly string[]): boolean {
   return (
     basenameToken(command) === "gemini" &&
@@ -303,6 +384,50 @@ function isCopilotAcpCommand(command: string, args: readonly string[]): boolean 
   return basenameToken(command) === "copilot" && args.includes("--acp");
 }
 
+function isQoderAcpCommand(command: string, args: readonly string[]): boolean {
+  return basenameToken(command) === "qodercli" && args.includes("--acp");
+}
+
+function hasCommandFlag(args: readonly string[], flagName: string): boolean {
+  return args.some((arg) => arg === flagName || arg.startsWith(`${flagName}=`));
+}
+
+function normalizeQoderAllowedToolName(tool: string): string {
+  switch (tool.trim().toLowerCase()) {
+    case "bash":
+    case "glob":
+    case "grep":
+    case "ls":
+    case "read":
+    case "write":
+      return tool.trim().toUpperCase();
+    default:
+      return tool.trim();
+  }
+}
+
+export function buildQoderAcpCommandArgs(
+  initialArgs: readonly string[],
+  options: Pick<AcpClientOptions, "sessionOptions">,
+): string[] {
+  const args = [...initialArgs];
+  const sessionOptions = options.sessionOptions;
+
+  if (typeof sessionOptions?.maxTurns === "number" && !hasCommandFlag(args, "--max-turns")) {
+    args.push(`--max-turns=${sessionOptions.maxTurns}`);
+  }
+
+  if (
+    Array.isArray(sessionOptions?.allowedTools) &&
+    !hasCommandFlag(args, "--allowed-tools") &&
+    !hasCommandFlag(args, "--disallowed-tools")
+  ) {
+    const encodedTools = sessionOptions.allowedTools.map(normalizeQoderAllowedToolName).join(",");
+    args.push(`--allowed-tools=${encodedTools}`);
+  }
+
+  return args;
+}
 function resolveGeminiAcpStartupTimeoutMs(): number {
   const raw = process.env.ACPX_GEMINI_ACP_STARTUP_TIMEOUT_MS;
   if (typeof raw === "string" && raw.trim().length > 0) {
@@ -857,7 +982,10 @@ export class AcpClient {
     }
 
     const { command, args: initialArgs } = splitCommandLine(this.options.agentCommand);
-    const args = await resolveGeminiCommandArgs(command, initialArgs);
+    let args = await resolveGeminiCommandArgs(command, initialArgs);
+    if (isQoderAcpCommand(command, args)) {
+      args = buildQoderAcpCommandArgs(args, this.options);
+    }
     this.log(`spawning agent: ${command} ${args.join(" ")}`);
     const geminiAcp = isGeminiAcpCommand(command, args);
     const copilotAcp = isCopilotAcpCommand(command, args);
@@ -896,7 +1024,9 @@ export class AcpClient {
 
     const input = Writable.toWeb(child.stdin);
     const output = Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>;
-    const stream = this.createTappedStream(ndJsonStream(input, output));
+    const stream = this.createTappedStream(
+      createNdJsonMessageStream(this.options.agentCommand, input, output),
+    );
 
     const connection = new ClientSideConnection(
       () => ({
@@ -1268,6 +1398,8 @@ export class AcpClient {
   private async terminateAgentProcess(
     child: ChildProcessByStdio<Writable, Readable, Readable>,
   ): Promise<void> {
+    const stdinCloseGraceMs = resolveAgentCloseAfterStdinEndMs(this.options.agentCommand);
+
     // Closing stdin is the most graceful shutdown signal for stdio-based ACP agents.
     if (!child.stdin.destroyed) {
       try {
@@ -1277,7 +1409,7 @@ export class AcpClient {
       }
     }
 
-    let exited = await waitForChildExit(child, AGENT_CLOSE_AFTER_STDIN_END_MS);
+    let exited = await waitForChildExit(child, stdinCloseGraceMs);
     if (!exited && isChildProcessRunning(child)) {
       try {
         child.kill("SIGTERM");

--- a/src/session-conversation-model.ts
+++ b/src/session-conversation-model.ts
@@ -456,6 +456,15 @@ export function cloneSessionAcpxState(
     desired_mode_id: state.desired_mode_id,
     available_commands: state.available_commands ? [...state.available_commands] : undefined,
     config_options: state.config_options ? deepClone(state.config_options) : undefined,
+    session_options: state.session_options
+      ? {
+          model: state.session_options.model,
+          allowed_tools: state.session_options.allowed_tools
+            ? [...state.session_options.allowed_tools]
+            : undefined,
+          max_turns: state.session_options.max_turns,
+        }
+      : undefined,
   };
 }
 

--- a/src/session-persistence/parse.ts
+++ b/src/session-persistence/parse.ts
@@ -291,6 +291,31 @@ function parseAcpxState(raw: unknown): SessionAcpxState | undefined {
     state.config_options = record.config_options as SessionAcpxState["config_options"];
   }
 
+  const sessionOptions = asRecord(record.session_options);
+  if (sessionOptions) {
+    const parsedSessionOptions: NonNullable<SessionAcpxState["session_options"]> = {};
+
+    if (typeof sessionOptions.model === "string") {
+      parsedSessionOptions.model = sessionOptions.model;
+    }
+
+    if (isStringArray(sessionOptions.allowed_tools)) {
+      parsedSessionOptions.allowed_tools = [...sessionOptions.allowed_tools];
+    }
+
+    if (
+      typeof sessionOptions.max_turns === "number" &&
+      Number.isInteger(sessionOptions.max_turns) &&
+      sessionOptions.max_turns > 0
+    ) {
+      parsedSessionOptions.max_turns = sessionOptions.max_turns;
+    }
+
+    if (Object.keys(parsedSessionOptions).length > 0) {
+      state.session_options = parsedSessionOptions;
+    }
+  }
+
   return state;
 }
 

--- a/src/session-runtime.ts
+++ b/src/session-runtime.ts
@@ -106,6 +106,61 @@ export type SessionAgentOptions = {
   maxTurns?: number;
 };
 
+function sessionOptionsFromRecord(record: SessionRecord): SessionAgentOptions | undefined {
+  const stored = record.acpx?.session_options;
+  if (!stored) {
+    return undefined;
+  }
+
+  const sessionOptions: SessionAgentOptions = {};
+
+  if (typeof stored.model === "string" && stored.model.trim().length > 0) {
+    sessionOptions.model = stored.model;
+  }
+  if (Array.isArray(stored.allowed_tools)) {
+    sessionOptions.allowedTools = [...stored.allowed_tools];
+  }
+  if (typeof stored.max_turns === "number") {
+    sessionOptions.maxTurns = stored.max_turns;
+  }
+
+  return Object.keys(sessionOptions).length > 0 ? sessionOptions : undefined;
+}
+
+function persistSessionOptions(
+  record: SessionRecord,
+  options: SessionAgentOptions | undefined,
+): void {
+  const next =
+    options &&
+    ({
+      model: typeof options.model === "string" ? options.model : undefined,
+      allowed_tools: Array.isArray(options.allowedTools) ? [...options.allowedTools] : undefined,
+      max_turns: typeof options.maxTurns === "number" ? options.maxTurns : undefined,
+    } satisfies NonNullable<NonNullable<SessionRecord["acpx"]>["session_options"]>);
+
+  const hasValues = Boolean(
+    next &&
+    ((typeof next.model === "string" && next.model.trim().length > 0) ||
+      (Array.isArray(next.allowed_tools) && next.allowed_tools.length > 0) ||
+      typeof next.max_turns === "number"),
+  );
+
+  if (hasValues && next) {
+    record.acpx = {
+      ...record.acpx,
+      session_options: next,
+    };
+    return;
+  }
+
+  if (!record.acpx) {
+    return;
+  }
+
+  delete record.acpx.session_options;
+}
+
 export type RunOnceOptions = {
   agentCommand: string;
   cwd: string;
@@ -531,6 +586,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       authPolicy: options.authPolicy,
       suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
       verbose: options.verbose,
+      sessionOptions: sessionOptionsFromRecord(record),
     });
   client.updateRuntimeOptions({
     permissionMode: options.permissionMode,
@@ -882,6 +938,8 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
           acpx: {},
         };
 
+        persistSessionOptions(record, options.sessionOptions);
+
         await writeSessionRecord(record);
         return record;
       },
@@ -970,6 +1028,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     authPolicy: options.authPolicy,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
+    sessionOptions: sessionOptionsFromRecord(sessionRecord),
   });
   const ttlMs = normalizeQueueOwnerTtlMs(options.ttlMs);
   const maxQueueDepth = Math.max(1, Math.round(options.maxQueueDepth ?? 16));

--- a/src/session-runtime/prompt-runner.ts
+++ b/src/session-runtime/prompt-runner.ts
@@ -22,6 +22,37 @@ import { applyLifecycleSnapshotToRecord } from "./lifecycle.js";
 
 export type ActiveSessionController = QueueOwnerActiveSessionController;
 
+function sessionOptionsFromRecord(record: SessionRecord):
+  | {
+      model?: string;
+      allowedTools?: string[];
+      maxTurns?: number;
+    }
+  | undefined {
+  const stored = record.acpx?.session_options;
+  if (!stored) {
+    return undefined;
+  }
+
+  const sessionOptions: {
+    model?: string;
+    allowedTools?: string[];
+    maxTurns?: number;
+  } = {};
+
+  if (typeof stored.model === "string" && stored.model.trim().length > 0) {
+    sessionOptions.model = stored.model;
+  }
+  if (Array.isArray(stored.allowed_tools)) {
+    sessionOptions.allowedTools = [...stored.allowed_tools];
+  }
+  if (typeof stored.max_turns === "number") {
+    sessionOptions.maxTurns = stored.max_turns;
+  }
+
+  return Object.keys(sessionOptions).length > 0 ? sessionOptions : undefined;
+}
+
 type WithConnectedSessionOptions<T> = {
   sessionRecordId: string;
   mcpServers?: McpServer[];
@@ -56,6 +87,7 @@ async function withConnectedSession<T>(
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
     verbose: options.verbose,
+    sessionOptions: sessionOptionsFromRecord(record),
   });
   let activeSessionIdForControl = record.acpSessionId;
   let notifiedClientAvailable = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,6 +281,11 @@ export type SessionAcpxState = {
   desired_mode_id?: string;
   available_commands?: string[];
   config_options?: SessionConfigOption[];
+  session_options?: {
+    model?: string;
+    allowed_tools?: string[];
+    max_turns?: number;
+  };
 };
 
 export type SessionRecord = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -56,6 +56,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
     "kimi",
     "kiro",
     "opencode",
+    "qoder",
     "qwen",
     "trae",
   ]);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,7 +2,13 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import test from "node:test";
 import type { RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
-import { AcpClient, buildAgentSpawnOptions } from "../src/client.js";
+import {
+  AcpClient,
+  buildAgentSpawnOptions,
+  buildQoderAcpCommandArgs,
+  resolveAgentCloseAfterStdinEndMs,
+  shouldIgnoreNonJsonAgentOutputLine,
+} from "../src/client.js";
 import {
   AuthPolicyError,
   PermissionDeniedError,
@@ -130,6 +136,64 @@ test("buildAgentSpawnOptions normalizes auth env keys and preserves existing val
       assert.equal(options.env.ACPX_AUTH_BAD_KEY, "ignored-for-raw-key");
       assert.equal(options.env.empty, undefined);
     },
+  );
+});
+
+test("resolveAgentCloseAfterStdinEndMs gives qodercli extra EOF shutdown grace", () => {
+  assert.equal(resolveAgentCloseAfterStdinEndMs("qodercli --acp"), 750);
+  assert.equal(resolveAgentCloseAfterStdinEndMs("/Users/me/bin/qodercli --acp"), 750);
+  assert.equal(resolveAgentCloseAfterStdinEndMs("node ./test/mock-agent.js"), 100);
+});
+
+test("shouldIgnoreNonJsonAgentOutputLine ignores qoder shutdown chatter only", () => {
+  assert.equal(
+    shouldIgnoreNonJsonAgentOutputLine(
+      "qodercli --acp",
+      "Received interrupt signal. Cleaning up resources...",
+    ),
+    true,
+  );
+  assert.equal(
+    shouldIgnoreNonJsonAgentOutputLine("qodercli --acp", "Cleanup completed. Exiting..."),
+    true,
+  );
+  assert.equal(
+    shouldIgnoreNonJsonAgentOutputLine(
+      "node ./test/mock-agent.js",
+      "Cleanup completed. Exiting...",
+    ),
+    false,
+  );
+  assert.equal(
+    shouldIgnoreNonJsonAgentOutputLine("qodercli --acp", "unexpected non-json output"),
+    false,
+  );
+});
+
+test("buildQoderAcpCommandArgs forwards allowed-tools and max-turns", () => {
+  assert.deepEqual(
+    buildQoderAcpCommandArgs(["--acp"], {
+      sessionOptions: {
+        allowedTools: ["Read", "Grep", "custom_tool"],
+        maxTurns: 9,
+      },
+    }),
+    ["--acp", "--max-turns=9", "--allowed-tools=READ,GREP,custom_tool"],
+  );
+});
+
+test("buildQoderAcpCommandArgs preserves explicit qoder startup flags", () => {
+  assert.deepEqual(
+    buildQoderAcpCommandArgs(
+      ["--acp", "--max-turns=3", "--allowed-tools=READ", "--disallowed-tools=BASH"],
+      {
+        sessionOptions: {
+          allowedTools: ["Write"],
+          maxTurns: 7,
+        },
+      },
+    ),
+    ["--acp", "--max-turns=3", "--allowed-tools=READ", "--disallowed-tools=BASH"],
   );
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -525,6 +525,111 @@ test("integration: built-in iflow agent resolves to iflow --experimental-acp", a
   });
 });
 
+test("integration: built-in qoder agent resolves to qodercli --acp", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-qoder-"));
+
+    try {
+      await writeFakeQoderAgent(fakeBinDir);
+
+      const result = await runCli(
+        ["--approve-all", "--cwd", cwd, "--format", "quiet", "qoder", "exec", "echo hello"],
+        homeDir,
+        {
+          env: {
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /hello/);
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: qoder session reuse preserves persisted startup flags", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-qoder-"));
+    const argLogPath = path.join(fakeBinDir, "qoder-args.log");
+
+    try {
+      await writeFakeQoderAgent(fakeBinDir, argLogPath);
+      const { createSession } = await import("../src/session.js");
+      const { runSessionSetModeDirect } = await import("../src/session-runtime/prompt-runner.js");
+      const previousHome = process.env.HOME;
+      const previousPath = process.env.PATH;
+      process.env.HOME = homeDir;
+      process.env.PATH = `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+      try {
+        const record = await createSession({
+          agentCommand: "qodercli --acp",
+          cwd,
+          permissionMode: "approve-reads",
+          timeoutMs: 10_000,
+          sessionOptions: {
+            allowedTools: ["Read", "Grep"],
+            maxTurns: 4,
+          },
+        });
+
+        const result = await runSessionSetModeDirect({
+          sessionRecordId: record.acpxRecordId,
+          modeId: "plan",
+          timeoutMs: 10_000,
+        });
+        assert.equal(result.record.acpxRecordId, record.acpxRecordId);
+      } finally {
+        if (previousHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = previousHome;
+        }
+        process.env.PATH = previousPath;
+      }
+
+      const argLines = (await fs.readFile(argLogPath, "utf8"))
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      assert.equal(
+        argLines.length >= 2,
+        true,
+        `expected at least two qoder invocations:\n${argLines.join("\n")}`,
+      );
+      assert.equal(
+        argLines.some(
+          (line) =>
+            line.includes("--acp") &&
+            line.includes("--max-turns=4") &&
+            line.includes("--allowed-tools=READ,GREP"),
+        ),
+        true,
+        `expected persisted qoder flags in logged invocations:\n${argLines.join("\n")}`,
+      );
+      assert.equal(
+        argLines.slice(-1)[0]?.includes("--allowed-tools=READ,GREP") ?? false,
+        true,
+        `expected reused prompt spawn to preserve allowed-tools:\n${argLines.join("\n")}`,
+      );
+      assert.equal(
+        argLines.slice(-1)[0]?.includes("--max-turns=4") ?? false,
+        true,
+        `expected reused prompt spawn to preserve max-turns:\n${argLines.join("\n")}`,
+      );
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec forwards model, allowed-tools, and max-turns in session/new _meta", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -2119,6 +2224,56 @@ async function writeFakeIflowAgent(binDir: string): Promise<void> {
       'if [ "$1" = "--experimental-acp" ]; then',
       "  shift",
       "fi",
+      `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
+      "",
+    ].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function writeFakeQoderAgent(binDir: string, argLogPath?: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      path.join(binDir, "qodercli.cmd"),
+      [
+        "@echo off",
+        "setlocal",
+        ...(argLogPath ? [`echo %*>> "${argLogPath}"`] : []),
+        ":shift_known",
+        'if "%~1"=="--acp" shift & goto shift_known',
+        'if /I "%~1"=="--max-turns" shift & shift & goto shift_known',
+        'if /I "%~1"=="--allowed-tools" shift & shift & goto shift_known',
+        'if /I "%~1"=="--disallowed-tools" shift & shift & goto shift_known',
+        'echo %~1 | findstr /B /C:"--max-turns=" >nul && shift & goto shift_known',
+        'echo %~1 | findstr /B /C:"--allowed-tools=" >nul && shift & goto shift_known',
+        'echo %~1 | findstr /B /C:"--disallowed-tools=" >nul && shift & goto shift_known',
+        `"${process.execPath}" "${MOCK_AGENT_PATH}" %*`,
+        "",
+      ].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  await fs.writeFile(
+    path.join(binDir, "qodercli"),
+    [
+      "#!/bin/sh",
+      ...(argLogPath ? [`printf '%s\\n' "$*" >> ${JSON.stringify(argLogPath)}`] : []),
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      "    --acp|--max-turns=*|--allowed-tools=*|--disallowed-tools=*)",
+      "      shift",
+      "      ;;",
+      "    --max-turns|--allowed-tools|--disallowed-tools)",
+      "      shift",
+      '      [ "$#" -gt 0 ] && shift',
+      "      ;;",
+      "    *)",
+      "      break",
+      "      ;;",
+      "  esac",
+      "done",
       `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
       "",
     ].join("\n"),

--- a/test/session-conversation-model.test.ts
+++ b/test/session-conversation-model.test.ts
@@ -211,9 +211,19 @@ test("cloneSessionAcpxState preserves desired mode id", () => {
     current_mode_id: "auto",
     desired_mode_id: "plan",
     available_commands: ["review"],
+    session_options: {
+      model: "sonnet",
+      allowed_tools: ["Read", "Grep"],
+      max_turns: 7,
+    },
   });
 
   assert.equal(cloned?.current_mode_id, "auto");
   assert.equal(cloned?.desired_mode_id, "plan");
   assert.deepEqual(cloned?.available_commands, ["review"]);
+  assert.deepEqual(cloned?.session_options, {
+    model: "sonnet",
+    allowed_tools: ["Read", "Grep"],
+    max_turns: 7,
+  });
 });

--- a/test/session-persistence.test.ts
+++ b/test/session-persistence.test.ts
@@ -49,6 +49,39 @@ test("listSessions preserves acpx desired_mode_id", async () => {
   });
 });
 
+test("listSessions preserves acpx session_options", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "session-options",
+        acpSessionId: "session-options",
+        agentCommand: "agent-a",
+        cwd,
+        acpx: {
+          session_options: {
+            model: "sonnet",
+            allowed_tools: ["Read", "Grep"],
+            max_turns: 7,
+          },
+        },
+      }),
+    );
+
+    const sessions = await session.listSessions();
+    const record = sessions.find((entry) => entry.acpxRecordId === "session-options");
+    assert.ok(record);
+    assert.deepEqual(record.acpx?.session_options, {
+      model: "sonnet",
+      allowed_tools: ["Read", "Grep"],
+      max_turns: 7,
+    });
+  });
+});
+
 test("listSessions ignores unsupported conversation message shapes", async () => {
   await withTempHome(async (homeDir) => {
     const sessionDir = path.join(homeDir, ".acpx", "sessions");


### PR DESCRIPTION
## Summary
- add built-in `qoder -> qodercli --acp` support and sync the neutral built-in docs surfaces
- add the small Qoder compatibility needed in `AcpClient` for clean ACP stdio runs and Qoder CLI startup flag forwarding
- persist session options so forwarded Qoder startup flags survive named-session reuse, queue-owner restarts, and `session/load` recovery
- add regression coverage for registry mapping, client behavior, session persistence, and integration flows

## Why
Qoder CLI already supports ACP over stdio, but `acpx` did not have a built-in entrypoint for it.

Real local ACP smoke also exposed two gaps: Qoder emits benign non-JSON shutdown chatter after successful runs, and Qoder-native startup flags derived from `acpx` session options would disappear after persistent session reuse unless they were stored in the session record.

This change makes `acpx qoder ...` work out of the box without adding new generic CLI conventions.

## Validation
- `pnpm run check`
- `pnpm run check:docs`
- real local `qodercli` smoke for `exec`, JSON output, `--file`, named-session reuse, `history`, `status`, `set-mode`, `cancel`, `--no-wait`, `approve-reads`, and `session/load` recovery

AI-assisted and fully tested locally.
