### PR TITLE
feat(flows): add decision node type for constrained LLM branching

### DIFF
--- a/src/flows.ts
+++ b/src/flows.ts
@@ -1,10 +1,21 @@
 export { FlowRunner } from "./flows/runtime.js";
-export { acp, action, checkpoint, compute, defineFlow, shell } from "./flows/definition.js";
+export {
+  acp,
+  action,
+  checkpoint,
+  compute,
+  decision,
+  defineFlow,
+  shell,
+} from "./flows/definition.js";
 export type {
   AcpNodeDefinition,
   ActionNodeDefinition,
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
+  DecisionNodeDefinition,
+  DecisionResolverInput,
+  DecisionResult,
   FlowDefinition,
   FlowEdge,
   FlowNodeCommon,

--- a/src/flows/definition.ts
+++ b/src/flows/definition.ts
@@ -3,6 +3,7 @@ import type {
   ActionNodeDefinition,
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
+  DecisionNodeDefinition,
   FlowDefinition,
   FunctionActionNodeDefinition,
   ShellActionNodeDefinition,
@@ -59,6 +60,15 @@ export function checkpoint(
 ): CheckpointNodeDefinition {
   return {
     nodeType: "checkpoint",
+    ...definition,
+  };
+}
+
+export function decision(
+  definition: Omit<DecisionNodeDefinition, "nodeType">,
+): DecisionNodeDefinition {
+  return {
+    nodeType: "decision",
     ...definition,
   };
 }

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -39,6 +39,7 @@ import type {
   DecisionNodeDefinition,
   DecisionResolverInput,
   DecisionResult,
+  FlowArtifactRef,
   FlowDefinition,
   FlowNodeCommon,
   FlowNodeContext,
@@ -532,23 +533,6 @@ export class FlowRunner {
           "Do not include any other text.",
         ].join("\n");
 
-        const isolatedBinding = createIsolatedSessionBinding(
-          flow.name,
-          state.runId,
-          state.currentAttemptId ?? randomUUID(),
-          node.profile,
-          agentInfo,
-        );
-        const initialIsolatedRecord = createSyntheticSessionRecord({
-          binding: isolatedBinding,
-          createdAt: state.currentNodeStartedAt ?? isoNow(),
-          updatedAt: state.currentNodeStartedAt ?? isoNow(),
-          conversation: createSessionConversation(state.currentNodeStartedAt ?? isoNow()),
-          acpxState: undefined,
-          lastSeq: 0,
-        });
-        await this.store.ensureSessionBundle(runDir, state, isolatedBinding, initialIsolatedRecord);
-
         const promptArtifact = await this.store.writeArtifact(runDir, state, acpPrompt, {
           mediaType: "text/plain",
           extension: "txt",
@@ -556,59 +540,20 @@ export class FlowRunner {
           attemptId: state.currentAttemptId,
         });
 
-        await this.store.appendTrace(runDir, state, {
-          scope: "acp",
-          type: "acp_prompt_prepared",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-          sessionId: isolatedBinding.bundleId,
-          payload: { sessionId: isolatedBinding.bundleId, promptArtifact },
-        });
-
-        const isolatedPrompt = await this.runIsolatedPrompt(
+        const { rawText, binding, trace } = await this.runIsolatedAcpPromptWithTrace(
           runDir,
           state,
-          isolatedBinding,
+          flow,
+          node.profile,
           agentInfo,
           normalizePromptInput(acpPrompt),
+          promptArtifact,
           nodeTimeoutMs,
         );
 
-        const rawResponseArtifact = await this.store.writeArtifact(
-          runDir,
-          state,
-          isolatedPrompt.rawText,
-          {
-            mediaType: "text/plain",
-            extension: "txt",
-            nodeId: state.currentNode,
-            attemptId: state.currentAttemptId,
-            sessionId: isolatedBinding.bundleId,
-          },
-        );
-        await this.store.appendTrace(runDir, state, {
-          scope: "acp",
-          type: "acp_response_parsed",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-          sessionId: isolatedBinding.bundleId,
-          payload: {
-            sessionId: isolatedBinding.bundleId,
-            conversation: isolatedPrompt.conversation,
-            rawResponseArtifact,
-          },
-        });
-
-        const trace: FlowStepTrace = {
-          sessionId: isolatedBinding.bundleId,
-          promptArtifact,
-          rawResponseArtifact,
-          conversation: isolatedPrompt.conversation,
-        };
-
         let parsed: DecisionResult;
         try {
-          parsed = extractJsonObject(isolatedPrompt.rawText) as DecisionResult;
+          parsed = extractJsonObject(rawText) as DecisionResult;
           validateDecisionResult(parsed, node.options);
         } catch (error) {
           throw attachStepTrace(error, trace);
@@ -617,8 +562,8 @@ export class FlowRunner {
         return {
           output: parsed,
           promptText: acpPrompt,
-          rawText: isolatedPrompt.rawText,
-          sessionInfo: isolatedBinding,
+          rawText,
+          sessionInfo: binding,
           agentInfo,
           trace,
         };
@@ -834,89 +779,27 @@ export class FlowRunner {
         });
 
         if (node.session?.isolated) {
-          const isolatedBinding = createIsolatedSessionBinding(
-            flow.name,
-            state.runId,
-            state.currentAttemptId ?? randomUUID(),
+          const { rawText, binding, trace } = await this.runIsolatedAcpPromptWithTrace(
+            runDir,
+            state,
+            flow,
             node.profile,
             agentInfo,
-          );
-          const initialIsolatedRecord = createSyntheticSessionRecord({
-            binding: isolatedBinding,
-            createdAt: state.currentNodeStartedAt ?? isoNow(),
-            updatedAt: state.currentNodeStartedAt ?? isoNow(),
-            conversation: createSessionConversation(state.currentNodeStartedAt ?? isoNow()),
-            acpxState: undefined,
-            lastSeq: 0,
-          });
-          await this.store.ensureSessionBundle(
-            runDir,
-            state,
-            isolatedBinding,
-            initialIsolatedRecord,
-          );
-          await this.store.appendTrace(runDir, state, {
-            scope: "acp",
-            type: "acp_prompt_prepared",
-            nodeId: state.currentNode,
-            attemptId: state.currentAttemptId,
-            sessionId: isolatedBinding.bundleId,
-            payload: {
-              sessionId: isolatedBinding.bundleId,
-              promptArtifact,
-            },
-          });
-          const isolatedPrompt = await this.runIsolatedPrompt(
-            runDir,
-            state,
-            isolatedBinding,
-            agentInfo,
             prompt,
+            promptArtifact,
             nodeTimeoutMs,
           );
-          const rawResponseArtifact = await this.store.writeArtifact(
-            runDir,
-            state,
-            isolatedPrompt.rawText,
-            {
-              mediaType: "text/plain",
-              extension: "txt",
-              nodeId: state.currentNode,
-              attemptId: state.currentAttemptId,
-              sessionId: isolatedBinding.bundleId,
-            },
-          );
-          await this.store.appendTrace(runDir, state, {
-            scope: "acp",
-            type: "acp_response_parsed",
-            nodeId: state.currentNode,
-            attemptId: state.currentAttemptId,
-            sessionId: isolatedBinding.bundleId,
-            payload: {
-              sessionId: isolatedBinding.bundleId,
-              conversation: isolatedPrompt.conversation,
-              rawResponseArtifact,
-            },
-          });
-          const trace: FlowStepTrace = {
-            sessionId: isolatedBinding.bundleId,
-            promptArtifact,
-            rawResponseArtifact,
-            conversation: isolatedPrompt.conversation,
-          };
           let parsedOutput: unknown;
           try {
-            parsedOutput = node.parse
-              ? await node.parse(isolatedPrompt.rawText, context)
-              : isolatedPrompt.rawText;
+            parsedOutput = node.parse ? await node.parse(rawText, context) : rawText;
           } catch (error) {
             throw attachStepTrace(error, trace);
           }
           return {
             output: parsedOutput,
             promptText,
-            rawText: isolatedPrompt.rawText,
-            sessionInfo: isolatedBinding,
+            rawText,
+            sessionInfo: binding,
             agentInfo,
             trace,
           };
@@ -1269,6 +1152,95 @@ export class FlowRunner {
     );
   }
 
+  private async runIsolatedAcpPromptWithTrace(
+    runDir: string,
+    state: FlowRunState,
+    flow: FlowDefinition,
+    profile: string | undefined,
+    agentInfo: ResolvedFlowAgent,
+    prompt: PromptInput,
+    promptArtifact: FlowArtifactRef,
+    nodeTimeoutMs: number | undefined,
+  ): Promise<{
+    rawText: string;
+    binding: FlowSessionBinding;
+    rawResponseArtifact: FlowArtifactRef;
+    trace: FlowStepTrace;
+  }> {
+    const isolatedBinding = createIsolatedSessionBinding(
+      flow.name,
+      state.runId,
+      state.currentAttemptId ?? randomUUID(),
+      profile,
+      agentInfo,
+    );
+    const initialIsolatedRecord = createSyntheticSessionRecord({
+      binding: isolatedBinding,
+      createdAt: state.currentNodeStartedAt ?? isoNow(),
+      updatedAt: state.currentNodeStartedAt ?? isoNow(),
+      conversation: createSessionConversation(state.currentNodeStartedAt ?? isoNow()),
+      acpxState: undefined,
+      lastSeq: 0,
+    });
+    await this.store.ensureSessionBundle(runDir, state, isolatedBinding, initialIsolatedRecord);
+    await this.store.appendTrace(runDir, state, {
+      scope: "acp",
+      type: "acp_prompt_prepared",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+      sessionId: isolatedBinding.bundleId,
+      payload: { sessionId: isolatedBinding.bundleId, promptArtifact },
+    });
+
+    const isolatedPrompt = await this.runIsolatedPrompt(
+      runDir,
+      state,
+      isolatedBinding,
+      agentInfo,
+      prompt,
+      nodeTimeoutMs,
+    );
+
+    const rawResponseArtifact = await this.store.writeArtifact(
+      runDir,
+      state,
+      isolatedPrompt.rawText,
+      {
+        mediaType: "text/plain",
+        extension: "txt",
+        nodeId: state.currentNode,
+        attemptId: state.currentAttemptId,
+        sessionId: isolatedBinding.bundleId,
+      },
+    );
+    await this.store.appendTrace(runDir, state, {
+      scope: "acp",
+      type: "acp_response_parsed",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+      sessionId: isolatedBinding.bundleId,
+      payload: {
+        sessionId: isolatedBinding.bundleId,
+        conversation: isolatedPrompt.conversation,
+        rawResponseArtifact,
+      },
+    });
+
+    const trace: FlowStepTrace = {
+      sessionId: isolatedBinding.bundleId,
+      promptArtifact,
+      rawResponseArtifact,
+      conversation: isolatedPrompt.conversation,
+    };
+
+    return {
+      rawText: isolatedPrompt.rawText,
+      binding: isolatedBinding,
+      rawResponseArtifact,
+      trace,
+    };
+  }
+
   private async runIsolatedPrompt(
     runDir: string,
     state: FlowRunState,
@@ -1590,11 +1562,16 @@ function validateDecisionResult(
   if (
     result == null ||
     typeof result !== "object" ||
-    typeof (result as DecisionResult).choice !== "string" ||
-    typeof (result as DecisionResult).reasoning !== "string"
+    typeof (result as DecisionResult).choice !== "string"
   ) {
     throw new Error(
-      `Decision result must have shape { choice: string, reasoning: string }, got: ${JSON.stringify(result)}`,
+      `Decision result must have shape { choice: string, reasoning?: string }, got: ${JSON.stringify(result)}`,
+    );
+  }
+  const reasoning = (result as Record<string, unknown>).reasoning;
+  if (reasoning !== undefined && typeof reasoning !== "string") {
+    throw new Error(
+      `Decision result reasoning must be a string if provided, got: ${JSON.stringify(result)}`,
     );
   }
   const choice = (result as DecisionResult).choice;

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -26,15 +26,19 @@ import {
 } from "../session.js";
 import { SESSION_RECORD_SCHEMA } from "../types.js";
 import type { PromptInput, SessionRecord } from "../types.js";
-import { acp, action, checkpoint, compute, defineFlow, shell } from "./definition.js";
+import { acp, action, checkpoint, compute, decision, defineFlow, shell } from "./definition.js";
 import { formatShellActionSummary, runShellAction } from "./executors/shell.js";
 import { resolveNext, resolveNextForOutcome, validateFlowDefinition } from "./graph.js";
+import { extractJsonObject } from "./json.js";
 import { FlowRunStore } from "./store.js";
 import type {
   AcpNodeDefinition,
   ActionNodeDefinition,
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
+  DecisionNodeDefinition,
+  DecisionResolverInput,
+  DecisionResult,
   FlowDefinition,
   FlowNodeCommon,
   FlowNodeContext,
@@ -56,12 +60,15 @@ import type {
   ShellActionResult,
 } from "./types.js";
 
-export { acp, action, checkpoint, compute, defineFlow, shell };
+export { acp, action, checkpoint, compute, decision, defineFlow, shell };
 export type {
   AcpNodeDefinition,
   ActionNodeDefinition,
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
+  DecisionNodeDefinition,
+  DecisionResolverInput,
+  DecisionResult,
   FlowDefinition,
   FlowEdge,
   FlowNodeCommon,
@@ -112,6 +119,7 @@ type TracedPromptResult = {
 
 export class FlowRunner {
   private readonly resolveAgent;
+  private readonly resolveDecision?;
   private readonly defaultCwd;
   private readonly permissionMode;
   private readonly mcpServers?;
@@ -129,6 +137,7 @@ export class FlowRunner {
 
   constructor(options: FlowRunnerOptions) {
     this.resolveAgent = options.resolveAgent;
+    this.resolveDecision = options.resolveDecision;
     this.defaultCwd = options.resolveAgent(undefined).cwd;
     this.permissionMode = options.permissionMode;
     this.mcpServers = options.mcpServers;
@@ -432,6 +441,8 @@ export class FlowRunner {
         return await this.executeCheckpointNode(runDir, state, nodeId, node, context);
       case "acp":
         return await this.executeAcpNode(runDir, state, flow, node, context);
+      case "decision":
+        return await this.executeDecisionNode(runDir, state, flow, node, context);
       default: {
         const exhaustive: never = node;
         throw new Error(`Unsupported flow node: ${String(exhaustive)}`);
@@ -462,6 +473,157 @@ export class FlowRunner {
       agentInfo: null,
       trace: null,
     };
+  }
+
+  private async executeDecisionNode(
+    runDir: string,
+    state: FlowRunState,
+    flow: FlowDefinition,
+    node: DecisionNodeDefinition,
+    context: FlowNodeContext,
+  ): Promise<FlowNodeExecutionResult> {
+    const nodeTimeoutMs = node.timeoutMs ?? this.defaultNodeTimeoutMs;
+
+    return await this.runWithHeartbeat(
+      runDir,
+      state,
+      state.currentNode ?? "",
+      node,
+      nodeTimeoutMs,
+      async () => {
+        const promptText = await Promise.resolve(node.prompt(context));
+        const optionKeys = Object.keys(node.options).join(", ");
+        this.updateStatusDetail(state, node.statusDetail ?? `Deciding: ${optionKeys}`);
+
+        if (this.resolveDecision) {
+          const result = await this.resolveDecision({
+            prompt: promptText,
+            options: node.options,
+            model: node.model,
+          });
+          validateDecisionResult(result, node.options);
+          return {
+            output: result,
+            promptText,
+            rawText: JSON.stringify(result),
+            sessionInfo: null,
+            agentInfo: null,
+            trace: null,
+          };
+        }
+
+        // Fallback: use an isolated ACP agent session with a structured prompt
+        const resolvedAgent = this.resolveAgent(node.profile);
+        const agentInfo = { ...resolvedAgent };
+
+        const optionLines = Object.entries(node.options)
+          .map(([id, desc]) => `  - "${id}": ${desc}`)
+          .join("\n");
+
+        const acpPrompt = [
+          promptText,
+          "",
+          "Choose exactly one of the following options:",
+          optionLines,
+          "",
+          "Respond with ONLY a JSON object in this exact format:",
+          '{"choice": "<option_id>", "reasoning": "<brief explanation>"}',
+          "",
+          "Do not include any other text.",
+        ].join("\n");
+
+        const isolatedBinding = createIsolatedSessionBinding(
+          flow.name,
+          state.runId,
+          state.currentAttemptId ?? randomUUID(),
+          node.profile,
+          agentInfo,
+        );
+        const initialIsolatedRecord = createSyntheticSessionRecord({
+          binding: isolatedBinding,
+          createdAt: state.currentNodeStartedAt ?? isoNow(),
+          updatedAt: state.currentNodeStartedAt ?? isoNow(),
+          conversation: createSessionConversation(state.currentNodeStartedAt ?? isoNow()),
+          acpxState: undefined,
+          lastSeq: 0,
+        });
+        await this.store.ensureSessionBundle(runDir, state, isolatedBinding, initialIsolatedRecord);
+
+        const promptArtifact = await this.store.writeArtifact(runDir, state, acpPrompt, {
+          mediaType: "text/plain",
+          extension: "txt",
+          nodeId: state.currentNode,
+          attemptId: state.currentAttemptId,
+        });
+
+        await this.store.appendTrace(runDir, state, {
+          scope: "acp",
+          type: "acp_prompt_prepared",
+          nodeId: state.currentNode,
+          attemptId: state.currentAttemptId,
+          sessionId: isolatedBinding.bundleId,
+          payload: { sessionId: isolatedBinding.bundleId, promptArtifact },
+        });
+
+        const isolatedPrompt = await this.runIsolatedPrompt(
+          runDir,
+          state,
+          isolatedBinding,
+          agentInfo,
+          normalizePromptInput(acpPrompt),
+          nodeTimeoutMs,
+        );
+
+        const rawResponseArtifact = await this.store.writeArtifact(
+          runDir,
+          state,
+          isolatedPrompt.rawText,
+          {
+            mediaType: "text/plain",
+            extension: "txt",
+            nodeId: state.currentNode,
+            attemptId: state.currentAttemptId,
+            sessionId: isolatedBinding.bundleId,
+          },
+        );
+        await this.store.appendTrace(runDir, state, {
+          scope: "acp",
+          type: "acp_response_parsed",
+          nodeId: state.currentNode,
+          attemptId: state.currentAttemptId,
+          sessionId: isolatedBinding.bundleId,
+          payload: {
+            sessionId: isolatedBinding.bundleId,
+            conversation: isolatedPrompt.conversation,
+            rawResponseArtifact,
+          },
+        });
+
+        const trace: FlowStepTrace = {
+          sessionId: isolatedBinding.bundleId,
+          promptArtifact,
+          rawResponseArtifact,
+          conversation: isolatedPrompt.conversation,
+        };
+
+        let parsed: DecisionResult;
+        try {
+          parsed = extractJsonObject(isolatedPrompt.rawText) as DecisionResult;
+          validateDecisionResult(parsed, node.options);
+        } catch (error) {
+          throw attachStepTrace(error, trace);
+        }
+
+        return {
+          output: parsed,
+          promptText: acpPrompt,
+          rawText: isolatedPrompt.rawText,
+          sessionInfo: isolatedBinding,
+          agentInfo,
+          trace,
+        };
+      },
+    );
   }
 
   private async executeActionNode(
@@ -1419,6 +1581,28 @@ function extractAttachedStepTrace(error: unknown): FlowStepTrace | null | undefi
     return undefined;
   }
   return (error as Error & { flowStepTrace?: FlowStepTrace | null }).flowStepTrace;
+}
+
+function validateDecisionResult(
+  result: unknown,
+  options: Record<string, string>,
+): asserts result is DecisionResult {
+  if (
+    result == null ||
+    typeof result !== "object" ||
+    typeof (result as DecisionResult).choice !== "string" ||
+    typeof (result as DecisionResult).reasoning !== "string"
+  ) {
+    throw new Error(
+      `Decision result must have shape { choice: string, reasoning: string }, got: ${JSON.stringify(result)}`,
+    );
+  }
+  const choice = (result as DecisionResult).choice;
+  if (!(choice in options)) {
+    throw new Error(
+      `Decision choice "${choice}" is not one of the valid options: ${Object.keys(options).join(", ")}`,
+    );
+  }
 }
 
 function toInlineOutput(value: unknown): undefined | null | boolean | number | string | object {

--- a/src/flows/store.ts
+++ b/src/flows/store.ts
@@ -452,6 +452,14 @@ function snapshotNode(node: FlowNodeDefinition) {
         ...(node.summary ? { summary: node.summary } : {}),
         hasRun: typeof node.run === "function",
       };
+    case "decision":
+      return {
+        ...common,
+        options: structuredClone(node.options),
+        ...(node.profile ? { profile: node.profile } : {}),
+        ...(node.model ? { model: node.model } : {}),
+        hasPrompt: true,
+      };
   }
 }
 

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -124,7 +124,7 @@ export type DecisionResolverInput = {
 
 export type DecisionResult = {
   choice: string;
-  reasoning: string;
+  reasoning?: string;
 };
 
 export type FlowNodeDefinition =

--- a/src/flows/types.ts
+++ b/src/flows/types.ts
@@ -108,11 +108,31 @@ export type CheckpointNodeDefinition = FlowNodeCommon & {
   run?: (context: FlowNodeContext) => MaybePromise<unknown>;
 };
 
+export type DecisionNodeDefinition = FlowNodeCommon & {
+  nodeType: "decision";
+  prompt: (context: FlowNodeContext) => MaybePromise<string>;
+  options: Record<string, string>;
+  model?: string;
+  profile?: string;
+};
+
+export type DecisionResolverInput = {
+  prompt: string;
+  options: Record<string, string>;
+  model?: string;
+};
+
+export type DecisionResult = {
+  choice: string;
+  reasoning: string;
+};
+
 export type FlowNodeDefinition =
   | AcpNodeDefinition
   | ComputeNodeDefinition
   | ActionNodeDefinition
-  | CheckpointNodeDefinition;
+  | CheckpointNodeDefinition
+  | DecisionNodeDefinition;
 
 export type FlowPermissionRequirements = {
   requiredMode: PermissionMode;
@@ -132,6 +152,7 @@ export type FlowDefinition = {
 export type FlowNodeSnapshot = FlowNodeCommon & {
   nodeType: FlowNodeDefinition["nodeType"];
   profile?: string;
+  model?: string;
   session?: {
     handle?: string;
     isolated?: boolean;
@@ -141,6 +162,7 @@ export type FlowNodeSnapshot = FlowNodeCommon & {
     value?: string;
   };
   summary?: string;
+  options?: Record<string, string>;
   actionExecution?: "function" | "shell";
   hasPrompt?: boolean;
   hasParse?: boolean;
@@ -339,6 +361,7 @@ export type ResolvedFlowAgent = {
 
 export type FlowRunnerOptions = {
   resolveAgent: (profile?: string) => ResolvedFlowAgent;
+  resolveDecision?: (input: DecisionResolverInput) => Promise<DecisionResult>;
   permissionMode: PermissionMode;
   mcpServers?: McpServer[];
   nonInteractivePermissions?: NonInteractivePermissionPolicy;

--- a/test/flows.test.ts
+++ b/test/flows.test.ts
@@ -11,6 +11,7 @@ import {
   action,
   checkpoint,
   compute,
+  decision,
   defineFlow,
   shell,
 } from "../src/flows/runtime.js";
@@ -1200,6 +1201,193 @@ test("FlowRunner stores successful node results separately from outputs", async 
     assert.equal(result.state.results.first?.outcome, "ok");
     assert.deepEqual(result.state.outputs.first, { next: "done" });
     assert.deepEqual(result.state.outputs.done, { firstOutcome: "ok" });
+  });
+});
+
+test("FlowRunner executes decision node with resolveDecision and routes via switch edge", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-"));
+    try {
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd: outputRoot,
+        }),
+        permissionMode: "approve-all",
+        resolveDecision: async ({ options }) => {
+          return { choice: Object.keys(options)[0]!, reasoning: "test pick" };
+        },
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "decision-route-test",
+        startAt: "decide",
+        nodes: {
+          decide: decision({
+            prompt: (ctx) => `Evaluate tone for ${(ctx.input as { audience: string }).audience}`,
+            options: {
+              good: "Tone is appropriate",
+              too_formal: "Too formal",
+              too_casual: "Too casual",
+            },
+          }),
+          good_path: compute({ run: () => ({ result: "good" }) }),
+          formal_path: compute({ run: () => ({ result: "formal" }) }),
+          casual_path: compute({ run: () => ({ result: "casual" }) }),
+        },
+        edges: [
+          {
+            from: "decide",
+            switch: {
+              on: "$.choice",
+              cases: {
+                good: "good_path",
+                too_formal: "formal_path",
+                too_casual: "casual_path",
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await runner.run(flow, { audience: "engineers" });
+      assert.equal(result.state.status, "completed");
+      assert.deepEqual(result.state.outputs.good_path, { result: "good" });
+      assert.equal(result.state.outputs.formal_path, undefined);
+      assert.equal(result.state.outputs.casual_path, undefined);
+      const decisionOutput = result.state.outputs.decide as {
+        choice: string;
+        reasoning: string;
+      };
+      assert.equal(decisionOutput.choice, "good");
+      assert.equal(decisionOutput.reasoning, "test pick");
+    } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test("FlowRunner decision node rejects invalid choice not in options", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-invalid-"));
+    try {
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd: outputRoot,
+        }),
+        permissionMode: "approve-all",
+        resolveDecision: async () => ({
+          choice: "nonexistent",
+          reasoning: "bad choice",
+        }),
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "decision-invalid-test",
+        startAt: "decide",
+        nodes: {
+          decide: decision({
+            prompt: () => "Pick one",
+            options: { a: "Option A", b: "Option B" },
+          }),
+        },
+        edges: [],
+      });
+
+      await assert.rejects(async () => await runner.run(flow, {}), /not one of the valid options/);
+
+      const runDir = await waitForRunDir(outputRoot, "decision-invalid-test");
+      const state = await readRunJson(runDir);
+      assert.equal(state.status, "failed");
+      assert.match(String(state.error), /not one of the valid options/);
+    } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test("FlowRunner decision node prompt receives upstream outputs in context", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-ctx-"));
+    try {
+      let capturedPrompt = "";
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd: outputRoot,
+        }),
+        permissionMode: "approve-all",
+        resolveDecision: async ({ prompt }) => {
+          capturedPrompt = prompt;
+          return { choice: "yes", reasoning: "looks good" };
+        },
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "decision-context-test",
+        startAt: "prep",
+        nodes: {
+          prep: compute({ run: () => ({ summary: "all good" }) }),
+          decide: decision({
+            prompt: (ctx) => `Review: ${(ctx.outputs.prep as { summary: string }).summary}`,
+            options: { yes: "Approved", no: "Rejected" },
+          }),
+        },
+        edges: [{ from: "prep", to: "decide" }],
+      });
+
+      const result = await runner.run(flow, {});
+      assert.equal(result.state.status, "completed");
+      assert.equal(capturedPrompt, "Review: all good");
+    } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test("FlowRunner decision node rejects result with missing reasoning field", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-shape-"));
+    try {
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd: outputRoot,
+        }),
+        permissionMode: "approve-all",
+        resolveDecision: async () => ({ choice: "a" }) as never,
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "decision-shape-test",
+        startAt: "decide",
+        nodes: {
+          decide: decision({
+            prompt: () => "Pick",
+            options: { a: "A", b: "B" },
+          }),
+        },
+        edges: [],
+      });
+
+      await assert.rejects(async () => await runner.run(flow, {}), /must have shape/);
+
+      const runDir = await waitForRunDir(outputRoot, "decision-shape-test");
+      const state = await readRunJson(runDir);
+      assert.equal(state.status, "failed");
+      assert.match(String(state.error), /must have shape/);
+    } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/flows.test.ts
+++ b/test/flows.test.ts
@@ -1352,9 +1352,9 @@ test("FlowRunner decision node prompt receives upstream outputs in context", asy
   });
 });
 
-test("FlowRunner decision node rejects result with missing reasoning field", async () => {
+test("FlowRunner decision node accepts result without reasoning field", async () => {
   await withTempHome(async () => {
-    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-shape-"));
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-no-reason-"));
     try {
       const runner = new FlowRunner({
         resolveAgent: () => ({
@@ -1368,7 +1368,7 @@ test("FlowRunner decision node rejects result with missing reasoning field", asy
       });
 
       const flow = defineFlow({
-        name: "decision-shape-test",
+        name: "decision-no-reason-test",
         startAt: "decide",
         nodes: {
           decide: decision({
@@ -1379,13 +1379,107 @@ test("FlowRunner decision node rejects result with missing reasoning field", asy
         edges: [],
       });
 
-      await assert.rejects(async () => await runner.run(flow, {}), /must have shape/);
+      const result = await runner.run(flow, {});
+      assert.equal(result.state.status, "completed");
+      assert.equal((result.state.outputs.decide as { choice: string }).choice, "a");
+    } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+});
 
-      const runDir = await waitForRunDir(outputRoot, "decision-shape-test");
+test("FlowRunner decision node rejects non-string reasoning", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-bad-reason-"));
+    try {
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd: outputRoot,
+        }),
+        permissionMode: "approve-all",
+        resolveDecision: async () => ({ choice: "a", reasoning: 42 }) as never,
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "decision-bad-reason-test",
+        startAt: "decide",
+        nodes: {
+          decide: decision({
+            prompt: () => "Pick",
+            options: { a: "A", b: "B" },
+          }),
+        },
+        edges: [],
+      });
+
+      await assert.rejects(async () => await runner.run(flow, {}), /reasoning must be a string/);
+
+      const runDir = await waitForRunDir(outputRoot, "decision-bad-reason-test");
       const state = await readRunJson(runDir);
       assert.equal(state.status, "failed");
-      assert.match(String(state.error), /must have shape/);
+      assert.match(String(state.error), /reasoning must be a string/);
     } finally {
+      await fs.rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test("FlowRunner decision node falls back to isolated ACP session when no resolveDecision", async () => {
+  await withTempHome(async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-acp-cwd-"));
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-decision-acp-"));
+    try {
+      const runner = new FlowRunner({
+        resolveAgent: () => ({
+          agentName: "mock",
+          agentCommand: MOCK_AGENT_COMMAND,
+          cwd,
+        }),
+        permissionMode: "approve-all",
+        ttlMs: 1_000,
+        outputRoot,
+      });
+
+      const flow = defineFlow({
+        name: "decision-acp-fallback",
+        startAt: "decide",
+        nodes: {
+          decide: decision({
+            prompt: () => 'echo {"choice":"approve","reasoning":"looks good"}',
+            options: { approve: "Approved", reject: "Rejected" },
+          }),
+          approved: compute({ run: () => ({ result: "approved" }) }),
+          rejected: compute({ run: () => ({ result: "rejected" }) }),
+        },
+        edges: [
+          {
+            from: "decide",
+            switch: {
+              on: "$.choice",
+              cases: {
+                approve: "approved",
+                reject: "rejected",
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await runner.run(flow, {});
+      assert.equal(result.state.status, "completed");
+      const decisionOutput = result.state.outputs.decide as {
+        choice: string;
+        reasoning: string;
+      };
+      assert.equal(decisionOutput.choice, "approve");
+      assert.equal(decisionOutput.reasoning, "looks good");
+      assert.deepEqual(result.state.outputs.approved, { result: "approved" });
+      assert.equal(result.state.outputs.rejected, undefined);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
       await fs.rm(outputRoot, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- Adds a first-class `decision` node type to ACPX flows for single constrained LLM calls that return validated `{ choice, reasoning? }` results
- Adds `resolveDecision` callback on `FlowRunnerOptions` — keeps ACPX provider-agnostic while enabling callers to inject structured output implementations (OpenAI `response_format`, Anthropic `tool_use`, etc.)
- Falls back to isolated ACP agent session with structured prompt + `extractJsonObject` parse when no resolver is provided
- Validates `choice ∈ options` at runtime; invalid choices fail the node
- `reasoning` is optional — resolvers that don't need to explain themselves can omit it
- Extracts shared `runIsolatedAcpPromptWithTrace` helper to deduplicate the isolated session path between `executeAcpNode` and `executeDecisionNode`
- Output feeds naturally into existing `switch` edges via `$.choice`

### Usage

```ts
import { decision, defineFlow, compute } from "acpx/flows";

const flow = defineFlow({
  name: "tone-review",
  startAt: "check_tone",
  nodes: {
    check_tone: decision({
      prompt: (ctx) => `Is the tone right for ${ctx.input.audience}?`,
      options: {
        good: "Tone is appropriate",
        too_formal: "Too formal, needs loosening",
        too_casual: "Too casual, needs tightening",
      },
    }),
    publish: compute({ run: () => ({ status: "published" }) }),
    revise: compute({ run: () => ({ status: "needs_revision" }) }),
  },
  edges: [
    {
      from: "check_tone",
      switch: {
        on: "$.choice",
        cases: {
          good: "publish",
          too_formal: "revise",
          too_casual: "revise",
        },
      },
    },
  ],
});
```

### Files changed

| File | Change |
|---|---|
| `src/flows/types.ts` | `DecisionNodeDefinition`, `DecisionResolverInput`, `DecisionResult` types; `resolveDecision` on `FlowRunnerOptions`; `reasoning` optional |
| `src/flows/definition.ts` | `decision()` builder helper |
| `src/flows/runtime.ts` | `executeDecisionNode`, `validateDecisionResult`, ACP fallback, `runIsolatedAcpPromptWithTrace` shared helper |
| `src/flows/store.ts` | Snapshot serialization for decision nodes |
| `src/flows.ts` | Public exports |
| `test/flows.test.ts` | 7 test cases (routing, invalid choice, context propagation, optional reasoning, bad reasoning type, ACP fallback) |

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [x] `pnpm run test` — 0 failures (7 new decision tests + all existing tests pass)
- [x] Pre-commit hooks (oxfmt, oxlint, build) pass

🤖 AI-assisted (Claude Code) — fully tested

Generated with [Claude Code](https://claude.com/claude-code)