### PR TITLE
fix: honor --model for reconnect prompts

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -86,6 +86,7 @@ import { extractAcpError } from "./error-shapes.js";
 import { isSessionUpdateNotification } from "./jsonrpc.js";
 import {
   formatSessionControlAcpSummary,
+  isLikelySessionControlUnsupportedError,
   maybeWrapSessionControlError,
 } from "./session-control-errors.js";
 import { TerminalManager } from "./terminal-manager.js";
@@ -234,6 +235,21 @@ function createNdJsonMessageStream(
   return { readable, writable };
 }
 
+function resolveModelIdFromConfigOptionResponse(
+  response: SetSessionConfigOptionResponse,
+  fallbackModelId: string,
+): string {
+  for (const option of response.configOptions) {
+    if (option.id !== "model") {
+      continue;
+    }
+    if (typeof option.currentValue === "string" && option.currentValue.trim().length > 0) {
+      return option.currentValue;
+    }
+  }
+  return fallbackModelId;
+}
+
 export class AcpClient {
   private options: AcpClientOptions;
   private connection?: ClientSideConnection;
@@ -346,6 +362,21 @@ export class AcpClient {
 
   clearEventHandlers(): void {
     this.eventHandlers = {};
+  }
+
+  updateSessionOptions(update: Partial<NonNullable<AcpClientOptions["sessionOptions"]>>): void {
+    if (!this.options.sessionOptions) {
+      this.options.sessionOptions = {};
+    }
+    if (update.model !== undefined) {
+      this.options.sessionOptions.model = update.model;
+    }
+    if (update.allowedTools !== undefined) {
+      this.options.sessionOptions.allowedTools = update.allowedTools;
+    }
+    if (update.maxTurns !== undefined) {
+      this.options.sessionOptions.maxTurns = update.maxTurns;
+    }
   }
 
   updateRuntimeOptions(options: {
@@ -682,6 +713,7 @@ export class AcpClient {
           sessionId,
           cwd: asAbsoluteCwd(cwd),
           mcpServers: this.options.mcpServers ?? [],
+          _meta: buildClaudeCodeOptionsMeta(this.options.sessionOptions),
         }),
       );
 
@@ -769,6 +801,46 @@ export class AcpClient {
     value: string,
   ): Promise<SetSessionConfigOptionResponse> {
     const connection = this.getConnection();
+    // For model changes: prefer session/set_config_option (supports alias resolution
+    // via resolveModelPreference on Claude adapter) then fall back to session/set_model
+    // for adapters like Droid that only support the dedicated method.
+    if (configId === "model") {
+      try {
+        const response = await this.runConnectionRequest(() =>
+          connection.setSessionConfigOption({
+            sessionId,
+            configId,
+            value,
+          }),
+        );
+        const resolvedModelId = resolveModelIdFromConfigOptionResponse(response, value);
+        await this.tryApplySessionModelAfterConfigOption(sessionId, resolvedModelId);
+        return response;
+      } catch (error) {
+        const acp = extractAcpError(error);
+        if (acp && isLikelySessionControlUnsupportedError(acp)) {
+          // Adapter doesn't support set_config_option — fall back to set_model
+          try {
+            await this.runConnectionRequest(() =>
+              connection.unstable_setSessionModel({ sessionId, modelId: value }),
+            );
+            return { configOptions: [] };
+          } catch (fallbackError) {
+            throw maybeWrapSessionControlError(
+              "session/set_model",
+              fallbackError,
+              `for model="${value}"`,
+            );
+          }
+        }
+        throw maybeWrapSessionControlError(
+          "session/set_config_option",
+          error,
+          `for "model"="${value}"`,
+        );
+      }
+    }
+
     try {
       return await this.runConnectionRequest(() =>
         connection.setSessionConfigOption({
@@ -783,6 +855,36 @@ export class AcpClient {
         error,
         `for "${configId}"="${value}"`,
       );
+    }
+  }
+
+  private async tryApplySessionModelAfterConfigOption(
+    sessionId: string,
+    modelId: string,
+  ): Promise<void> {
+    const connection = this.getConnection();
+    try {
+      await this.runConnectionRequest(() =>
+        connection.unstable_setSessionModel({
+          sessionId,
+          modelId,
+        }),
+      );
+    } catch (error) {
+      const acp = extractAcpError(error);
+      if (acp && isLikelySessionControlUnsupportedError(acp)) {
+        return;
+      }
+      if (this.options.verbose) {
+        const summary = acp
+          ? formatSessionControlAcpSummary(acp)
+          : error instanceof Error
+            ? error.message
+            : String(error);
+        process.stderr.write(
+          `[acpx] warning: session/set_model after session/set_config_option failed: ${summary}\n`,
+        );
+      }
     }
   }
 

--- a/src/acp/session-control-errors.ts
+++ b/src/acp/session-control-errors.ts
@@ -9,7 +9,7 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
-function isLikelySessionControlUnsupportedError(acp: {
+export function isLikelySessionControlUnsupportedError(acp: {
   code: number;
   message: string;
   data?: unknown;

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -233,6 +233,11 @@ export async function handlePrompt(
     promptRetries: globalFlags.promptRetries,
     verbose: globalFlags.verbose,
     waitForCompletion: flags.wait !== false,
+    sessionOptions: {
+      model: globalFlags.model,
+      allowedTools: globalFlags.allowedTools,
+      maxTurns: globalFlags.maxTurns,
+    },
   });
 
   if ("queued" in result) {

--- a/src/cli/queue/ipc-server.ts
+++ b/src/cli/queue/ipc-server.ts
@@ -4,6 +4,7 @@ import { normalizeOutputError } from "../../acp/error-normalization.js";
 import { recordPerfDuration } from "../../perf-metrics.js";
 import { textPrompt } from "../../prompt-content.js";
 import type {
+  AcpClientOptions,
   NonInteractivePermissionPolicy,
   PermissionMode,
   PromptInput,
@@ -83,6 +84,7 @@ export type QueueTask = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   timeoutMs?: number;
   suppressSdkConsoleErrors?: boolean;
+  sessionOptions?: NonNullable<AcpClientOptions["sessionOptions"]>;
   waitForCompletion: boolean;
   enqueuedAt: number;
   send: (message: QueueOwnerMessage) => void;
@@ -451,6 +453,7 @@ export class SessionQueueOwner {
         nonInteractivePermissions: request.nonInteractivePermissions,
         timeoutMs: request.timeoutMs,
         suppressSdkConsoleErrors: request.suppressSdkConsoleErrors,
+        sessionOptions: request.sessionOptions,
         waitForCompletion: request.waitForCompletion,
         enqueuedAt: Date.now(),
         send: (message) => {

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -3,6 +3,7 @@ import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { QueueConnectionError, QueueProtocolError } from "../../errors.js";
 import { incrementPerfCounter } from "../../perf-metrics.js";
 import type {
+  AcpClientOptions,
   NonInteractivePermissionPolicy,
   OutputErrorEmissionPolicy,
   OutputFormatter,
@@ -269,6 +270,7 @@ export type SubmitToQueueOwnerOptions = {
   suppressSdkConsoleErrors?: boolean;
   waitForCompletion: boolean;
   verbose?: boolean;
+  sessionOptions?: NonNullable<AcpClientOptions["sessionOptions"]>;
 };
 
 async function submitToQueueOwner(
@@ -288,6 +290,7 @@ async function submitToQueueOwner(
     timeoutMs: options.timeoutMs,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     waitForCompletion: options.waitForCompletion,
+    sessionOptions: options.sessionOptions,
   };
 
   options.outputFormatter.setContext({

--- a/src/cli/queue/messages.ts
+++ b/src/cli/queue/messages.ts
@@ -4,6 +4,7 @@ import { isPromptInput, textPrompt } from "../../prompt-content.js";
 import {
   OUTPUT_ERROR_CODES,
   OUTPUT_ERROR_ORIGINS,
+  type AcpClientOptions,
   type OutputErrorAcpPayload,
   type OutputErrorCode,
   type OutputErrorOrigin,
@@ -17,6 +18,8 @@ import type {
   SessionSendResult,
 } from "../../types.js";
 
+type QueueSessionOptions = NonNullable<AcpClientOptions["sessionOptions"]>;
+
 export type QueueSubmitRequest = {
   type: "submit_prompt";
   requestId: string;
@@ -29,6 +32,7 @@ export type QueueSubmitRequest = {
   timeoutMs?: number;
   suppressSdkConsoleErrors?: boolean;
   waitForCompletion: boolean;
+  sessionOptions?: QueueSessionOptions;
 };
 
 export type QueueCancelRequest = {
@@ -186,6 +190,43 @@ function parseAcpError(value: unknown): OutputErrorAcpPayload | undefined {
   };
 }
 
+function parseSessionOptions(value: unknown): QueueSessionOptions | null | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const sessionOptions: QueueSessionOptions = {};
+
+  if (record.model != null) {
+    if (typeof record.model !== "string" || record.model.trim().length === 0) {
+      return null;
+    }
+    sessionOptions.model = record.model;
+  }
+  if (record.allowedTools != null) {
+    if (!Array.isArray(record.allowedTools)) {
+      return null;
+    }
+    const allowedTools = record.allowedTools.filter((tool): tool is string => typeof tool === "string");
+    if (allowedTools.length !== record.allowedTools.length) {
+      return null;
+    }
+    sessionOptions.allowedTools = allowedTools;
+  }
+  if (record.maxTurns != null) {
+    if (typeof record.maxTurns !== "number" || !Number.isFinite(record.maxTurns)) {
+      return null;
+    }
+    sessionOptions.maxTurns = Math.max(1, Math.round(record.maxTurns));
+  }
+
+  return sessionOptions;
+}
+
 function parseOwnerGeneration(value: unknown): number | undefined | null {
   if (value == null) {
     return undefined;
@@ -235,6 +276,7 @@ export function parseQueueRequest(raw: unknown): QueueRequest | null {
         : typeof request.suppressSdkConsoleErrors === "boolean"
           ? request.suppressSdkConsoleErrors
           : null;
+    const sessionOptions = parseSessionOptions(request.sessionOptions);
 
     const prompt =
       request.prompt == null ? undefined : isPromptInput(request.prompt) ? request.prompt : null;
@@ -245,6 +287,7 @@ export function parseQueueRequest(raw: unknown): QueueRequest | null {
       prompt === null ||
       nonInteractivePermissions === null ||
       suppressSdkConsoleErrors === null ||
+      sessionOptions === null ||
       typeof request.waitForCompletion !== "boolean"
     ) {
       return null;
@@ -262,6 +305,7 @@ export function parseQueueRequest(raw: unknown): QueueRequest | null {
       timeoutMs,
       ...(suppressSdkConsoleErrors !== undefined ? { suppressSdkConsoleErrors } : {}),
       waitForCompletion: request.waitForCompletion,
+      ...(sessionOptions !== undefined ? { sessionOptions } : {}),
     };
   }
 

--- a/src/cli/queue/owner-env.ts
+++ b/src/cli/queue/owner-env.ts
@@ -79,6 +79,22 @@ export function parseQueueOwnerPayload(raw: string): QueueOwnerRuntimeOptions {
     options.promptRetries = Math.max(0, Math.round(record.promptRetries));
   }
 
+  const sessionOpts = asRecord(record.sessionOptions);
+  if (sessionOpts) {
+    options.sessionOptions = {};
+    if (typeof sessionOpts.model === "string" && sessionOpts.model.trim().length > 0) {
+      options.sessionOptions.model = sessionOpts.model;
+    }
+    if (Array.isArray(sessionOpts.allowedTools)) {
+      options.sessionOptions.allowedTools = sessionOpts.allowedTools.filter(
+        (t): t is string => typeof t === "string",
+      );
+    }
+    if (typeof sessionOpts.maxTurns === "number" && Number.isFinite(sessionOpts.maxTurns)) {
+      options.sessionOptions.maxTurns = Math.max(1, Math.round(sessionOpts.maxTurns));
+    }
+  }
+
   return options;
 }
 

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -89,6 +89,7 @@ export type SessionSendOptions = {
   maxQueueDepth?: number;
   client?: AcpClient;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
 } & TimedRunOptions;
 
 export type SessionEnsureOptions = {

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
+import type { SessionAgentOptions } from "../../runtime/engine/session-options.js";
 import type {
   AuthPolicy,
   McpServer,
@@ -19,6 +20,7 @@ export type QueueOwnerRuntimeOptions = {
   ttlMs?: number;
   maxQueueDepth?: number;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
 };
 
 type SessionSendLike = {
@@ -33,6 +35,7 @@ type SessionSendLike = {
   ttlMs?: number;
   maxQueueDepth?: number;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
 };
 
 export function sanitizeQueueOwnerExecArgv(
@@ -131,6 +134,7 @@ export function queueOwnerRuntimeOptionsFromSend(
     ttlMs: options.ttlMs,
     maxQueueDepth: options.maxQueueDepth,
     promptRetries: options.promptRetries,
+    sessionOptions: options.sessionOptions,
   };
 }
 

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -5,7 +5,7 @@ import { checkpointPerfMetricsCapture } from "../../perf-metrics-capture.js";
 import { setPerfGauge } from "../../perf-metrics.js";
 import { promptToDisplayText } from "../../prompt-content.js";
 import { applyLifecycleSnapshotToRecord } from "../../runtime/engine/lifecycle.js";
-import { sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
+import { mergeSessionOptions, sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
 import {
   absolutePath,
   resolveSessionRecord,
@@ -17,6 +17,7 @@ import {
   SessionQueueOwner,
   releaseQueueOwnerLease,
   tryAcquireQueueOwnerLease,
+  trySetConfigOptionOnRunningOwner,
   trySubmitToRunningOwner,
   waitMs,
 } from "../queue/ipc.js";
@@ -56,6 +57,7 @@ async function submitToRunningOwner(
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     waitForCompletion,
     verbose: options.verbose,
+    sessionOptions: options.sessionOptions,
   });
 }
 
@@ -78,7 +80,10 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     authPolicy: options.authPolicy,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
-    sessionOptions: sessionOptionsFromRecord(sessionRecord),
+    sessionOptions: mergeSessionOptions(
+      options.sessionOptions,
+      sessionOptionsFromRecord(sessionRecord),
+    ),
   });
   const ttlMs = normalizeQueueOwnerTtlMs(options.ttlMs);
   const maxQueueDepth = Math.max(1, Math.round(options.maxQueueDepth ?? 16));
@@ -112,6 +117,25 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
       });
     },
     setSessionConfigOptionFallback: async (configId: string, value: string, timeoutMs?: number) => {
+      // If the sharedClient has a reusable session, route through it directly
+      // instead of creating a temporary connection that doesn't affect the live session.
+      const currentRecord = await resolveSessionRecord(options.sessionId);
+      if (sharedClient.hasReusableSession(currentRecord.acpSessionId)) {
+        const response = await withTimeout(
+          (async () =>
+            await sharedClient.setSessionConfigOption(
+              currentRecord.acpSessionId,
+              configId,
+              value,
+            ))(),
+          timeoutMs,
+        );
+        if (configId === "model") {
+          sharedClient.updateSessionOptions({ model: value });
+        }
+        return response;
+      }
+
       const result = await runSessionSetConfigOptionDirect({
         sessionRecordId: options.sessionId,
         configId,
@@ -123,6 +147,10 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
         timeoutMs,
         verbose: options.verbose,
       });
+      // Update sharedClient session options so future reconnects use the latest model.
+      if (configId === "model") {
+        sharedClient.updateSessionOptions({ model: value });
+      }
       return result.response;
     },
   });
@@ -226,6 +254,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
             authPolicy: options.authPolicy,
             suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
             promptRetries: options.promptRetries,
+            sessionOptions: options.sessionOptions,
             onClientAvailable: setActiveController,
             onClientClosed: clearActiveController,
             onPromptActive: async () => {
@@ -266,6 +295,24 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
 
 export async function sendSession(options: SessionSendOptions): Promise<SessionSendOutcome> {
   const waitForCompletion = options.waitForCompletion !== false;
+
+  // If a model is requested and an owner is already running, update the model
+  // before submitting the prompt.
+  if (options.sessionOptions?.model) {
+    await trySetConfigOptionOnRunningOwner(
+      options.sessionId,
+      "model",
+      options.sessionOptions.model,
+      options.timeoutMs,
+      options.verbose,
+    ).catch((err: unknown) => {
+      if (options.verbose) {
+        process.stderr.write(
+          `[acpx] warning: failed to pre-set model on running owner: ${formatErrorMessage(err)}\n`,
+        );
+      }
+    });
+  }
 
   const queuedToOwner = await submitToRunningOwner(options, waitForCompletion);
   if (queuedToOwner) {

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -14,7 +14,11 @@ import {
 } from "../../runtime/engine/lifecycle.js";
 import { runPromptTurn } from "../../runtime/engine/prompt-turn.js";
 import { connectAndLoadSession } from "../../runtime/engine/reconnect.js";
-import { sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
+import {
+  mergeSessionOptions,
+  sessionOptionsFromRecord,
+  type SessionAgentOptions,
+} from "../../runtime/engine/session-options.js";
 import {
   cloneSessionAcpxState,
   cloneSessionConversation,
@@ -24,7 +28,7 @@ import {
   trimConversationForRuntime,
 } from "../../session/conversation-model.js";
 import { SessionEventWriter } from "../../session/events.js";
-import { absolutePath, isoNow, resolveSessionRecord } from "../../session/persistence.js";
+import { absolutePath, isoNow, resolveSessionRecord, writeSessionRecord } from "../../session/persistence.js";
 import type {
   AcpJsonRpcMessage,
   AcpMessageDirection,
@@ -66,6 +70,7 @@ type RunSessionPromptOptions = {
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
   onClientAvailable?: (controller: ActiveSessionController) => void;
   onClientClosed?: () => void;
   onPromptActive?: () => Promise<void> | void;
@@ -274,6 +279,7 @@ export async function runQueuedTask(
     authPolicy?: AuthPolicy;
     suppressSdkConsoleErrors?: boolean;
     promptRetries?: number;
+    sessionOptions?: SessionAgentOptions;
     onClientAvailable?: (controller: ActiveSessionController) => void;
     onClientClosed?: () => void;
     onPromptActive?: () => Promise<void> | void;
@@ -299,11 +305,20 @@ export async function runQueuedTask(
       suppressSdkConsoleErrors: task.suppressSdkConsoleErrors ?? options.suppressSdkConsoleErrors,
       verbose: options.verbose,
       promptRetries: options.promptRetries,
+      sessionOptions: mergeSessionOptions(task.sessionOptions, options.sessionOptions),
       onClientAvailable: options.onClientAvailable,
       onClientClosed: options.onClientClosed,
       onPromptActive: options.onPromptActive,
       client: options.sharedClient,
     });
+
+    // Persist the record after each prompt so control commands see updated acpSessionId
+    // if loadSession fallback recreated the backend session.
+    if (result.record) {
+      await writeSessionRecord(result.record).catch(() => {
+        // best effort — control commands still work via sharedClient
+      });
+    }
 
     if (task.waitForCompletion) {
       task.send({
@@ -398,7 +413,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       authPolicy: options.authPolicy,
       suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
       verbose: options.verbose,
-      sessionOptions: sessionOptionsFromRecord(record),
+      sessionOptions: mergeSessionOptions(options.sessionOptions, sessionOptionsFromRecord(record)),
     });
   client.updateRuntimeOptions({
     permissionMode: options.permissionMode,
@@ -502,6 +517,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
           process.stderr.write(
             `[acpx] ${formatPerfMetric("prompt.connect_and_load", Date.now() - connectStartedAt)}\n`,
           );
+        }
+
+        if (options.sessionOptions?.model) {
+          await client.setSessionConfigOption(activeSessionId, "model", options.sessionOptions.model);
         }
 
         output.setContext({
@@ -789,6 +808,7 @@ export async function sendSessionDirect(options: SessionSendOptions): Promise<Se
     timeoutMs: options.timeoutMs,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
+    sessionOptions: options.sessionOptions,
     client: options.client,
   });
 }

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -12,7 +12,11 @@ import type {
 } from "../../types.js";
 import { applyLifecycleSnapshotToRecord } from "./lifecycle.js";
 import { connectAndLoadSession, type ConnectedSessionController } from "./reconnect.js";
-import { sessionOptionsFromRecord } from "./session-options.js";
+import {
+  mergeSessionOptions,
+  sessionOptionsFromRecord,
+  type SessionAgentOptions,
+} from "./session-options.js";
 
 export type FullConnectedSessionController = ConnectedSessionController & {
   setSessionModel: (modelId: string) => Promise<void>;
@@ -44,6 +48,7 @@ export type WithConnectedSessionOptions<T> = {
   resumePolicy?: SessionResumePolicy;
   timeoutMs?: number;
   verbose?: boolean;
+  sessionOptions?: SessionAgentOptions;
   onClientAvailable?: (controller: FullConnectedSessionController) => void;
   onClientClosed?: () => void;
   onConnectedRecord?: (record: SessionRecord) => void;
@@ -92,7 +97,7 @@ export async function withConnectedSession<T>(
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
       verbose: options.verbose,
-      sessionOptions: sessionOptionsFromRecord(record),
+      sessionOptions: mergeSessionOptions(options.sessionOptions, sessionOptionsFromRecord(record)),
     }) ??
     new AcpClient({
       agentCommand: record.agentCommand,
@@ -103,7 +108,7 @@ export async function withConnectedSession<T>(
       authCredentials: options.authCredentials,
       authPolicy: options.authPolicy,
       verbose: options.verbose,
-      sessionOptions: sessionOptionsFromRecord(record),
+      sessionOptions: mergeSessionOptions(options.sessionOptions, sessionOptionsFromRecord(record)),
     });
   let activeSessionIdForControl = record.acpSessionId;
   let notifiedClientAvailable = false;

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -6,6 +6,25 @@ export type SessionAgentOptions = {
   maxTurns?: number;
 };
 
+export function mergeSessionOptions(
+  preferred: SessionAgentOptions | undefined,
+  fallback: SessionAgentOptions | undefined,
+): SessionAgentOptions | undefined {
+  const merged: SessionAgentOptions = {
+    ...fallback,
+  };
+  if (preferred?.model !== undefined) {
+    merged.model = preferred.model;
+  }
+  if (preferred?.allowedTools !== undefined) {
+    merged.allowedTools = preferred.allowedTools;
+  }
+  if (preferred?.maxTurns !== undefined) {
+    merged.maxTurns = preferred.maxTurns;
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 export function sessionOptionsFromRecord(record: SessionRecord): SessionAgentOptions | undefined {
   const stored = record.acpx?.session_options;
   if (!stored) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -972,6 +972,48 @@ test("integration: exec --model skips session/set_model when agent does not adve
   });
 });
 
+test("integration: prompt --model updates existing session model before prompt", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const ensured = await runCli(
+        [...baseAgentArgs(cwd), "sessions", "ensure", "--name", "model-prompt-session"],
+        homeDir,
+      );
+      assert.equal(ensured.code, 0, ensured.stderr);
+
+      const result = await runCli(
+        [
+          ...baseAgentArgs(cwd),
+          "--format",
+          "json",
+          "--model",
+          "haiku",
+          "prompt",
+          "-s",
+          "model-prompt-session",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const setConfigRequest = payloads.find(
+        (payload) =>
+          payload.method === "session/set_config_option" &&
+          (payload.params as { configId?: string; value?: string } | undefined)?.configId ===
+            "model" &&
+          (payload.params as { configId?: string; value?: string } | undefined)?.value === "haiku",
+      );
+      assert(setConfigRequest, "expected session/set_config_option for model=haiku");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec --model fails when session/set_model fails", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));


### PR DESCRIPTION
## Summary
This PR fixes model selection drift on persistent/reconnected sessions so per-prompt `--model` is honored consistently (including warm queue-owner paths).

## Root Cause
Session options were not consistently propagated through refactored queue-owner request/task boundaries, and model config updates were not always enforced immediately before the next prompt on all adapters.

## Changes
- Ported session-option propagation to refactored runtime/queue files.
- Added merge helpers so command-level session options override persisted defaults where appropriate.
- Carried per-prompt `sessionOptions` through queue submit request parsing, transport, and task execution.
- Ensured queued prompt execution prefers task-level session options over owner startup defaults.
- Improved model switching behavior:
  - prefer `session/set_config_option` for model updates (alias-friendly)
  - immediately enforce with `session/set_model` after config update when available
  - gracefully tolerate adapters that do not support specific session control methods
- Added/updated integration coverage for prompt model updates on existing sessions.

## Files Changed
- `src/acp/client.ts`
- `src/acp/session-control-errors.ts`
- `src/cli/command-handlers.ts`
- `src/cli/queue/ipc-server.ts`
- `src/cli/queue/ipc.ts`
- `src/cli/queue/messages.ts`
- `src/cli/queue/owner-env.ts`
- `src/cli/session/contracts.ts`
- `src/cli/session/queue-owner-process.ts`
- `src/cli/session/queue-owner-runtime.ts`
- `src/cli/session/runtime.ts`
- `src/runtime/engine/connected-session.ts`
- `src/runtime/engine/session-options.ts`
- `test/integration.test.ts`

## Validation
- `corepack pnpm run typecheck`
- `corepack pnpm run build:test`
- `node --test --test-name-pattern "integration: prompt --model updates existing session model before prompt" dist-test/test/integration.test.js`

## Manual Repro
- `npx tsx src/cli.ts --model haiku claude sessions ensure --name "acpx-test-model"`
- `npx tsx src/cli.ts --model haiku claude prompt -s acpx-test-model "What is your model name"`
- `npx tsx src/cli.ts --verbose --model sonnet claude prompt -s acpx-test-model "What is your model name"`
- Confirmed model switches correctly on subsequent prompt turns.
