### PR TITLE
feat(sessions): add prune command to delete closed sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Repo: https://github.com/openclaw/acpx
 ### Changes
 
 - CLI/claude: add `--system-prompt <text>` and `--append-system-prompt <text>` global flags that forward through ACP `_meta.systemPrompt` on `session/new`, letting callers replace or append to the Claude Code system prompt without dropping out of persistent acpx sessions. The value is persisted in `session_options.system_prompt` so ensure/reuse flows keep the override. Codex and other agents ignore the field. (#229) Thanks @Vercantez.
+- CLI/sessions: add `sessions prune` with `--dry-run`, age filters, and `--include-history` so closed session records and optional event streams can be cleaned up explicitly. (#227) Thanks @coder999999999.
 - Runtime/embedding: add `startTurn(...)` turn handles so embedders can observe live runtime events separately from terminal completion, cancel a turn, or close only the event stream while preserving `runTurn(...)` compatibility. (#262) Thanks @enki.
 
 ### Breaking

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -305,6 +305,7 @@ acpx [global_options] <agent> sessions show
 acpx [global_options] <agent> sessions show <name>
 acpx [global_options] <agent> sessions history
 acpx [global_options] <agent> sessions history <name> [--limit <count>]
+acpx [global_options] <agent> sessions prune [--dry-run] [--before <date> | --older-than <days>] [--include-history]
 
 acpx [global_options] sessions ...   # defaults to codex
 ```
@@ -322,6 +323,9 @@ Behavior:
 - `sessions close <name>` soft-closes current cwd named session
 - `sessions show [name]` displays stored session metadata
 - `sessions history [name]` displays stored turn history previews (default 20, configurable with `--limit`)
+- `sessions prune --dry-run` previews closed sessions that can be deleted
+- `sessions prune` deletes closed session records for the selected agent; add `--include-history` to delete event stream files too
+- `sessions prune --before <date>` and `--older-than <days>` filter by close time, falling back to last-used time for older records
 - close errors if the target session does not exist
 
 ## `status` command
@@ -492,7 +496,7 @@ Hard rule for the ACP stream:
 When `--format json` is used:
 
 - commands that talk to an ACP adapter emit raw ACP JSON-RPC messages.
-- local query commands (`sessions list/show/history`) emit local JSON documents (not ACP stream traffic).
+- local query commands (`sessions list/show/history/prune`) emit local JSON documents (not ACP stream traffic).
 
 ### Sessions/query command output behavior
 
@@ -503,6 +507,9 @@ When `--format json` is used:
 - `sessions show` with `json`: full session record object
 - `sessions history` with `text`: tab-separated `timestamp role textPreview` entries
 - `sessions history` with `json`: object containing `entries` array
+- `sessions prune` with `text`: summary plus pruned ids and close/last-used time
+- `sessions prune` with `json`: object containing `action`, `dryRun`, `count`, `bytesFreed`, and `pruned`
+- `sessions prune` with `quiet`: one pruned session id per line
 - `status` with `text`: key/value process status lines
 
 ## Permission modes

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -33,6 +33,7 @@ import {
   type PromptFlags,
   type SessionsHistoryFlags,
   type SessionsNewFlags,
+  type SessionsPruneFlags,
   type StatusFlags,
 } from "./flags.js";
 import { emitJsonResult } from "./output/json-output.js";
@@ -881,6 +882,32 @@ export async function handleSessionsHistory(
   }
 
   printSessionHistoryByFormat(record, flags.limit, globalFlags.format);
+}
+
+export async function handleSessionsPrune(
+  explicitAgentName: string | undefined,
+  flags: SessionsPruneFlags,
+  command: Command,
+  config: ResolvedAcpxConfig,
+): Promise<void> {
+  const globalFlags = resolveGlobalFlags(command, config);
+  const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
+  const [{ pruneSessions }, { printPruneResultByFormat }] = await Promise.all([
+    loadSessionModule(),
+    loadOutputRenderModule(),
+  ]);
+
+  const olderThanMs = flags.olderThan != null ? flags.olderThan * 24 * 60 * 60 * 1000 : undefined;
+
+  const result = await pruneSessions({
+    agentCommand: agent.agentCommand,
+    before: flags.before,
+    olderThanMs,
+    includeHistory: flags.includeHistory,
+    dryRun: flags.dryRun,
+  });
+
+  printPruneResultByFormat(result, globalFlags.format);
 }
 
 export { parseHistoryLimit, NoSessionError, loadSessionModule };

--- a/src/cli/command-registration.ts
+++ b/src/cli/command-registration.ts
@@ -9,6 +9,7 @@ import {
   handleSessionsHistory,
   handleSessionsList,
   handleSessionsNew,
+  handleSessionsPrune,
   handleSessionsShow,
   handleSetConfigOption,
   handleSetMode,
@@ -20,11 +21,14 @@ import {
   addPromptInputOption,
   addSessionNameOption,
   addSessionOption,
+  parseDaysOlderThan,
   parseNonEmptyValue,
+  parsePruneBeforeDate,
   parseSessionName,
   type PromptFlags,
   type SessionsHistoryFlags,
   type SessionsNewFlags,
+  type SessionsPruneFlags,
   type StatusFlags,
 } from "./flags.js";
 import { registerStatusCommand } from "./status-command.js";
@@ -133,6 +137,17 @@ export function registerSessionsCommand(
         this,
         config,
       );
+    });
+
+  sessionsCommand
+    .command("prune")
+    .description("Delete closed sessions and free disk space")
+    .option("--dry-run", "Preview what would be pruned without deleting anything")
+    .option("--before <date>", "Prune sessions closed before this date", parsePruneBeforeDate)
+    .option("--older-than <days>", "Prune sessions closed more than N days ago", parseDaysOlderThan)
+    .option("--include-history", "Also delete event stream files (.stream.ndjson)")
+    .action(async function (this: Command, flags: SessionsPruneFlags) {
+      await handleSessionsPrune(explicitAgentName, flags, this, config);
     });
 }
 

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -70,6 +70,13 @@ export type StatusFlags = {
   session?: string;
 };
 
+export type SessionsPruneFlags = {
+  dryRun?: boolean;
+  before?: Date;
+  olderThan?: number;
+  includeHistory?: boolean;
+};
+
 export function parseOutputFormat(value: string): OutputFormat {
   if (!OUTPUT_FORMATS.includes(value as OutputFormat)) {
     throw new InvalidArgumentError(
@@ -135,6 +142,24 @@ export function parseHistoryLimit(value: string): number {
     throw new InvalidArgumentError("Limit must be a positive integer");
   }
   return parsed;
+}
+
+export function parseDaysOlderThan(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("--older-than must be a positive integer number of days");
+  }
+  return parsed;
+}
+
+export function parsePruneBeforeDate(value: string): Date {
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new InvalidArgumentError(
+      `--before must be a valid date (e.g. 2026-01-01 or 2026-01-01T00:00:00Z)`,
+    );
+  }
+  return date;
 }
 
 export function parseAllowedTools(value: string): string[] {

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -205,6 +205,64 @@ export function printCreatedSessionBanner(
   process.stderr.write(`[acpx] cwd: ${record.cwd}\n`);
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_073_741_824) {
+    return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+  }
+  if (bytes >= 1_048_576) {
+    return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+export function printPruneResultByFormat(
+  result: { pruned: SessionRecord[]; bytesFreed: number; dryRun: boolean },
+  format: OutputFormat,
+): void {
+  const count = result.pruned.length;
+
+  if (
+    emitJsonResult(format, {
+      action: result.dryRun ? "sessions_prune_dry_run" : "sessions_pruned",
+      dryRun: result.dryRun,
+      count,
+      bytesFreed: result.bytesFreed,
+      pruned: result.pruned.map((r) => r.acpxRecordId),
+    })
+  ) {
+    return;
+  }
+
+  if (format === "quiet") {
+    for (const record of result.pruned) {
+      process.stdout.write(`${record.acpxRecordId}\n`);
+    }
+    return;
+  }
+
+  if (count === 0) {
+    process.stdout.write(
+      result.dryRun ? "[DRY RUN] No sessions to prune\n" : "No sessions pruned\n",
+    );
+    return;
+  }
+
+  const prefix = result.dryRun ? "[DRY RUN] Would prune" : "Pruned";
+  const bytesSuffix =
+    !result.dryRun && result.bytesFreed > 0 ? `, freed ${formatBytes(result.bytesFreed)}` : "";
+  process.stdout.write(`${prefix} ${count} session${count === 1 ? "" : "s"}${bytesSuffix}\n`);
+
+  for (const record of result.pruned) {
+    const label = record.name ? ` (${record.name})` : "";
+    process.stdout.write(
+      `  ${record.acpxRecordId}${label}\t${record.closedAt ?? record.lastUsedAt}\n`,
+    );
+  }
+}
+
 export function agentSessionIdPayload(agentSessionId: string | undefined): {
   agentSessionId?: string;
 } {

--- a/src/session/persistence.ts
+++ b/src/session/persistence.ts
@@ -10,6 +10,8 @@ export {
   listSessions,
   listSessionsForAgent,
   normalizeName,
+  pruneSessions,
   resolveSessionRecord,
   writeSessionRecord,
 } from "./persistence/repository.js";
+export type { PruneOptions, PruneResult } from "./persistence/repository.js";

--- a/src/session/persistence/repository.ts
+++ b/src/session/persistence/repository.ts
@@ -311,6 +311,18 @@ export type PruneResult = {
   dryRun: boolean;
 };
 
+function closedAtOrLastUsedAt(record: SessionRecord): string {
+  return record.closedAt ?? record.lastUsedAt;
+}
+
+function isSessionStreamFile(fileName: string, safeId: string): boolean {
+  return (
+    fileName === `${safeId}.stream.ndjson` ||
+    fileName === `${safeId}.stream.lock` ||
+    fileName.startsWith(`${safeId}.stream.`)
+  );
+}
+
 export async function pruneSessions(options: PruneOptions = {}): Promise<PruneResult> {
   await ensureSessionDir();
   const entries = await loadSessionIndexEntries();
@@ -325,15 +337,10 @@ export async function pruneSessions(options: PruneOptions = {}): Promise<PruneRe
     options.before ??
     (options.olderThanMs != null ? new Date(Date.now() - options.olderThanMs) : undefined);
 
-  if (cutoff) {
-    const cutoffIso = cutoff.toISOString();
-    eligible = eligible.filter((entry) => entry.lastUsedAt < cutoffIso);
-  }
-
   const records: SessionRecord[] = [];
   for (const entry of eligible) {
     const record = await loadRecordFromIndexEntry(entry);
-    if (record) {
+    if (record && (!cutoff || closedAtOrLastUsedAt(record) < cutoff.toISOString())) {
       records.push(record);
     }
   }
@@ -369,9 +376,8 @@ export async function pruneSessions(options: PruneOptions = {}): Promise<PruneRe
     await fs.unlink(jsonFile).catch(() => undefined);
 
     if (options.includeHistory) {
-      const prefix = `${safeId}.stream`;
       for (const name of dirEntries) {
-        if (!name.startsWith(prefix)) {
+        if (!isSessionStreamFile(name, safeId)) {
           continue;
         }
         const filePath = path.join(sessionDir, name);

--- a/src/session/persistence/repository.ts
+++ b/src/session/persistence/repository.ts
@@ -297,6 +297,102 @@ function killSignalCandidates(signal: NodeJS.Signals | undefined): NodeJS.Signal
   return [normalized, "SIGKILL"];
 }
 
+export type PruneOptions = {
+  agentCommand?: string;
+  before?: Date;
+  olderThanMs?: number;
+  includeHistory?: boolean;
+  dryRun?: boolean;
+};
+
+export type PruneResult = {
+  pruned: SessionRecord[];
+  bytesFreed: number;
+  dryRun: boolean;
+};
+
+export async function pruneSessions(options: PruneOptions = {}): Promise<PruneResult> {
+  await ensureSessionDir();
+  const entries = await loadSessionIndexEntries();
+
+  let eligible = entries.filter((entry) => entry.closed);
+
+  if (options.agentCommand) {
+    eligible = eligible.filter((entry) => entry.agentCommand === options.agentCommand);
+  }
+
+  const cutoff =
+    options.before ??
+    (options.olderThanMs != null ? new Date(Date.now() - options.olderThanMs) : undefined);
+
+  if (cutoff) {
+    const cutoffIso = cutoff.toISOString();
+    eligible = eligible.filter((entry) => entry.lastUsedAt < cutoffIso);
+  }
+
+  const records: SessionRecord[] = [];
+  for (const entry of eligible) {
+    const record = await loadRecordFromIndexEntry(entry);
+    if (record) {
+      records.push(record);
+    }
+  }
+
+  if (options.dryRun) {
+    return { pruned: records, bytesFreed: 0, dryRun: true };
+  }
+
+  const sessionDir = sessionBaseDir();
+  let bytesFreed = 0;
+
+  // Read the directory once upfront so stream-file matching doesn't re-read
+  // it for every session in the loop.
+  let dirEntries: string[] = [];
+  if (options.includeHistory) {
+    try {
+      dirEntries = await fs.readdir(sessionDir);
+    } catch {
+      // ignore
+    }
+  }
+
+  for (const record of records) {
+    const safeId = encodeURIComponent(record.acpxRecordId);
+    const jsonFile = path.join(sessionDir, `${safeId}.json`);
+
+    try {
+      const stat = await fs.stat(jsonFile);
+      bytesFreed += stat.size;
+    } catch {
+      // file already gone
+    }
+    await fs.unlink(jsonFile).catch(() => undefined);
+
+    if (options.includeHistory) {
+      const prefix = `${safeId}.stream`;
+      for (const name of dirEntries) {
+        if (!name.startsWith(prefix)) {
+          continue;
+        }
+        const filePath = path.join(sessionDir, name);
+        try {
+          const stat = await fs.stat(filePath);
+          bytesFreed += stat.size;
+        } catch {
+          // ignore
+        }
+        await fs.unlink(filePath).catch(() => undefined);
+      }
+    }
+  }
+
+  await rebuildSessionIndex(sessionDir).catch(() => {
+    // best effort cache rebuild
+  });
+
+  return { pruned: records, bytesFreed, dryRun: false };
+}
+
 export async function closeSession(id: string): Promise<SessionRecord> {
   const record = await resolveSessionRecord(id);
   const now = isoNow();

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -10,5 +10,7 @@ export {
   findSessionByDirectoryWalk,
   listSessions,
   listSessionsForAgent,
+  pruneSessions,
 } from "./persistence.js";
+export type { PruneOptions, PruneResult } from "./persistence.js";
 export { isProcessAlive } from "../cli/queue/ipc.js";

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -226,6 +226,7 @@ test("sessions new command is present in help output", async () => {
     assert.match(result.stdout, /\bnew\b/);
     assert.match(result.stdout, /\bensure\b/);
     assert.match(result.stdout, /\bread\b/);
+    assert.match(result.stdout, /\bprune\b/);
 
     const newHelp = await runCli(["sessions", "new", "--help"], homeDir);
     assert.equal(newHelp.code, 0, newHelp.stderr);
@@ -240,6 +241,11 @@ test("sessions new command is present in help output", async () => {
     assert.equal(readHelp.code, 0, readHelp.stderr);
     assert.match(readHelp.stdout, /--tail <count>/);
     assert.match(ensureHelp.stdout, /--resume-session <id>/);
+
+    const pruneHelp = await runCli(["sessions", "prune", "--help"], homeDir);
+    assert.equal(pruneHelp.code, 0, pruneHelp.stderr);
+    assert.match(pruneHelp.stdout, /--dry-run/);
+    assert.match(pruneHelp.stdout, /--include-history/);
   });
 });
 
@@ -1850,6 +1856,86 @@ test("sessions history prints stored history entries", async () => {
   });
 });
 
+test("sessions prune dry-run previews closed sessions without deleting", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "prune-dry-run",
+      acpSessionId: "prune-dry-run",
+      agentCommand: AGENT_REGISTRY.codex,
+      cwd,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: "2026-01-01T00:10:00.000Z",
+      closed: true,
+      closedAt: "2026-01-01T00:10:00.000Z",
+    });
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "prune-open",
+      acpSessionId: "prune-open",
+      agentCommand: AGENT_REGISTRY.codex,
+      cwd,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: "2026-01-01T00:20:00.000Z",
+      closed: false,
+    });
+
+    const result = await runCli(["--cwd", cwd, "codex", "sessions", "prune", "--dry-run"], homeDir);
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /\[DRY RUN\] Would prune 1 session/);
+    assert.match(result.stdout, /prune-dry-run/);
+    assert.doesNotMatch(result.stdout, /prune-open/);
+    assert.ok(await fileExists(sessionFilePath(homeDir, "prune-dry-run")));
+    assert.ok(await fileExists(sessionFilePath(homeDir, "prune-open")));
+  });
+});
+
+test("sessions prune supports json output and include-history", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    const sessionDir = path.join(homeDir, ".acpx", "sessions");
+    await fs.mkdir(cwd, { recursive: true });
+
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "prune-json",
+      acpSessionId: "prune-json",
+      agentCommand: AGENT_REGISTRY.codex,
+      cwd,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: "2026-01-01T00:10:00.000Z",
+      closed: true,
+      closedAt: "2026-01-01T00:10:00.000Z",
+    });
+
+    const safeId = encodeURIComponent("prune-json");
+    const streamFile = path.join(sessionDir, `${safeId}.stream.ndjson`);
+    await fs.writeFile(streamFile, "event-data\n", "utf8");
+
+    const result = await runCli(
+      ["--cwd", cwd, "--format", "json", "codex", "sessions", "prune", "--include-history"],
+      homeDir,
+    );
+
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout) as {
+      action?: string;
+      dryRun?: boolean;
+      count?: number;
+      bytesFreed?: number;
+      pruned?: string[];
+    };
+    assert.equal(payload.action, "sessions_pruned");
+    assert.equal(payload.dryRun, false);
+    assert.equal(payload.count, 1);
+    assert.ok((payload.bytesFreed ?? 0) > 0);
+    assert.deepEqual(payload.pruned, ["prune-json"]);
+    assert.ok(!(await fileExists(sessionFilePath(homeDir, "prune-json"))));
+    assert.ok(!(await fileExists(streamFile)));
+  });
+});
+
 test("sessions read prints full history by default and supports --tail", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
@@ -2247,6 +2333,19 @@ async function writeSessionRecord(
     `${JSON.stringify(serializeSessionRecordForDisk(makeSessionRecord(record)), null, 2)}\n`,
     "utf8",
   );
+}
+
+function sessionFilePath(homeDir: string, acpxRecordId: string): string {
+  return path.join(homeDir, ".acpx", "sessions", `${encodeURIComponent(acpxRecordId)}.json`);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function escapeRegex(value: string): string {

--- a/test/sessions-prune.test.ts
+++ b/test/sessions-prune.test.ts
@@ -184,7 +184,7 @@ test("pruneSessions --dry-run does not delete files but returns correct count", 
   });
 });
 
-test("pruneSessions --before only prunes sessions with lastUsedAt before the cutoff", async () => {
+test("pruneSessions --before uses closedAt before falling back to lastUsedAt", async () => {
   await withTempHome(async (homeDir) => {
     const session = await loadSessionModule();
     const cwd = path.join(homeDir, "workspace");
@@ -198,7 +198,7 @@ test("pruneSessions --before only prunes sessions with lastUsedAt before the cut
         cwd,
         closed: true,
         closedAt: "2025-06-01T00:00:00.000Z",
-        lastUsedAt: "2025-06-01T00:00:00.000Z",
+        lastUsedAt: "2026-03-01T00:00:00.000Z",
       }),
     );
 
@@ -211,7 +211,7 @@ test("pruneSessions --before only prunes sessions with lastUsedAt before the cut
         cwd,
         closed: true,
         closedAt: "2026-03-01T00:00:00.000Z",
-        lastUsedAt: "2026-03-01T00:00:00.000Z",
+        lastUsedAt: "2025-06-01T00:00:00.000Z",
       }),
     );
 
@@ -330,9 +330,14 @@ test("pruneSessions --include-history deletes stream files", async () => {
     const streamFile = path.join(sessionsDir, `${safeId}.stream.ndjson`);
     const streamSegment = path.join(sessionsDir, `${safeId}.stream.0.ndjson`);
     const streamLock = path.join(sessionsDir, `${safeId}.stream.lock`);
+    const neighborStreamFile = path.join(
+      sessionsDir,
+      `${encodeURIComponent("stream-session.stream-neighbor")}.stream.ndjson`,
+    );
     await fs.writeFile(streamFile, "event-data\n", "utf8");
     await fs.writeFile(streamSegment, "segment-data\n", "utf8");
     await fs.writeFile(streamLock, "", "utf8");
+    await fs.writeFile(neighborStreamFile, "neighbor-data\n", "utf8");
 
     const result = await session.pruneSessions({
       agentCommand: "agent-a",
@@ -343,6 +348,7 @@ test("pruneSessions --include-history deletes stream files", async () => {
     assert.ok(!(await fileExists(streamFile)));
     assert.ok(!(await fileExists(streamSegment)));
     assert.ok(!(await fileExists(streamLock)));
+    assert.ok(await fileExists(neighborStreamFile));
   });
 });
 

--- a/test/sessions-prune.test.ts
+++ b/test/sessions-prune.test.ts
@@ -1,0 +1,395 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { serializeSessionRecordForDisk } from "../src/session/persistence.js";
+import type { SessionRecord } from "../src/types.js";
+
+type SessionModule = typeof import("../src/session/session.js");
+
+const SESSION_MODULE_URL = new URL("../src/session/session.js", import.meta.url);
+
+async function loadSessionModule(): Promise<SessionModule> {
+  const cacheBuster = `${Date.now()}-${Math.random()}`;
+  return (await import(`${SESSION_MODULE_URL.href}?prune_test=${cacheBuster}`)) as SessionModule;
+}
+
+async function withTempHome(run: (homeDir: string) => Promise<void>): Promise<void> {
+  const originalHome = process.env.HOME;
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-prune-test-"));
+  process.env.HOME = tempHome;
+
+  try {
+    await run(tempHome);
+  } finally {
+    if (originalHome == null) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+function makeSessionRecord(
+  overrides: Partial<SessionRecord> & {
+    acpxRecordId: string;
+    acpSessionId: string;
+    agentCommand: string;
+    cwd: string;
+  },
+): SessionRecord {
+  const timestamp = "2026-01-01T00:00:00.000Z";
+  return {
+    schema: "acpx.session.v1",
+    acpxRecordId: overrides.acpxRecordId,
+    acpSessionId: overrides.acpSessionId,
+    agentSessionId: overrides.agentSessionId,
+    agentCommand: overrides.agentCommand,
+    cwd: path.resolve(overrides.cwd),
+    name: overrides.name,
+    createdAt: overrides.createdAt ?? timestamp,
+    lastUsedAt: overrides.lastUsedAt ?? timestamp,
+    lastSeq: overrides.lastSeq ?? 0,
+    lastRequestId: overrides.lastRequestId,
+    eventLog: overrides.eventLog ?? {
+      active_path: `.stream.ndjson`,
+      segment_count: 1,
+      max_segment_bytes: 1024,
+      max_segments: 1,
+      last_write_at: overrides.lastUsedAt ?? timestamp,
+      last_write_error: null,
+    },
+    closed: overrides.closed ?? false,
+    closedAt: overrides.closedAt,
+    pid: overrides.pid,
+    agentStartedAt: overrides.agentStartedAt,
+    lastPromptAt: overrides.lastPromptAt,
+    lastAgentExitCode: overrides.lastAgentExitCode,
+    lastAgentExitSignal: overrides.lastAgentExitSignal,
+    lastAgentExitAt: overrides.lastAgentExitAt,
+    lastAgentDisconnectReason: overrides.lastAgentDisconnectReason,
+    protocolVersion: overrides.protocolVersion,
+    agentCapabilities: overrides.agentCapabilities,
+    title: overrides.title ?? null,
+    messages: overrides.messages ?? [],
+    updated_at: overrides.updated_at ?? overrides.lastUsedAt ?? timestamp,
+    cumulative_token_usage: overrides.cumulative_token_usage ?? {},
+    request_token_usage: overrides.request_token_usage ?? {},
+    acpx: overrides.acpx,
+  };
+}
+
+function sessionFilePath(homeDir: string, acpxRecordId: string): string {
+  return path.join(homeDir, ".acpx", "sessions", `${encodeURIComponent(acpxRecordId)}.json`);
+}
+
+async function writeSessionRecord(homeDir: string, record: SessionRecord): Promise<void> {
+  const filePath = sessionFilePath(homeDir, record.acpxRecordId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(
+    filePath,
+    `${JSON.stringify(serializeSessionRecordForDisk(record), null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("pruneSessions returns empty result when no closed sessions exist", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "open-session",
+        acpSessionId: "open-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: false,
+      }),
+    );
+
+    const result = await session.pruneSessions({ agentCommand: "agent-a" });
+    assert.equal(result.pruned.length, 0);
+    assert.equal(result.bytesFreed, 0);
+    assert.equal(result.dryRun, false);
+  });
+});
+
+test("pruneSessions deletes closed session files and removes them from the index", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "closed-session",
+        acpSessionId: "closed-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    const filePath = sessionFilePath(homeDir, "closed-session");
+    assert.ok(await fileExists(filePath));
+
+    const result = await session.pruneSessions({ agentCommand: "agent-a" });
+    assert.equal(result.pruned.length, 1);
+    assert.equal(result.pruned[0].acpxRecordId, "closed-session");
+    assert.ok(result.bytesFreed > 0);
+    assert.equal(result.dryRun, false);
+    assert.ok(!(await fileExists(filePath)));
+  });
+});
+
+test("pruneSessions --dry-run does not delete files but returns correct count", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "dry-run-session",
+        acpSessionId: "dry-run-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    const filePath = sessionFilePath(homeDir, "dry-run-session");
+    assert.ok(await fileExists(filePath));
+
+    const result = await session.pruneSessions({ agentCommand: "agent-a", dryRun: true });
+    assert.equal(result.pruned.length, 1);
+    assert.equal(result.bytesFreed, 0);
+    assert.equal(result.dryRun, true);
+    assert.ok(await fileExists(filePath));
+  });
+});
+
+test("pruneSessions --before only prunes sessions with lastUsedAt before the cutoff", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "old-session",
+        acpSessionId: "old-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2025-06-01T00:00:00.000Z",
+        lastUsedAt: "2025-06-01T00:00:00.000Z",
+      }),
+    );
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "recent-session",
+        acpSessionId: "recent-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2026-03-01T00:00:00.000Z",
+        lastUsedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    );
+
+    const result = await session.pruneSessions({
+      agentCommand: "agent-a",
+      before: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    assert.equal(result.pruned.length, 1);
+    assert.equal(result.pruned[0].acpxRecordId, "old-session");
+    assert.ok(!(await fileExists(sessionFilePath(homeDir, "old-session"))));
+    assert.ok(await fileExists(sessionFilePath(homeDir, "recent-session")));
+  });
+});
+
+test("pruneSessions --older-than prunes sessions beyond the day threshold", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    // Session with lastUsedAt far in the past
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "ancient-session",
+        acpSessionId: "ancient-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2020-01-01T00:00:00.000Z",
+        lastUsedAt: "2020-01-01T00:00:00.000Z",
+      }),
+    );
+
+    // Session with lastUsedAt very recently (should not be pruned)
+    const now = new Date().toISOString();
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "fresh-session",
+        acpSessionId: "fresh-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: now,
+        lastUsedAt: now,
+      }),
+    );
+
+    // Prune sessions older than 1 day
+    const result = await session.pruneSessions({
+      agentCommand: "agent-a",
+      olderThanMs: 1 * 24 * 60 * 60 * 1000,
+    });
+    assert.equal(result.pruned.length, 1);
+    assert.equal(result.pruned[0].acpxRecordId, "ancient-session");
+    assert.ok(await fileExists(sessionFilePath(homeDir, "fresh-session")));
+  });
+});
+
+test("pruneSessions scoped to agentCommand only prunes that agent's sessions", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "agent-a-session",
+        acpSessionId: "agent-a-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "agent-b-session",
+        acpSessionId: "agent-b-session",
+        agentCommand: "agent-b",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    const result = await session.pruneSessions({ agentCommand: "agent-a" });
+    assert.equal(result.pruned.length, 1);
+    assert.equal(result.pruned[0].acpxRecordId, "agent-a-session");
+    assert.ok(!(await fileExists(sessionFilePath(homeDir, "agent-a-session"))));
+    assert.ok(await fileExists(sessionFilePath(homeDir, "agent-b-session")));
+  });
+});
+
+test("pruneSessions --include-history deletes stream files", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+    const sessionsDir = path.join(homeDir, ".acpx", "sessions");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "stream-session",
+        acpSessionId: "stream-session",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    const safeId = encodeURIComponent("stream-session");
+    const streamFile = path.join(sessionsDir, `${safeId}.stream.ndjson`);
+    const streamSegment = path.join(sessionsDir, `${safeId}.stream.0.ndjson`);
+    const streamLock = path.join(sessionsDir, `${safeId}.stream.lock`);
+    await fs.writeFile(streamFile, "event-data\n", "utf8");
+    await fs.writeFile(streamSegment, "segment-data\n", "utf8");
+    await fs.writeFile(streamLock, "", "utf8");
+
+    const result = await session.pruneSessions({
+      agentCommand: "agent-a",
+      includeHistory: true,
+    });
+    assert.equal(result.pruned.length, 1);
+    assert.ok(result.bytesFreed > 0);
+    assert.ok(!(await fileExists(streamFile)));
+    assert.ok(!(await fileExists(streamSegment)));
+    assert.ok(!(await fileExists(streamLock)));
+  });
+});
+
+test("pruneSessions without agentCommand prunes all closed sessions across all agents", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "all-a",
+        acpSessionId: "all-a",
+        agentCommand: "agent-a",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "all-b",
+        acpSessionId: "all-b",
+        agentCommand: "agent-b",
+        cwd,
+        closed: true,
+        closedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "all-open",
+        acpSessionId: "all-open",
+        agentCommand: "agent-a",
+        cwd,
+        closed: false,
+      }),
+    );
+
+    const result = await session.pruneSessions({});
+    assert.equal(result.pruned.length, 2);
+    const prunedIds = result.pruned.map((r) => r.acpxRecordId).toSorted();
+    assert.deepEqual(prunedIds, ["all-a", "all-b"]);
+    assert.ok(await fileExists(sessionFilePath(homeDir, "all-open")));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `acpx sessions prune` to delete closed sessions and free disk space
- Supports `--dry-run` to preview what would be removed without deleting anything
- Supports `--before <date>` and `--older-than <days>` to filter by age (`--before` takes precedence if both are supplied)
- Supports `--include-history` to also delete event stream files (`.stream.ndjson`)
- Output works in `text`, `json`, and `quiet` formats

## Changes

- `src/session/persistence/repository.ts` — core `pruneSessions` function; filters closed sessions from the index, deletes their JSON records, optionally deletes stream files, then rebuilds the index
- `src/cli/flags.ts` — `SessionsPruneFlags` type and parsers for `--before` (returns `Date`) and `--older-than`
- `src/cli/command-handlers.ts` — `handleSessionsPrune` handler
- `src/cli/command-registration.ts` — registers the `prune` subcommand under `sessions`
- `src/cli/output/render.ts` — `printPruneResultByFormat` with text, json, and quiet output
- `test/sessions-prune.test.ts` — 8 tests covering all flag combinations and edge cases

## Test plan

- [ ] `sessions prune --dry-run` lists sessions without deleting
- [ ] `sessions prune` deletes closed sessions and reports bytes freed
- [ ] `sessions prune --before 2026-01-01` respects date cutoff
- [ ] `sessions prune --older-than 30` respects day threshold
- [ ] `sessions prune --include-history` removes stream files too
- [ ] `sessions prune --format json` emits valid JSON
- [ ] Open sessions are never touched