### PR TITLE
feat: add flow run title API

### DIFF
--- a/examples/flows/pr-triage/pr-triage.flow.ts
+++ b/examples/flows/pr-triage/pr-triage.flow.ts
@@ -12,6 +12,9 @@ const MAIN_SESSION = {
 
 const flow = {
   name: "pr-triage",
+  run: {
+    title: ({ input }) => formatPrTriageRunTitle(loadPullRequestInput(input)),
+  },
   permissions: {
     requiredMode: "approve-all",
     requireExplicitGrant: true,
@@ -1182,6 +1185,11 @@ function loadPullRequestInput(input) {
     prNumber,
     prUrl: `https://github.com/${repo}/pull/${prNumber}`,
   };
+}
+
+function formatPrTriageRunTitle(pr) {
+  const repoName = pr.repo.split("/").filter(Boolean).at(-1) ?? pr.repo;
+  return `PR-triage-${repoName}-${pr.prNumber}`;
 }
 
 function loadPrOutput(outputs) {

--- a/examples/flows/replay-viewer/server/run-bundles.ts
+++ b/examples/flows/replay-viewer/server/run-bundles.ts
@@ -76,6 +76,7 @@ async function readRunBundleSummary(runsDir: string, runId: string): Promise<Run
   return {
     runId: manifest.runId,
     flowName: manifest.flowName,
+    runTitle: manifest.runTitle ?? run.runTitle,
     status: run.status,
     startedAt: manifest.startedAt,
     finishedAt: manifest.finishedAt,

--- a/examples/flows/replay-viewer/src/components/run-browser.tsx
+++ b/examples/flows/replay-viewer/src/components/run-browser.tsx
@@ -46,14 +46,15 @@ export function RunBrowser({
         <div className="run-browser__list">
           {runs.map((run) => {
             const active = run.runId === activeRunId;
+            const displayName = run.runTitle ?? run.flowName;
             return (
               <button
                 key={run.runId}
                 type="button"
                 className={`run-list-item${active ? " run-list-item--active" : ""}`}
                 onClick={() => onLoadRun(run)}
-                aria-label={`${run.flowName} ${run.runId} ${run.status}`}
-                title={`${run.flowName} • ${run.runId}`}
+                aria-label={`${displayName} ${run.runId} ${run.status}`}
+                title={`${displayName} • ${run.runId}`}
               >
                 {collapsed ? (
                   <>
@@ -61,7 +62,7 @@ export function RunBrowser({
                       className={`run-list-item__status-dot run-list-item__status-dot--${run.status}`}
                       aria-hidden="true"
                     />
-                    <span className="run-list-item__abbr">{abbreviateRun(run.flowName)}</span>
+                    <span className="run-list-item__abbr">{abbreviateRun(displayName)}</span>
                   </>
                 ) : (
                   <>
@@ -121,5 +122,5 @@ function shortRunToken(runId: string): string {
 }
 
 function compactRunLabel(run: RunBundleSummary): string {
-  return `${run.flowName} · ${shortRunToken(run.runId)}`;
+  return `${run.runTitle ?? run.flowName} · ${shortRunToken(run.runId)}`;
 }

--- a/examples/flows/replay-viewer/src/types.ts
+++ b/examples/flows/replay-viewer/src/types.ts
@@ -14,6 +14,9 @@ export type FlowEdge =
 export type FlowDefinitionSnapshot = {
   schema: "acpx.flow-definition-snapshot.v1";
   name: string;
+  run?: {
+    hasTitle?: boolean;
+  };
   startAt: string;
   nodes: Record<
     string,
@@ -127,6 +130,7 @@ export type FlowNodeResult = {
 export type FlowRunState = {
   runId: string;
   flowName: string;
+  runTitle?: string;
   flowPath?: string;
   startedAt: string;
   finishedAt?: string;
@@ -151,6 +155,7 @@ export type FlowRunManifest = {
   schema: "acpx.flow-run-bundle.v1";
   runId: string;
   flowName: string;
+  runTitle?: string;
   flowPath?: string;
   startedAt: string;
   finishedAt?: string;
@@ -177,6 +182,7 @@ export type FlowRunManifest = {
 export type RunBundleSummary = {
   runId: string;
   flowName: string;
+  runTitle?: string;
   status: FlowRunState["status"];
   startedAt: string;
   finishedAt?: string;

--- a/src/flows.ts
+++ b/src/flows.ts
@@ -11,6 +11,7 @@ export type {
   FlowNodeContext,
   FlowNodeDefinition,
   FlowPermissionRequirements,
+  FlowRunDefinition,
   FlowRunResult,
   FlowRunState,
   FlowRunnerOptions,

--- a/src/flows/cli.ts
+++ b/src/flows/cli.ts
@@ -275,6 +275,7 @@ function printFlowRunResult(
     action: "flow_run_result",
     runId: result.state.runId,
     flowName: result.state.flowName,
+    runTitle: result.state.runTitle,
     flowPath: result.state.flowPath,
     status: result.state.status,
     currentNode: result.state.currentNode,
@@ -300,6 +301,9 @@ function printFlowRunResult(
 
   process.stdout.write(`runId: ${payload.runId}\n`);
   process.stdout.write(`flow: ${payload.flowName}\n`);
+  if (payload.runTitle) {
+    process.stdout.write(`title: ${payload.runTitle}\n`);
+  }
   process.stdout.write(`status: ${payload.status}\n`);
   process.stdout.write(`runDir: ${payload.runDir}\n`);
   if (payload.currentNode) {

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -153,10 +153,12 @@ export class FlowRunner {
     validateFlowDefinition(flow);
 
     const runId = createRunId(flow.name);
+    const runTitle = await resolveFlowRunTitle(flow, input, options.flowPath);
     const runDir = await this.store.createRunDir(runId);
     const state: FlowRunState = {
       runId,
       flowName: flow.name,
+      runTitle,
       flowPath: options.flowPath,
       startedAt: isoNow(),
       updatedAt: isoNow(),
@@ -1243,6 +1245,29 @@ function createQuietCaptureOutput(): {
     }),
     read: () => chunks.join("").trim(),
   };
+}
+
+async function resolveFlowRunTitle(
+  flow: FlowDefinition,
+  input: unknown,
+  flowPath?: string,
+): Promise<string | undefined> {
+  const titleDefinition = flow.run?.title;
+  if (titleDefinition === undefined) {
+    return undefined;
+  }
+
+  const resolved =
+    typeof titleDefinition === "function"
+      ? await Promise.resolve(titleDefinition({ input, flowName: flow.name, flowPath }))
+      : titleDefinition;
+
+  return normalizeFlowRunTitle(resolved);
+}
+
+function normalizeFlowRunTitle(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function createRunId(flowName: string): string {

--- a/src/flows/store.ts
+++ b/src/flows/store.ts
@@ -34,6 +34,7 @@ const ARTIFACTS_DIR = "artifacts";
 type FlowLiveState = {
   runId: string;
   flowName: string;
+  runTitle?: string;
   flowPath?: string;
   startedAt: string;
   finishedAt?: string;
@@ -96,6 +97,7 @@ export class FlowRunStore {
       schema: FLOW_BUNDLE_SCHEMA,
       runId: options.state.runId,
       flowName: options.state.flowName,
+      runTitle: options.state.runTitle,
       flowPath: options.state.flowPath,
       startedAt: options.state.startedAt,
       finishedAt: options.state.finishedAt,
@@ -129,6 +131,7 @@ export class FlowRunStore {
       type: "run_started",
       payload: {
         flowName: options.state.flowName,
+        ...(options.state.runTitle ? { runTitle: options.state.runTitle } : {}),
         ...(options.state.flowPath ? { flowPath: options.state.flowPath } : {}),
         ...(options.inputArtifact ? { inputArtifact: options.inputArtifact } : {}),
       },
@@ -311,6 +314,7 @@ export class FlowRunStore {
       existing.status = state.status;
       existing.flowPath = state.flowPath;
       existing.flowName = state.flowName;
+      existing.runTitle = state.runTitle;
       return existing;
     }
 
@@ -318,6 +322,7 @@ export class FlowRunStore {
       schema: FLOW_BUNDLE_SCHEMA,
       runId: state.runId,
       flowName: state.flowName,
+      runTitle: state.runTitle,
       flowPath: state.flowPath,
       startedAt: state.startedAt,
       finishedAt: state.finishedAt,
@@ -373,6 +378,7 @@ function createLiveState(state: FlowRunState): FlowLiveState {
   return {
     runId: state.runId,
     flowName: state.flowName,
+    runTitle: state.runTitle,
     flowPath: state.flowPath,
     startedAt: state.startedAt,
     finishedAt: state.finishedAt,
@@ -394,6 +400,7 @@ function createFlowDefinitionSnapshot(flow: FlowDefinition): FlowDefinitionSnaps
   return {
     schema: FLOW_SNAPSHOT_SCHEMA,
     name: flow.name,
+    ...(flow.run?.title !== undefined ? { run: { hasTitle: true } } : {}),
     ...(flow.permissions ? { permissions: structuredClone(flow.permissions) } : {}),
     startAt: flow.startAt,
     nodes: Object.fromEntries(

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -12,6 +12,16 @@ import type {
 
 type MaybePromise<T> = T | Promise<T>;
 
+export type FlowRunDefinition<TInput = unknown> = {
+  title?:
+    | string
+    | ((context: {
+        input: TInput;
+        flowName: string;
+        flowPath?: string;
+      }) => MaybePromise<string | undefined>);
+};
+
 export type FlowNodeContext<TInput = unknown> = {
   input: TInput;
   outputs: Record<string, unknown>;
@@ -112,6 +122,7 @@ export type FlowPermissionRequirements = {
 
 export type FlowDefinition = {
   name: string;
+  run?: FlowRunDefinition;
   permissions?: FlowPermissionRequirements;
   startAt: string;
   nodes: Record<string, FlowNodeDefinition>;
@@ -140,6 +151,9 @@ export type FlowNodeSnapshot = FlowNodeCommon & {
 export type FlowDefinitionSnapshot = {
   schema: "acpx.flow-definition-snapshot.v1";
   name: string;
+  run?: {
+    hasTitle?: boolean;
+  };
   permissions?: FlowPermissionRequirements;
   startAt: string;
   nodes: Record<string, FlowNodeSnapshot>;
@@ -234,6 +248,7 @@ export type FlowSessionBinding = {
 export type FlowRunState = {
   runId: string;
   flowName: string;
+  runTitle?: string;
   flowPath?: string;
   startedAt: string;
   finishedAt?: string;
@@ -271,6 +286,7 @@ export type FlowRunManifest = {
   schema: "acpx.flow-run-bundle.v1";
   runId: string;
   flowName: string;
+  runTitle?: string;
   flowPath?: string;
   startedAt: string;
   finishedAt?: string;

--- a/test/flows-store.test.ts
+++ b/test/flows-store.test.ts
@@ -22,6 +22,7 @@ test("FlowRunStore writes manifest, projections, flow snapshot, and trace events
     const state: FlowRunState = {
       runId: "run-123",
       flowName: "demo",
+      runTitle: "Demo run title",
       flowPath: "/tmp/demo.flow.ts",
       startedAt: "2026-03-26T00:00:00.000Z",
       updatedAt: "2026-03-26T00:00:00.000Z",
@@ -56,6 +57,7 @@ test("FlowRunStore writes manifest, projections, flow snapshot, and trace events
 
     const manifest = JSON.parse(await fs.readFile(path.join(runDir, "manifest.json"), "utf8")) as {
       schema: string;
+      runTitle?: string;
       paths: {
         runProjection: string;
         liveProjection: string;
@@ -71,6 +73,7 @@ test("FlowRunStore writes manifest, projections, flow snapshot, and trace events
       await fs.readFile(path.join(runDir, "projections", "run.json"), "utf8"),
     ) as {
       runId: string;
+      runTitle?: string;
       currentNode?: string;
       statusDetail?: string;
     };
@@ -78,6 +81,7 @@ test("FlowRunStore writes manifest, projections, flow snapshot, and trace events
       await fs.readFile(path.join(runDir, "projections", "live.json"), "utf8"),
     ) as {
       runId: string;
+      runTitle?: string;
       currentNode?: string;
       currentAttemptId?: string;
       statusDetail?: string;
@@ -91,13 +95,16 @@ test("FlowRunStore writes manifest, projections, flow snapshot, and trace events
       .map((line) => JSON.parse(line) as { type?: string; at?: string; seq?: number });
 
     assert.equal(manifest.schema, "acpx.flow-run-bundle.v1");
+    assert.equal(manifest.runTitle, "Demo run title");
     assert.equal(manifest.paths.runProjection, "projections/run.json");
     assert.equal(flowSnapshot.schema, "acpx.flow-definition-snapshot.v1");
     assert.equal(flowSnapshot.nodes.prepare?.nodeType, "action");
     assert.equal(flowSnapshot.nodes.prepare?.actionExecution, "function");
     assert.equal(snapshot.runId, "run-123");
+    assert.equal(snapshot.runTitle, "Demo run title");
     assert.equal(snapshot.currentNode, "prepare");
     assert.equal(live.runId, "run-123");
+    assert.equal(live.runTitle, "Demo run title");
     assert.equal(live.currentAttemptId, "prepare#1");
     assert.equal(live.statusDetail, "Preparing");
     assert.deepEqual(steps, []);

--- a/test/flows.test.ts
+++ b/test/flows.test.ts
@@ -120,6 +120,63 @@ test("FlowRunner executes isolated ACP nodes and branches deterministically", as
   });
 });
 
+test("FlowRunner resolves and persists dynamic run titles", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-flow-run-title-"));
+
+    try {
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd: outputRoot,
+        }),
+        permissionMode: "approve-all",
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "title-test",
+        run: {
+          title: ({ input }) => {
+            const payload = input as { repo: string; prNumber: number };
+            const repoName = payload.repo.split("/").at(-1);
+            return `PR-triage-${repoName}-${payload.prNumber}`;
+          },
+        },
+        startAt: "done",
+        nodes: {
+          done: compute({
+            run: () => ({ ok: true }),
+          }),
+        },
+        edges: [],
+      });
+
+      const result = await runner.run(flow, {
+        repo: "openclaw/acpx",
+        prNumber: 128,
+      });
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(result.runDir, "manifest.json"), "utf8"),
+      ) as {
+        runTitle?: string;
+      };
+      const runProjection = JSON.parse(
+        await fs.readFile(path.join(result.runDir, "projections", "run.json"), "utf8"),
+      ) as {
+        runTitle?: string;
+      };
+
+      assert.equal(result.state.runTitle, "PR-triage-acpx-128");
+      assert.equal(manifest.runTitle, "PR-triage-acpx-128");
+      assert.equal(runProjection.runTitle, "PR-triage-acpx-128");
+    } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 test("FlowRunner writes isolated ACP bundle traces and artifacts", async () => {
   await withTempHome(async () => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-flow-isolated-trace-"));

--- a/test/pr-triage-example.test.ts
+++ b/test/pr-triage-example.test.ts
@@ -132,3 +132,15 @@ test("judge_refactor asks whether anything should be added removed simplified or
     );
   });
 });
+
+test("pr-triage configures a descriptive run title from repo and PR number", () => {
+  const sourcePath = path.join(process.cwd(), "examples/flows/pr-triage/pr-triage.flow.ts");
+
+  return fs.readFile(sourcePath, "utf8").then((source) => {
+    assert.match(
+      source,
+      /run:\s*\{[\s\S]*title:\s*\(\{\s*input\s*\}\)\s*=>\s*formatPrTriageRunTitle\(loadPullRequestInput\(input\)\)/,
+    );
+    assert.match(source, /return `PR-triage-\$\{repoName\}-\$\{pr\.prNumber\}`;/);
+  });
+});

--- a/test/replay-viewer-run-bundles.test.ts
+++ b/test/replay-viewer-run-bundles.test.ts
@@ -15,6 +15,7 @@ test("listRunBundles returns newest valid bundles first", async () => {
     await writeRunBundle(runsDir, {
       runId: "2026-03-27T060000000Z-example-a",
       flowName: "flow-a",
+      runTitle: "PR-triage-acpx-171",
       status: "completed",
       startedAt: "2026-03-27T06:00:00.000Z",
       currentNode: "done",
@@ -36,6 +37,7 @@ test("listRunBundles returns newest valid bundles first", async () => {
     );
     assert.equal(runs[0]?.currentNode, "extract_intent");
     assert.equal(runs[1]?.flowName, "flow-a");
+    assert.equal(runs[1]?.runTitle, "PR-triage-acpx-171");
   } finally {
     await fs.rm(runsDir, { recursive: true, force: true });
   }
@@ -59,6 +61,7 @@ async function writeRunBundle(
   options: {
     runId: string;
     flowName: string;
+    runTitle?: string;
     status: "running" | "waiting" | "completed" | "failed" | "timed_out";
     startedAt: string;
     currentNode?: string;
@@ -74,6 +77,7 @@ async function writeRunBundle(
       schema: "acpx.flow-run-bundle.v1",
       runId: options.runId,
       flowName: options.flowName,
+      runTitle: options.runTitle,
       startedAt: options.startedAt,
       status: options.status,
       traceSchema: "acpx.flow-trace-event.v1",
@@ -95,6 +99,7 @@ async function writeRunBundle(
     JSON.stringify({
       runId: options.runId,
       flowName: options.flowName,
+      runTitle: options.runTitle,
       startedAt: options.startedAt,
       updatedAt: options.startedAt,
       status: options.status,
@@ -112,6 +117,7 @@ async function writeRunBundle(
     JSON.stringify({
       runId: options.runId,
       flowName: options.flowName,
+      runTitle: options.runTitle,
       startedAt: options.startedAt,
       updatedAt: options.startedAt,
       status: options.status,


### PR DESCRIPTION
## Summary
- add a flow-level run title API via `flow.run.title`
- persist `runTitle` through flow state, manifests, CLI output, and replay-viewer recent-run summaries
- configure `pr-triage` to emit descriptive titles like `PR-triage-acpx-167`

## Design
The new API is intentionally run-scoped, not flow-name scoped:
- `flow.name` stays stable for IDs, routing, and file naming
- `flow.run.title` is resolved once at run start and used only as display metadata
- flows can provide either a static string or a function of `{ input, flowName, flowPath }`

That keeps the title flexible for future workflows without turning `flow.name` into a user-visible convention bucket.

## Validation
- `pnpm run check`
- real runtime verification using the actual `pr-triage` flow object with a fast single-node slice

Verified runtime result:
- input: `{"repo":"openclaw/acpx","prNumber":167}`
- generated title: `PR-triage-acpx-167`
- persisted in both `result.state.runTitle` and `manifest.json`
