### PR TITLE
feat(claude): forward --system-prompt / --append-system-prompt via ACP _meta [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- CLI/claude: add `--system-prompt <text>` and `--append-system-prompt <text>` global flags that forward through ACP `_meta.systemPrompt` on `session/new`, letting callers replace or append to the Claude Code system prompt without dropping out of persistent acpx sessions. The value is persisted in `session_options.system_prompt` so ensure/reuse flows keep the override. Codex and other agents ignore the field. (#229) Thanks @Vercantez.
+
 ### Breaking
 
 ### Fixes

--- a/src/acp/agent-command.ts
+++ b/src/acp/agent-command.ts
@@ -340,13 +340,26 @@ export function buildClaudeCodeOptionsMeta(
     claudeCodeOptions.maxTurns = options.maxTurns;
   }
 
-  if (Object.keys(claudeCodeOptions).length === 0) {
+  const meta: Record<string, unknown> = {};
+  if (Object.keys(claudeCodeOptions).length > 0) {
+    meta.claudeCode = { options: claudeCodeOptions };
+  }
+
+  const systemPrompt = options.systemPrompt;
+  if (typeof systemPrompt === "string" && systemPrompt.length > 0) {
+    meta.systemPrompt = systemPrompt;
+  } else if (
+    systemPrompt &&
+    typeof systemPrompt === "object" &&
+    typeof systemPrompt.append === "string" &&
+    systemPrompt.append.length > 0
+  ) {
+    meta.systemPrompt = { append: systemPrompt.append };
+  }
+
+  if (Object.keys(meta).length === 0) {
     return undefined;
   }
 
-  return {
-    claudeCode: {
-      options: claudeCodeOptions,
-    },
-  };
+  return meta;
 }

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -308,6 +308,7 @@ export async function handleExec(
       model: globalFlags.model,
       allowedTools: globalFlags.allowedTools,
       maxTurns: globalFlags.maxTurns,
+      systemPrompt: globalFlags.systemPrompt,
     },
   });
 
@@ -628,6 +629,7 @@ export async function handleSessionsNew(
       model: globalFlags.model,
       allowedTools: globalFlags.allowedTools,
       maxTurns: globalFlags.maxTurns,
+      systemPrompt: globalFlags.systemPrompt,
     },
   });
 
@@ -668,6 +670,7 @@ export async function handleSessionsEnsure(
       model: globalFlags.model,
       allowedTools: globalFlags.allowedTools,
       maxTurns: globalFlags.maxTurns,
+      systemPrompt: globalFlags.systemPrompt,
     },
   });
 

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_AGENT_NAME,
   resolveAgentCommand as resolveAgentCommandFromRegistry,
 } from "../agent-registry.js";
+import type { SystemPromptOption } from "../runtime/engine/session-options.js";
 import { DEFAULT_QUEUE_OWNER_TTL_MS } from "../session/session.js";
 import {
   AUTH_POLICIES,
@@ -42,6 +43,7 @@ export type GlobalFlags = PermissionFlags & {
   model?: string;
   allowedTools?: string[];
   maxTurns?: number;
+  systemPrompt?: SystemPromptOption;
   promptRetries?: number;
 };
 
@@ -159,6 +161,31 @@ export function parseMaxTurns(value: string): number {
   return parsed;
 }
 
+export function resolveSystemPromptFlag(opts: {
+  systemPrompt?: unknown;
+  appendSystemPrompt?: unknown;
+}): SystemPromptOption | undefined {
+  const replace =
+    typeof opts.systemPrompt === "string" && opts.systemPrompt.length > 0
+      ? opts.systemPrompt
+      : undefined;
+  const append =
+    typeof opts.appendSystemPrompt === "string" && opts.appendSystemPrompt.length > 0
+      ? opts.appendSystemPrompt
+      : undefined;
+
+  if (replace !== undefined && append !== undefined) {
+    throw new InvalidArgumentError("Use only one of --system-prompt or --append-system-prompt");
+  }
+  if (replace !== undefined) {
+    return replace;
+  }
+  if (append !== undefined) {
+    return { append };
+  }
+  return undefined;
+}
+
 export function parsePromptRetries(value: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 0) {
@@ -218,6 +245,16 @@ export function addGlobalFlags(command: Command): Command {
       parseAllowedTools,
     )
     .option("--max-turns <count>", "Maximum turns for the session", parseMaxTurns)
+    .option(
+      "--system-prompt <text>",
+      "Replace the agent system prompt (claude-agent-acp via ACP _meta.systemPrompt)",
+      (value: string) => parseNonEmptyValue("System prompt", value),
+    )
+    .option(
+      "--append-system-prompt <text>",
+      "Append text to the agent system prompt (claude-agent-acp via ACP _meta.systemPrompt.append)",
+      (value: string) => parseNonEmptyValue("Append system prompt", value),
+    )
     .option(
       "--prompt-retries <count>",
       "Retry failed prompt turns on transient errors (default: 0)",
@@ -309,6 +346,7 @@ export function resolveGlobalFlags(command: Command, config: ResolvedAcpxConfig)
     model: typeof opts.model === "string" ? parseNonEmptyValue("Model", opts.model) : undefined,
     allowedTools: Array.isArray(opts.allowedTools) ? opts.allowedTools : undefined,
     maxTurns: typeof opts.maxTurns === "number" ? opts.maxTurns : undefined,
+    systemPrompt: resolveSystemPromptFlag(opts),
     promptRetries: typeof opts.promptRetries === "number" ? opts.promptRetries : undefined,
     approveAll: opts.approveAll ? true : undefined,
     approveReads: opts.approveReads ? true : undefined,

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -27,19 +27,32 @@ function persistSessionOptions(
   record: SessionRecord,
   options: SessionAgentOptions | undefined,
 ): void {
+  const systemPromptOption = options?.systemPrompt;
+  const normalizedSystemPrompt =
+    typeof systemPromptOption === "string" && systemPromptOption.length > 0
+      ? systemPromptOption
+      : systemPromptOption &&
+          typeof systemPromptOption === "object" &&
+          typeof systemPromptOption.append === "string" &&
+          systemPromptOption.append.length > 0
+        ? { append: systemPromptOption.append }
+        : undefined;
+
   const next =
     options &&
     ({
       model: typeof options.model === "string" ? options.model : undefined,
       allowed_tools: Array.isArray(options.allowedTools) ? [...options.allowedTools] : undefined,
       max_turns: typeof options.maxTurns === "number" ? options.maxTurns : undefined,
+      system_prompt: normalizedSystemPrompt,
     } satisfies NonNullable<NonNullable<SessionRecord["acpx"]>["session_options"]>);
 
   const hasValues = Boolean(
     next &&
     ((typeof next.model === "string" && next.model.trim().length > 0) ||
       (Array.isArray(next.allowed_tools) && next.allowed_tools.length > 0) ||
-      typeof next.max_turns === "number"),
+      typeof next.max_turns === "number" ||
+      next.system_prompt !== undefined),
   );
 
   if (hasValues && next) {

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -1,9 +1,12 @@
 import type { SessionRecord } from "../../types.js";
 
+export type SystemPromptOption = string | { append: string };
+
 export type SessionAgentOptions = {
   model?: string;
   allowedTools?: string[];
   maxTurns?: number;
+  systemPrompt?: SystemPromptOption;
 };
 
 export function sessionOptionsFromRecord(record: SessionRecord): SessionAgentOptions | undefined {
@@ -22,6 +25,17 @@ export function sessionOptionsFromRecord(record: SessionRecord): SessionAgentOpt
   }
   if (typeof stored.max_turns === "number") {
     sessionOptions.maxTurns = stored.max_turns;
+  }
+  const storedSystemPrompt = stored.system_prompt;
+  if (typeof storedSystemPrompt === "string" && storedSystemPrompt.length > 0) {
+    sessionOptions.systemPrompt = storedSystemPrompt;
+  } else if (
+    storedSystemPrompt &&
+    typeof storedSystemPrompt === "object" &&
+    typeof (storedSystemPrompt as { append?: unknown }).append === "string" &&
+    (storedSystemPrompt as { append: string }).append.length > 0
+  ) {
+    sessionOptions.systemPrompt = { append: (storedSystemPrompt as { append: string }).append };
   }
 
   return Object.keys(sessionOptions).length > 0 ? sessionOptions : undefined;

--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -465,6 +465,14 @@ export function cloneSessionAcpxState(
             ? [...state.session_options.allowed_tools]
             : undefined,
           max_turns: state.session_options.max_turns,
+          ...(state.session_options.system_prompt !== undefined
+            ? {
+                system_prompt:
+                  typeof state.session_options.system_prompt === "string"
+                    ? state.session_options.system_prompt
+                    : { append: state.session_options.system_prompt.append },
+              }
+            : {}),
         }
       : undefined,
   };

--- a/src/session/mode-preference.ts
+++ b/src/session/mode-preference.ts
@@ -56,7 +56,8 @@ export function setDesiredModelId(record: SessionRecord, modelId: string | undef
   if (
     typeof sessionOptions.model === "string" ||
     Array.isArray(sessionOptions.allowed_tools) ||
-    typeof sessionOptions.max_turns === "number"
+    typeof sessionOptions.max_turns === "number" ||
+    sessionOptions.system_prompt !== undefined
   ) {
     acpx.session_options = sessionOptions;
   } else {

--- a/src/session/persistence/parse.ts
+++ b/src/session/persistence/parse.ts
@@ -323,6 +323,20 @@ function parseAcpxState(raw: unknown): SessionAcpxState | undefined {
       parsedSessionOptions.max_turns = sessionOptions.max_turns;
     }
 
+    const rawSystemPrompt = sessionOptions.system_prompt;
+    if (typeof rawSystemPrompt === "string" && rawSystemPrompt.length > 0) {
+      parsedSessionOptions.system_prompt = rawSystemPrompt;
+    } else {
+      const appendRecord = asRecord(rawSystemPrompt);
+      if (
+        appendRecord &&
+        typeof appendRecord.append === "string" &&
+        appendRecord.append.length > 0
+      ) {
+        parsedSessionOptions.system_prompt = { append: appendRecord.append };
+      }
+    }
+
     if (Object.keys(parsedSessionOptions).length > 0) {
       state.session_options = parsedSessionOptions;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,7 @@ export type AcpClientOptions = {
     model?: string;
     allowedTools?: string[];
     maxTurns?: number;
+    systemPrompt?: string | { append: string };
   };
   onAcpMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
   onAcpOutputMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
@@ -292,6 +293,7 @@ export type SessionAcpxState = {
     model?: string;
     allowed_tools?: string[];
     max_turns?: number;
+    system_prompt?: string | { append: string };
   };
 };
 

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { hasExplicitPermissionModeFlag, resolvePermissionMode } from "../src/cli/flags.js";
+import {
+  hasExplicitPermissionModeFlag,
+  resolvePermissionMode,
+  resolveSystemPromptFlag,
+} from "../src/cli/flags.js";
 
 test("resolvePermissionMode honors explicit approve-reads overrides", () => {
   assert.equal(resolvePermissionMode({ approveReads: true }, "approve-all"), "approve-reads");
@@ -13,4 +17,30 @@ test("hasExplicitPermissionModeFlag detects explicit permission grants", () => {
   assert.equal(hasExplicitPermissionModeFlag({ approveReads: true }), true);
   assert.equal(hasExplicitPermissionModeFlag({ approveAll: true }), true);
   assert.equal(hasExplicitPermissionModeFlag({ denyAll: true }), true);
+});
+
+test("resolveSystemPromptFlag returns undefined when neither flag is set", () => {
+  assert.equal(resolveSystemPromptFlag({}), undefined);
+  assert.equal(resolveSystemPromptFlag({ systemPrompt: "" }), undefined);
+  assert.equal(resolveSystemPromptFlag({ appendSystemPrompt: "" }), undefined);
+});
+
+test("resolveSystemPromptFlag returns string for --system-prompt", () => {
+  assert.equal(
+    resolveSystemPromptFlag({ systemPrompt: "you are an obsidian assistant" }),
+    "you are an obsidian assistant",
+  );
+});
+
+test("resolveSystemPromptFlag returns append object for --append-system-prompt", () => {
+  assert.deepEqual(resolveSystemPromptFlag({ appendSystemPrompt: "always speak in spanish" }), {
+    append: "always speak in spanish",
+  });
+});
+
+test("resolveSystemPromptFlag rejects combining --system-prompt and --append-system-prompt", () => {
+  assert.throws(
+    () => resolveSystemPromptFlag({ systemPrompt: "a", appendSystemPrompt: "b" }),
+    /Use only one of --system-prompt or --append-system-prompt/,
+  );
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -446,6 +446,62 @@ test("AcpClient createSession forwards claudeCode options in _meta", async () =>
   });
 });
 
+test("AcpClient createSession forwards systemPrompt string in _meta", async () => {
+  const client = makeClient({
+    sessionOptions: {
+      systemPrompt: "you are an obsidian assistant",
+    },
+  });
+
+  let capturedParams: Record<string, unknown> | undefined;
+  asInternals(client).connection = {
+    newSession: async (params: Record<string, unknown>) => {
+      capturedParams = params;
+      return { sessionId: "session-sp-string" };
+    },
+  };
+
+  await client.createSession("/tmp/acpx-client-system-prompt");
+  assert.deepEqual(capturedParams, {
+    cwd: "/tmp/acpx-client-system-prompt",
+    mcpServers: [],
+    _meta: {
+      systemPrompt: "you are an obsidian assistant",
+    },
+  });
+});
+
+test("AcpClient createSession forwards systemPrompt append in _meta alongside claudeCode options", async () => {
+  const client = makeClient({
+    sessionOptions: {
+      model: "sonnet",
+      systemPrompt: { append: "always speak in spanish" },
+    },
+  });
+
+  let capturedParams: Record<string, unknown> | undefined;
+  asInternals(client).connection = {
+    newSession: async (params: Record<string, unknown>) => {
+      capturedParams = params;
+      return { sessionId: "session-sp-append" };
+    },
+  };
+
+  await client.createSession("/tmp/acpx-client-system-prompt-append");
+  assert.deepEqual(capturedParams, {
+    cwd: "/tmp/acpx-client-system-prompt-append",
+    mcpServers: [],
+    _meta: {
+      claudeCode: {
+        options: {
+          model: "sonnet",
+        },
+      },
+      systemPrompt: { append: "always speak in spanish" },
+    },
+  });
+});
+
 test("AcpClient createSession forwards codex model metadata without setting it explicitly", async () => {
   const client = makeClient({
     agentCommand: "npx @zed-industries/codex-acp",

--- a/test/session-persistence.test.ts
+++ b/test/session-persistence.test.ts
@@ -107,6 +107,59 @@ test("listSessions preserves acpx session_options", async () => {
   });
 });
 
+test("listSessions preserves acpx session_options system_prompt string and append", async () => {
+  await withTempHome(async (homeDir) => {
+    const session = await loadSessionModule();
+    const cwd = path.join(homeDir, "workspace");
+
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "session-system-prompt-string",
+        acpSessionId: "session-system-prompt-string",
+        agentCommand: "agent-a",
+        cwd,
+        acpx: {
+          session_options: {
+            system_prompt: "you are an obsidian assistant",
+          },
+        },
+      }),
+    );
+    await writeSessionRecord(
+      homeDir,
+      makeSessionRecord({
+        acpxRecordId: "session-system-prompt-append",
+        acpSessionId: "session-system-prompt-append",
+        agentCommand: "agent-a",
+        cwd,
+        acpx: {
+          session_options: {
+            system_prompt: { append: "always speak in spanish" },
+          },
+        },
+      }),
+    );
+
+    const sessions = await session.listSessions();
+    const stringRecord = sessions.find(
+      (entry) => entry.acpxRecordId === "session-system-prompt-string",
+    );
+    const appendRecord = sessions.find(
+      (entry) => entry.acpxRecordId === "session-system-prompt-append",
+    );
+    assert.ok(stringRecord);
+    assert.ok(appendRecord);
+    assert.equal(
+      stringRecord.acpx?.session_options?.system_prompt,
+      "you are an obsidian assistant",
+    );
+    assert.deepEqual(appendRecord.acpx?.session_options?.system_prompt, {
+      append: "always speak in spanish",
+    });
+  });
+});
+
 test("listSessions ignores unsupported conversation message shapes", async () => {
   await withTempHome(async (homeDir) => {
     const sessionDir = path.join(homeDir, ".acpx", "sessions");


### PR DESCRIPTION
## Summary

Adds two global CLI flags that forward through to claude-agent-acp via the ACP `_meta.systemPrompt` field that landed in [agentclientprotocol/claude-agent-acp#91](https://github.com/agentclientprotocol/claude-agent-acp/pull/91):

- `--system-prompt <text>` — replace the Claude Code system prompt entirely
- `--append-system-prompt <text>` — append to the default Claude Code system prompt

Both are mutually exclusive and validated at flag-resolve time. The option is persisted in `session_options.system_prompt` so `acpx claude sessions ensure` / reuse flows keep the override across turns, and is emitted alongside the existing `claudeCode.options` in `_meta` on `session/new`:

```jsonc
// --system-prompt "..."
{ "_meta": { "systemPrompt": "you are an obsidian assistant" } }

// --append-system-prompt "..." --model sonnet
{
  "_meta": {
    "claudeCode": { "options": { "model": "sonnet" } },
    "systemPrompt": { "append": "always speak in spanish" }
  }
}
```

Codex and other adapters ignore the field, so this is safe to keep as a global flag rather than a claude-specific one, matching how `--model` / `--allowed-tools` are already handled.

## Why

Today there is no way to pass a system prompt override through acpx into Claude Code: acpx drives claude-agent-acp over ACP rather than forwarding unknown args to the `claude` binary, so `--system-prompt` / `--append-system-prompt` on the underlying CLI are unreachable. `claude-agent-acp` has supported `_meta.systemPrompt` (string = replace, `{append}` = append) since PR #91, so this is purely an acpx-side plumbing gap.

## Changes

- `SessionAgentOptions` / `AcpClientOptions.sessionOptions` gain a `systemPrompt?: string | { append: string }` field; the persisted shape is `session_options.system_prompt` (snake_case, passes `lint:persisted-key-casing`).
- `buildClaudeCodeOptionsMeta` lifts `systemPrompt` to the top level of `_meta` (not nested under `claudeCode.options`), matching the claude-agent-acp parser.
- New `resolveSystemPromptFlag` helper enforces mutual exclusion and returns the correct union shape.
- Persistence round-trips the field through `conversation-model`, `persistence/parse`, `session-management`, and `mode-preference`.
- All three `sessionOptions` construction sites in `command-handlers.ts` (`runOnce`, `sessions new`, `sessions ensure`) now forward the flag.

## Tests

- `pnpm check` passes locally (format, typecheck, oxlint, build, viewer typecheck/build, `test:coverage`): **528 / 528 tests pass**.
- New unit tests:
  - `test/client.test.ts` — `AcpClient createSession` emits `_meta.systemPrompt` as a string, and emits `{ append }` alongside `claudeCode.options`.
  - `test/cli-flags.test.ts` — `resolveSystemPromptFlag` string/append/none/mutual-exclusion cases.
  - `test/session-persistence.test.ts` — `listSessions` round-trips both the string and the `{ append }` shapes through `session_options.system_prompt`.
- Live end-to-end against `@anthropic-ai/claude-code@2.1.92` + `@agentclientprotocol/claude-agent-acp`:
  - `acpx --system-prompt "...respond with EXACTLY SP_OVERRIDE_TOKEN_42..." claude exec "say hi"` → returns exactly `SP_OVERRIDE_TOKEN_42`, confirming the replace path.
  - `acpx --append-system-prompt "...always include APPEND_TOKEN_99..." claude exec "What is 2+2?"` → returns `4` followed by `APPEND_TOKEN_99`, confirming the append path.
  - Passing both flags errors with `Use only one of --system-prompt or --append-system-prompt`.

## Test plan

- [x] `pnpm check`
- [x] Live verification against `claude-agent-acp` for both replace and append
- [x] Mutual exclusion guard exercised
- [ ] Reviewer sanity check that top-level `_meta.systemPrompt` is the shape they want vs. nesting under `claudeCode`

## AI-assisted PR

Per CONTRIBUTING.md:

- [x] Marked AI-assisted in the title
- [x] Fully tested (unit tests + live e2e against real claude-agent-acp)
- [x] I understand what the code does and will own any review follow-through