### PR TITLE
fix: restrict IPC socket directory permissions to owner-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Runtime/persistent sessions: keep reusable persistent ACP clients warm across turns and close pooled clients during runtime close. (#265) Thanks @Sway-Chan.
+- CLI/queue: tighten persistent queue and IPC socket directories to owner-only permissions, including previously-created permissive directories. (#216) Thanks @garagon.
 - Runtime/ACP: drain late post-success session updates before closing prompt turns so adapters that resolve `session/prompt` before final updates do not drop assistant output. (#251) Thanks @logofet85-ai.
 - Sessions/reset: close the live backend session when discarding persistent state so reset flows start a fresh ACP session instead of silently reopening the old one.
 - Agents/kiro: use `kiro-cli-chat acp` for the built-in Kiro adapter command to avoid orphan child processes. (#129) Thanks @vokako.

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -82,10 +82,13 @@ function isQueueOwnerHeartbeatStale(owner: QueueOwnerRecord): boolean {
 }
 
 async function ensureQueueDir(): Promise<void> {
-  await fs.mkdir(queueBaseDir(), { recursive: true, mode: 0o700 });
+  const baseDir = queueBaseDir();
+  await fs.mkdir(baseDir, { recursive: true, mode: 0o700 });
+  await fs.chmod(baseDir, 0o700);
   const socketDir = queueSocketBaseDir();
   if (socketDir) {
     await fs.mkdir(socketDir, { recursive: true, mode: 0o700 });
+    await fs.chmod(socketDir, 0o700);
   }
 }
 

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -82,10 +82,10 @@ function isQueueOwnerHeartbeatStale(owner: QueueOwnerRecord): boolean {
 }
 
 async function ensureQueueDir(): Promise<void> {
-  await fs.mkdir(queueBaseDir(), { recursive: true });
+  await fs.mkdir(queueBaseDir(), { recursive: true, mode: 0o700 });
   const socketDir = queueSocketBaseDir();
   if (socketDir) {
-    await fs.mkdir(socketDir, { recursive: true });
+    await fs.mkdir(socketDir, { recursive: true, mode: 0o700 });
   }
 }
 

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -13,7 +13,7 @@ import {
   terminateQueueOwnerForSession,
   tryAcquireQueueOwnerLease,
 } from "../src/cli/queue/lease-store.js";
-import { queueLockFilePath } from "../src/cli/queue/paths.js";
+import { queueBaseDir, queueLockFilePath, queueSocketBaseDir } from "../src/cli/queue/paths.js";
 import {
   queuePaths,
   startKeeperProcess,
@@ -58,6 +58,36 @@ test("tryAcquireQueueOwnerLease creates a lease that can be refreshed and releas
 
     await releaseQueueOwnerLease(lease);
     assert.equal(await readQueueOwnerRecord("lease-create"), undefined);
+  });
+});
+
+test("tryAcquireQueueOwnerLease tightens queue directory permissions", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  await withTempHome(async (homeDir) => {
+    const baseDir = queueBaseDir(homeDir);
+    const socketDir = queueSocketBaseDir(homeDir);
+    assert(socketDir);
+
+    await fs.mkdir(baseDir, { recursive: true, mode: 0o777 });
+    await fs.chmod(baseDir, 0o777);
+    await fs.mkdir(socketDir, { recursive: true, mode: 0o777 });
+    await fs.chmod(socketDir, 0o777);
+
+    const lease = await tryAcquireQueueOwnerLease("lease-permissions");
+    assert(lease);
+
+    try {
+      const baseMode = (await fs.stat(baseDir)).mode & 0o777;
+      const socketMode = (await fs.stat(socketDir)).mode & 0o777;
+      assert.equal(baseMode, 0o700);
+      assert.equal(socketMode, 0o700);
+    } finally {
+      await releaseQueueOwnerLease(lease);
+      await fs.rm(socketDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
The queue socket directory at `/tmp/acpx-<hash>/` and the queue base directory at `~/.acpx/queues/` are created with `fs.mkdir` without an explicit `mode`, so they inherit the default umask (typically `0o755`). This allows other local users to traverse the directory and discover session socket files.

This change sets `mode: 0o700` on both directories so only the owning user can access the IPC sockets.

**What changed:**
- `ensureQueueDir()` in `src/queue-lease-store.ts` now passes `mode: 0o700` to both `mkdir` calls

**What did NOT change:**
- No changes to the IPC protocol or queue behavior
- No changes to socket file creation (Unix sockets inherit directory permissions for access control)

**How I verified:**
- Reviewed that `queueBaseDir()` resolves to `~/.acpx/queues/` and `queueSocketBaseDir()` resolves to `/tmp/acpx-<hash>/`
- Confirmed no other code path creates these directories
- Confirmed `mode` is respected by Node.js `fs.mkdir` on Linux and macOS