### PR TITLE
docs: add conflict gates to PR triage flow

### DIFF
--- a/examples/flows/pr-triage/README.md
+++ b/examples/flows/pr-triage/README.md
@@ -1,5 +1,5 @@
 ---
-description: Prompt for triaging PRs, issues, or issue descriptions by inferring the plain-language intent, judging whether the work actually solves the underlying problem, routing ambiguous cases to a human, and only landing changes after Codex review and CI are in an acceptable state
+description: Prompt for triaging PRs, issues, or issue descriptions by inferring the plain-language intent, judging whether the work actually solves the underlying problem, routing cases that still need human judgment to a human, and only landing changes after Codex review and CI are in an acceptable state
 ---
 
 ```mermaid
@@ -95,7 +95,7 @@ This prompt may process multiple items in one run. Use it for the triage lane, n
    - a fundamental refactor is needed to solve the problem properly
    - a human must decide what the correct product or architecture direction should be before any implementation can be judged
 
-8. **Check conflicts against the current base before doing write-heavy autonomous work.** After the early read-only judgment says the solution is good enough to continue, update against the current base in the isolated workspace and check whether the branch still applies cleanly. If there are no conflicts, continue. If the conflicts are straightforward and mechanical, resolve them autonomously and then continue. If the conflicts are ambiguous, semantic, or require judgment about the right final shape, stop and escalate to a human instead of pretending the rest of the autonomous lane is still trustworthy.
+8. **Check conflicts against the current base before doing write-heavy autonomous work.** After the early read-only judgment says the solution is good enough to continue, update against the current base in the isolated workspace and check whether the branch still applies cleanly. If there are no conflicts, continue. If the conflict has a clear resolution path, resolve it autonomously and then continue. If the conflict still needs human judgment about the right final shape, stop and escalate to a human instead of pretending the rest of the autonomous lane is still trustworthy.
 
 9. **Choose the right validation path before polishing the PR.** After deciding that the solution is good enough to continue, explicitly decide whether the PR is primarily a bug-fix or a feature/behavior change. That choice determines how the work should be validated before it proceeds to refactor, review, or CI.
 
@@ -127,13 +127,13 @@ This prompt may process multiple items in one run. Use it for the triage lane, n
 
 - if you changed code while fixing CI-related problems, rerun the targeted validation from the earlier bug-or-feature validation step and any nearby integration or end-to-end tests when feasible before checking CI again
 
-19. **Check for new conflicts again before the final handoff or landing decision.** After review is clear and CI is green or clearly unrelated, check one more time whether the branch still applies cleanly to the current base. The base branch may have moved while review or CI was in progress. If new conflicts appeared, assess them again. If they are straightforward and mechanical, resolve them autonomously, then go back through the final CI check path on the updated branch. If they are ambiguous or require judgment about the right final shape, escalate to a human instead of pretending the PR is still merge-ready.
+19. **Check for new conflicts again before the final handoff or landing decision.** After review is clear and CI is green or clearly unrelated, check one more time whether the branch still applies cleanly to the current base. The base branch may have moved while review or CI was in progress. If new conflicts appeared, assess them again. If they have a clear resolution path, resolve them autonomously, then go back through the final CI check path on the updated branch. If they still need human judgment about the right final shape, escalate to a human instead of pretending the PR is still merge-ready.
 
 20. **Only land PRs that clear every gate.** A PR is ready to land only if all of the following are true:
 
 - the plain-language intention is clear
 - the implementation serves that intention in a real way rather than merely covering symptoms
-- the branch either applies cleanly to the current base or only needed straightforward conflicts that were resolved and then revalidated
+- the branch either applies cleanly to the current base or only needed conflicts with a clear resolution path that were resolved and then revalidated
 - the work has been validated on the correct path: a bug was reproduced and shown fixed, or a feature was tested directly
 - any needed refactor is either unnecessary or superficial rather than fundamental
 - there is no remaining need for human framing or architectural judgment
@@ -147,7 +147,7 @@ This prompt may process multiple items in one run. Use it for the triage lane, n
 - Plain-language intention
 - Is the intention valid
 - Does the current PR or proposed solution actually solve the right problem
-- Conflict status: clean, straightforward conflicts resolved, or ambiguous conflicts escalated
+- Conflict status: clean, clear resolution path resolved, or needs human judgment escalated
 - Was the work validated on the correct path: bug reproduced and fixed, or feature tested directly
 - Should this PR be closed immediately
 - Refactor needed: none, superficial, or fundamental
@@ -156,7 +156,7 @@ This prompt may process multiple items in one run. Use it for the triage lane, n
 - CI/CD status and whether any failures are unrelated
 - Final recommendation: close PR, land, continue autonomously, or escalate to a human
 
-23. **Post the result back, and close PRs when the outcome says to close them.** If the item is a real PR or issue, post the final result back onto that item as a comment. The comment should be written for a human reviewer or author, in plain language, and should include the intention, the judgment about whether the work really solves the right problem, whether conflict resolution stayed straightforward or needed human judgment, whether the work was actually validated on the correct bug or feature path, whether a refactor is needed and what kind, whether the PR should be closed, any blocking Codex review or CI concerns, and the final recommendation. There are two human-escalation variants: one for `needs judgment`, where the autonomous review-and-land path stopped early because a fundamental refactor, ambiguous conflict, failed validation step, or human reframing is still needed; and one for `ready for landing`, where the autonomous lane is otherwise clear and the remaining step is a human landing decision. If the item is a PR and the conclusion is that the current implementation is unclear, a bad fix, or merely a localized fix, close the PR after posting the comment. If the input item is only a raw issue description with no real item to comment on, skip the posting step and state that there was no concrete item to comment on.
+23. **Post the result back, and close PRs when the outcome says to close them.** If the item is a real PR or issue, post the final result back onto that item as a comment. The comment should be written for a human reviewer or author, in plain language, and should include the intention, the judgment about whether the work really solves the right problem, whether conflict resolution had a clear resolution path or still needed human judgment, whether the work was actually validated on the correct bug or feature path, whether a refactor is needed and what kind, whether the PR should be closed, any blocking Codex review or CI concerns, and the final recommendation. There are two human-escalation variants: one for `needs judgment`, where the autonomous review-and-land path stopped early because a fundamental refactor, a conflict that still needs human judgment, a failed validation step, or human reframing is still needed; and one for `ready for landing`, where the autonomous lane is otherwise clear and the remaining step is a human landing decision. If the item is a PR and the conclusion is that the current implementation is unclear, a bad fix, or merely a localized fix, close the PR after posting the comment. If the input item is only a raw issue description with no real item to comment on, skip the posting step and state that there was no concrete item to comment on.
 
 ### Timeout assumptions in the executable flow
 
@@ -240,7 +240,7 @@ Default comment template:
 If the item needs human attention because the autonomous lane stopped early, the template should make that obvious near the top:
 
 - `Human attention: ⚠️ Required`
-- `Human decision needed: <design decision/human call | ambiguous conflicts | validation not established | ready for human landing decision | other explicit reason>`
+- `Human decision needed: <design decision/human call | conflict still needs human judgment | validation not established | ready for human landing decision | other explicit reason>`
 - `Refactor needed: 🧱 Fundamental` if applicable
 - `Recommendation: 🏁 escalate to a human`
 

--- a/examples/flows/pr-triage/pr-triage.flow.ts
+++ b/examples/flows/pr-triage/pr-triage.flow.ts
@@ -54,6 +54,17 @@ const flow = {
         }),
     },
 
+    judge_initial_conflicts: {
+      kind: "acp",
+      session: MAIN_SESSION,
+      cwd: ({ outputs }) => prepared(outputs).workdir,
+      timeoutMs: 20 * 60_000,
+      async prompt({ outputs }) {
+        return promptJudgeInitialConflicts(prepared(outputs), outputs);
+      },
+      parse: (text) => extractJson(text),
+    },
+
     resolve_initial_conflicts: {
       kind: "acp",
       session: MAIN_SESSION,
@@ -158,6 +169,17 @@ const flow = {
         }),
     },
 
+    judge_final_conflicts: {
+      kind: "acp",
+      session: MAIN_SESSION,
+      cwd: ({ outputs }) => prepared(outputs).workdir,
+      timeoutMs: 20 * 60_000,
+      async prompt({ outputs }) {
+        return promptJudgeFinalConflicts(prepared(outputs), outputs);
+      },
+      parse: (text) => extractJson(text),
+    },
+
     resolve_final_conflicts: {
       kind: "acp",
       session: MAIN_SESSION,
@@ -219,11 +241,18 @@ const flow = {
         validationPath: outputs.bug_or_feature ?? null,
         validation: outputs.reproduce_bug_and_test_fix ?? outputs.test_feature_directly ?? null,
         initialConflict:
-          outputs.check_initial_conflicts ?? outputs.resolve_initial_conflicts ?? null,
+          outputs.check_initial_conflicts ??
+          outputs.judge_initial_conflicts ??
+          outputs.resolve_initial_conflicts ??
+          null,
         refactor: outputs.judge_refactor ?? null,
         review: outputs.review_loop ?? null,
         ci: outputs.fix_ci_failures ?? null,
-        finalConflict: outputs.check_final_conflicts ?? outputs.resolve_final_conflicts ?? null,
+        finalConflict:
+          outputs.check_final_conflicts ??
+          outputs.judge_final_conflicts ??
+          outputs.resolve_final_conflicts ??
+          null,
         workspace: outputs.prepare_workspace ?? null,
         sessionBindings: state.sessionBindings,
       }),
@@ -250,6 +279,15 @@ const flow = {
         on: "$.route",
         cases: {
           bug_or_feature: "bug_or_feature",
+          judge_initial_conflicts: "judge_initial_conflicts",
+        },
+      },
+    },
+    {
+      from: "judge_initial_conflicts",
+      switch: {
+        on: "$.route",
+        cases: {
           resolve_initial_conflicts: "resolve_initial_conflicts",
           comment_and_escalate_to_human: "comment_and_escalate_to_human",
         },
@@ -334,6 +372,16 @@ const flow = {
     },
     {
       from: "check_final_conflicts",
+      switch: {
+        on: "$.route",
+        cases: {
+          comment_and_escalate_to_human: "comment_and_escalate_to_human",
+          judge_final_conflicts: "judge_final_conflicts",
+        },
+      },
+    },
+    {
+      from: "judge_final_conflicts",
       switch: {
         on: "$.route",
         cases: {
@@ -708,17 +756,14 @@ async function collectConflictState(pr, options) {
     .filter(Boolean);
 
   const clean = attempt.exitCode === 0;
-  const straightforward = !clean && conflictsLookStraightforward(conflictedFiles);
-  const conflictStatus = clean ? "clean" : straightforward ? "straightforward" : "ambiguous";
+  const conflictStatus = clean ? "clean" : "conflicts_detected";
   const route = clean
     ? options.phase === "initial"
       ? "bug_or_feature"
       : "comment_and_escalate_to_human"
-    : straightforward
-      ? options.phase === "initial"
-        ? "resolve_initial_conflicts"
-        : "resolve_final_conflicts"
-      : "comment_and_escalate_to_human";
+    : options.phase === "initial"
+      ? "judge_initial_conflicts"
+      : "judge_final_conflicts";
 
   const conflictState = {
     phase: options.phase,
@@ -733,7 +778,7 @@ async function collectConflictState(pr, options) {
   const statePath = path.join(pr.flowDir, `${options.phase}-conflict-state.json`);
   await writeJson(statePath, conflictState);
 
-  if (clean || !straightforward) {
+  if (clean) {
     await cleanupMergeState(pr.workdir);
   }
 
@@ -743,9 +788,7 @@ async function collectConflictState(pr, options) {
     summary:
       conflictStatus === "clean"
         ? `No conflicts were detected against ${baseRef}.`
-        : conflictStatus === "straightforward"
-          ? `Conflicts were detected against ${baseRef} and look straightforward enough to resolve autonomously.`
-          : `Conflicts were detected against ${baseRef} and need human judgment.`,
+        : `Conflicts were detected against ${baseRef} and need conflict judgment before the flow can continue.`,
   };
 }
 
@@ -872,6 +915,29 @@ function promptBugOrFeature(pr) {
   ].join("\n");
 }
 
+function promptJudgeInitialConflicts(pr, outputs) {
+  const conflictStatePath =
+    outputs.check_initial_conflicts?.conflict_state_path ??
+    `${FLOW_DIR}/initial-conflict-state.json`;
+  return [
+    "You are still in the same PR session inside the isolated workspace.",
+    `Target PR: ${prRef(pr)}`,
+    `The runtime already attempted a merge against the current base and left the worktree in the conflict state. Read ${conflictStatePath} for the conflict summary and inspect the conflicted files directly in the repo.`,
+    "Decide whether the conflict has a clear resolution path or needs human judgment.",
+    "Use `clear_resolution_path` if the correct merged result is apparent from the PR intent plus the current base, even when code moved or was refactored.",
+    "Use `needs_human_judgment` if resolving the conflict requires choosing behavior, design, or architecture rather than integrating both sides safely.",
+    "If the correct move is to keep the current-base refactor and port the PR's behavior into the new structure, that still counts as `clear_resolution_path`.",
+    "Route `resolve_initial_conflicts` for `clear_resolution_path`.",
+    "Route `comment_and_escalate_to_human` for `needs_human_judgment`.",
+    "Return exactly one JSON object and nothing else:",
+    "{",
+    '  "conflict_assessment": "clear_resolution_path" | "needs_human_judgment",',
+    '  "route": "resolve_initial_conflicts" | "comment_and_escalate_to_human",',
+    '  "reason": "short explanation"',
+    "}",
+  ].join("\n");
+}
+
 function promptResolveInitialConflicts(pr, outputs) {
   const conflictStatePath =
     outputs.check_initial_conflicts?.conflict_state_path ??
@@ -881,7 +947,7 @@ function promptResolveInitialConflicts(pr, outputs) {
     `Target PR: ${prRef(pr)}`,
     `The runtime already prepared a merge-conflict state for this PR. Read ${conflictStatePath} for the conflict summary and inspect the conflicted files directly in the repo.`,
     `Use the local branch ${pr.localBranch}. If you need to push, use remote ${pr.pushRemote} branch ${pr.pushRef}.`,
-    "Resolve only straightforward conflicts while preserving the intended PR behavior.",
+    "Resolve the conflict only because you already judged that it has a clear resolution path while preserving the intended PR behavior.",
     "If you cannot resolve the conflicts confidently, do not guess. Route to `comment_and_escalate_to_human` instead.",
     "If you resolve them, finish the merge, run focused checks when feasible, commit the merge result if needed, push the branch yourself, and route to `bug_or_feature`.",
     "Return exactly one JSON object and nothing else:",
@@ -993,6 +1059,28 @@ function promptFixCiFailures(pr, outputs) {
   ].join("\n");
 }
 
+function promptJudgeFinalConflicts(pr, outputs) {
+  const conflictStatePath =
+    outputs.check_final_conflicts?.conflict_state_path ?? `${FLOW_DIR}/final-conflict-state.json`;
+  return [
+    "You are still in the same PR session inside the isolated workspace.",
+    `Target PR: ${prRef(pr)}`,
+    `The runtime already attempted a merge against the current base and left the worktree in the conflict state. Read ${conflictStatePath} for the conflict summary and inspect the conflicted files directly in the repo.`,
+    "Decide whether the conflict has a clear resolution path or needs human judgment.",
+    "Use `clear_resolution_path` if the correct merged result is apparent from the PR intent plus the current base, even when code moved or was refactored.",
+    "Use `needs_human_judgment` if resolving the conflict requires choosing behavior, design, or architecture rather than integrating both sides safely.",
+    "If the correct move is to keep the current-base refactor and port the PR's behavior into the new structure, that still counts as `clear_resolution_path`.",
+    "Route `resolve_final_conflicts` for `clear_resolution_path`.",
+    "Route `comment_and_escalate_to_human` for `needs_human_judgment`.",
+    "Return exactly one JSON object and nothing else:",
+    "{",
+    '  "conflict_assessment": "clear_resolution_path" | "needs_human_judgment",',
+    '  "route": "resolve_final_conflicts" | "comment_and_escalate_to_human",',
+    '  "reason": "short explanation"',
+    "}",
+  ].join("\n");
+}
+
 function promptResolveFinalConflicts(pr, outputs) {
   const conflictStatePath =
     outputs.check_final_conflicts?.conflict_state_path ?? `${FLOW_DIR}/final-conflict-state.json`;
@@ -1002,7 +1090,7 @@ function promptResolveFinalConflicts(pr, outputs) {
     `Target PR: ${prRef(pr)}`,
     `The runtime already prepared a merge-conflict state for this PR. Read ${conflictStatePath} for the conflict summary and inspect the conflicted files directly in the repo.`,
     `Use the local branch ${pr.localBranch}. If you need to push, use remote ${pr.pushRemote} branch ${pr.pushRef}.`,
-    "Resolve only straightforward conflicts while preserving the intended PR behavior.",
+    "Resolve the conflict only because you already judged that it has a clear resolution path while preserving the intended PR behavior.",
     "If you cannot resolve the conflicts confidently, do not guess. Route to `comment_and_escalate_to_human` instead.",
     `If you resolve them, rerun the earlier targeted validation before returning. Latest validation summary: ${validation?.summary ?? "none"}.`,
     "After resolving and pushing the branch, route back to `collect_ci_state` so the flow runtime can rerun the final CI path.",
@@ -1051,7 +1139,7 @@ function promptCommentAndEscalate(pr, outputs) {
     "- `Recommendation: 🏁 escalate to a human`",
     "- `Human decision needed: <explicit next human action>` near the top of the comment",
     "If the final conflict gate is clean and CI is green or unrelated, make the human decision needed `ready for human landing decision`.",
-    "If the blocker is an ambiguous conflict or another earlier stop condition, say that plainly in `Human decision needed`.",
+    "If the blocker is a conflict that still needs human judgment or another earlier stop condition, say that plainly in `Human decision needed`.",
     "If the remaining blocker is workflow approval, say that plainly.",
     "Use the current run state below as the source of truth:",
     JSON.stringify(summary, null, 2),
@@ -1100,13 +1188,21 @@ function finalCommentSummary(outputs) {
   return {
     intent: outputs.extract_intent ?? null,
     solution: outputs.judge_solution ?? null,
-    initialConflict: outputs.check_initial_conflicts ?? outputs.resolve_initial_conflicts ?? null,
+    initialConflict:
+      outputs.check_initial_conflicts ??
+      outputs.judge_initial_conflicts ??
+      outputs.resolve_initial_conflicts ??
+      null,
     validationPath: outputs.bug_or_feature ?? null,
     validation: outputs.reproduce_bug_and_test_fix ?? outputs.test_feature_directly ?? null,
     refactor: outputs.judge_refactor ?? null,
     review: outputs.review_loop ?? null,
     ci: outputs.fix_ci_failures ?? null,
-    finalConflict: outputs.check_final_conflicts ?? outputs.resolve_final_conflicts ?? null,
+    finalConflict:
+      outputs.check_final_conflicts ??
+      outputs.judge_final_conflicts ??
+      outputs.resolve_final_conflicts ??
+      null,
   };
 }
 
@@ -1234,21 +1330,6 @@ function extractLinkedIssueNumber(body) {
 
 function isTestFile(filename) {
   return /(^|\/)(test|tests|__tests__)\/|\.test\.[jt]sx?$|\.spec\.[jt]sx?$/.test(filename);
-}
-
-function isDocsLikeFile(filename) {
-  return (
-    /\.(md|mdx|txt|ya?ml|json)$/i.test(filename) ||
-    /^(docs|examples|skills|agents|\.github\/workflows)\//.test(filename)
-  );
-}
-
-function conflictsLookStraightforward(conflictedFiles) {
-  return (
-    conflictedFiles.length > 0 &&
-    conflictedFiles.length <= 3 &&
-    conflictedFiles.every((filename) => isDocsLikeFile(filename) || isTestFile(filename))
-  );
 }
 
 async function writeJson(filename, value) {


### PR DESCRIPTION
## Summary
- add an early conflict gate after the initial implementation/solution judgment
- add a second conflict gate before the final handoff or landing decision
- document straightforward vs ambiguous conflict handling in the shipped PR-triage spec and flowchart

## Validation
- rendered the updated Mermaid flowchart locally
- `pnpm run check:docs`