### PR TITLE
fix(ci): handle newer sdk and lint behavior

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -548,6 +548,7 @@ export class AcpClient {
       this.log(`initialized protocol version ${initResult.protocolVersion}`);
     } catch (error) {
       startupFailure.dispose();
+      const normalizedError = await this.normalizeInitializeError(error, child, startupStderr);
       try {
         child.kill();
       } catch {
@@ -562,7 +563,7 @@ export class AcpClient {
           },
         );
       }
-      throw error;
+      throw normalizedError;
     }
   }
 
@@ -1085,6 +1086,31 @@ export class AcpClient {
       promise,
       dispose: () => finish(),
     };
+  }
+
+  private async normalizeInitializeError(
+    error: unknown,
+    child: ChildProcessByStdio<Writable, Readable, Readable>,
+    startupStderr: string[],
+  ): Promise<unknown> {
+    if (error instanceof AgentStartupError) {
+      return error;
+    }
+
+    const connectionClosedDuringInitialize =
+      error instanceof Error && /acp connection closed/i.test(error.message);
+    if (!connectionClosedDuringInitialize) {
+      return error;
+    }
+
+    await waitForChildExit(child, 100);
+    return new AgentStartupError({
+      agentCommand: this.options.agentCommand,
+      exitCode: child.exitCode ?? null,
+      signal: child.signalCode ?? null,
+      stderrSummary: this.summarizeStartupStderr(startupStderr),
+      cause: error,
+    });
   }
 
   private selectAuthMethod(methods: AuthMethod[]): AuthSelection | undefined {

--- a/src/acp/jsonrpc-error.ts
+++ b/src/acp/jsonrpc-error.ts
@@ -57,16 +57,37 @@ function buildFallbackData(params: BuildJsonRpcErrorParams): Record<string, unkn
   return data;
 }
 
+function mergeAcpErrorData(acpData: unknown, fallbackData: Record<string, unknown>): unknown {
+  if (Object.keys(fallbackData).length === 0) {
+    return acpData;
+  }
+  if (acpData === undefined) {
+    return fallbackData;
+  }
+  if (acpData && typeof acpData === "object" && !Array.isArray(acpData)) {
+    return {
+      ...acpData,
+      ...fallbackData,
+    };
+  }
+  return {
+    acpData,
+    ...fallbackData,
+  };
+}
+
 function buildErrorObject(params: BuildJsonRpcErrorParams): JsonRpcErrorObject {
+  const fallbackData = buildFallbackData(params);
   if (hasValidAcpError(params.acp)) {
+    const data = mergeAcpErrorData(params.acp.data, fallbackData);
     return {
       code: params.acp.code,
       message: params.acp.message,
-      ...(params.acp.data !== undefined ? { data: params.acp.data } : {}),
+      ...(data !== undefined ? { data } : {}),
     };
   }
 
-  const data = buildFallbackData(params);
+  const data = fallbackData;
   return {
     code: OUTPUT_ERROR_JSONRPC_CODES[params.outputCode] ?? -32603,
     message: params.message,

--- a/src/acp/jsonrpc-error.ts
+++ b/src/acp/jsonrpc-error.ts
@@ -66,14 +66,11 @@ function mergeAcpErrorData(acpData: unknown, fallbackData: Record<string, unknow
   }
   if (acpData && typeof acpData === "object" && !Array.isArray(acpData)) {
     return {
-      ...acpData,
       ...fallbackData,
+      ...acpData,
     };
   }
-  return {
-    acpData,
-    ...fallbackData,
-  };
+  return acpData;
 }
 
 function buildErrorObject(params: BuildJsonRpcErrorParams): JsonRpcErrorObject {

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -133,7 +133,7 @@ async function defaultConfirmExecute(commandLine: string): Promise<boolean> {
 }
 
 function canPromptForPermission(): boolean {
-  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+  return process.stdin.isTTY && process.stderr.isTTY;
 }
 
 function waitMs(ms: number): Promise<void> {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -56,7 +56,7 @@ async function defaultConfirmWrite(filePath: string, preview: string): Promise<b
 }
 
 function canPromptForPermission(): boolean {
-  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+  return process.stdin.isTTY && process.stderr.isTTY;
 }
 
 export class FileSystemHandlers {

--- a/src/flows/graph.ts
+++ b/src/flows/graph.ts
@@ -101,7 +101,7 @@ function getByPath(value: unknown, jsonPath: string): unknown {
   return jsonPath
     .slice(2)
     .split(".")
-    .reduce<unknown>((current, key) => {
+    .reduce((current: unknown, key) => {
       if (current == null || typeof current !== "object") {
         return undefined;
       }

--- a/src/flows/json.ts
+++ b/src/flows/json.ts
@@ -1,5 +1,23 @@
 export type JsonObjectParseMode = "strict" | "fenced" | "compat";
 
+function normalizeJsonText(text: unknown): string {
+  if (typeof text === "string") {
+    return text.trim();
+  }
+  if (text == null) {
+    return "";
+  }
+  if (
+    typeof text === "number" ||
+    typeof text === "boolean" ||
+    typeof text === "bigint" ||
+    typeof text === "symbol"
+  ) {
+    return String(text).trim();
+  }
+  return "";
+}
+
 // The generic entrypoint when a workflow wants to choose its tolerance level
 // explicitly. Most callers should still use one of the small helpers below.
 export function parseJsonObject(
@@ -8,7 +26,7 @@ export function parseJsonObject(
     mode?: JsonObjectParseMode;
   } = {},
 ): unknown {
-  const trimmed = text.trim();
+  const trimmed = normalizeJsonText(text);
   if (!trimmed) {
     throw new Error("Expected JSON output, got empty text");
   }

--- a/src/flows/json.ts
+++ b/src/flows/json.ts
@@ -8,7 +8,7 @@ export function parseJsonObject(
     mode?: JsonObjectParseMode;
   } = {},
 ): unknown {
-  const trimmed = String(text ?? "").trim();
+  const trimmed = text.trim();
   if (!trimmed) {
     throw new Error("Expected JSON output, got empty text");
   }

--- a/src/flows/store.ts
+++ b/src/flows/store.ts
@@ -410,7 +410,7 @@ function createFlowDefinitionSnapshot(flow: FlowDefinition): FlowDefinitionSnaps
   };
 }
 
-function snapshotNode(node: FlowNodeDefinition) {
+function snapshotNode(node: FlowNodeDefinition): FlowDefinitionSnapshot["nodes"][string] {
   const common = {
     nodeType: node.nodeType,
     ...(node.timeoutMs !== undefined ? { timeoutMs: node.timeoutMs } : {}),
@@ -453,6 +453,8 @@ function snapshotNode(node: FlowNodeDefinition) {
         hasRun: typeof node.run === "function",
       };
   }
+
+  throw new Error(`Unsupported flow node type: ${String(node satisfies never)}`);
 }
 
 function snapshotCwd(cwd: AcpNodeDefinition["cwd"]): {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -92,7 +92,7 @@ async function promptForToolPermission(params: RequestPermissionRequest): Promis
 }
 
 function canPromptForPermission(): boolean {
-  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+  return process.stdin.isTTY && process.stderr.isTTY;
 }
 
 export function permissionModeSatisfies(actual: PermissionMode, required: PermissionMode): boolean {

--- a/test/flows.test.ts
+++ b/test/flows.test.ts
@@ -64,6 +64,14 @@ test("parseJsonObject supports strict and fenced-only modes", () => {
   assert.deepEqual(parseJsonObject('```json\n{"ok":true}\n```', { mode: "fenced" }), {
     ok: true,
   });
+  assert.throws(
+    () => parseJsonObject(undefined as unknown as string),
+    /Expected JSON output, got empty text/,
+  );
+  assert.throws(
+    () => parseJsonObject(null as unknown as string),
+    /Expected JSON output, got empty text/,
+  );
   assert.throws(() => parseStrictJsonObject('before {"ok":true} after'), /Could not parse JSON/);
   assert.throws(
     () => parseJsonObject('before {"ok":true} after', { mode: "fenced" }),

--- a/test/jsonrpc-error.test.ts
+++ b/test/jsonrpc-error.test.ts
@@ -25,14 +25,69 @@ test("buildJsonRpcErrorResponse preserves ACP payload and ACPX metadata when ava
   assert.equal(response.error.code, -32099);
   assert.equal(response.error.message, "adapter failure");
   assert.deepEqual(response.error.data, {
-    reason: "boom",
     acpxCode: "RUNTIME",
     detailCode: "SESSION_MODE_REPLAY_FAILED",
     origin: "acp",
     retryable: true,
     timestamp: "2026-02-28T00:00:00.000Z",
     sessionId: "session-1",
+    reason: "boom",
   });
+});
+
+test("buildJsonRpcErrorResponse preserves adapter keys when ACP payload overlaps metadata names", () => {
+  const response = buildJsonRpcErrorResponse({
+    outputCode: "RUNTIME",
+    detailCode: "SESSION_MODE_REPLAY_FAILED",
+    origin: "acp",
+    message: "fallback message",
+    retryable: true,
+    timestamp: "2026-02-28T00:00:00.000Z",
+    sessionId: "session-1",
+    acp: {
+      code: -32099,
+      message: "adapter failure",
+      data: {
+        sessionId: "adapter-session",
+        retryable: false,
+      },
+    },
+  });
+
+  assert.deepEqual(response.error.data, {
+    acpxCode: "RUNTIME",
+    detailCode: "SESSION_MODE_REPLAY_FAILED",
+    origin: "acp",
+    retryable: false,
+    timestamp: "2026-02-28T00:00:00.000Z",
+    sessionId: "adapter-session",
+  });
+});
+
+test("buildJsonRpcErrorResponse preserves scalar and array ACP payloads verbatim", () => {
+  const arrayResponse = buildJsonRpcErrorResponse({
+    outputCode: "RUNTIME",
+    message: "fallback message",
+    sessionId: "session-1",
+    acp: {
+      code: -32099,
+      message: "adapter failure",
+      data: ["boom"],
+    },
+  });
+  assert.deepEqual(arrayResponse.error.data, ["boom"]);
+
+  const scalarResponse = buildJsonRpcErrorResponse({
+    outputCode: "RUNTIME",
+    message: "fallback message",
+    sessionId: "session-1",
+    acp: {
+      code: -32099,
+      message: "adapter failure",
+      data: "boom",
+    },
+  });
+  assert.equal(scalarResponse.error.data, "boom");
 });
 
 test("buildJsonRpcErrorResponse shapes fallback ACPX metadata", () => {

--- a/test/jsonrpc-error.test.ts
+++ b/test/jsonrpc-error.test.ts
@@ -2,10 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildJsonRpcErrorResponse } from "../src/acp/jsonrpc-error.js";
 
-test("buildJsonRpcErrorResponse preserves ACP payload when available", () => {
+test("buildJsonRpcErrorResponse preserves ACP payload and ACPX metadata when available", () => {
   const response = buildJsonRpcErrorResponse({
     outputCode: "RUNTIME",
+    detailCode: "SESSION_MODE_REPLAY_FAILED",
+    origin: "acp",
     message: "fallback message",
+    retryable: true,
+    timestamp: "2026-02-28T00:00:00.000Z",
     sessionId: "session-1",
     acp: {
       code: -32099,
@@ -22,6 +26,12 @@ test("buildJsonRpcErrorResponse preserves ACP payload when available", () => {
   assert.equal(response.error.message, "adapter failure");
   assert.deepEqual(response.error.data, {
     reason: "boom",
+    acpxCode: "RUNTIME",
+    detailCode: "SESSION_MODE_REPLAY_FAILED",
+    origin: "acp",
+    retryable: true,
+    timestamp: "2026-02-28T00:00:00.000Z",
+    sessionId: "session-1",
   });
 });
 


### PR DESCRIPTION
## TL;DR
This keeps CI green against newer ACP SDK and type-aware lint behavior. It normalizes initialize-time connection-close races back into startup failures, preserves ACPX metadata without breaking adapter error payloads, and removes a handful of newer lint violations.

## Summary
- normalize initialize-time `ACP connection closed` failures into `AgentStartupError`
- preserve ACPX metadata for object-shaped ACP error payloads while keeping scalar and array adapter payloads unchanged
- restore null-safe `parseJsonObject` behavior for untyped callers and cover it with tests
- remove newer type-aware lint violations in permission helpers and flow utilities

## Review Focus
- startup failure handling in `src/acp/client.ts`
- JSON error payload compatibility in `src/acp/jsonrpc-error.ts`
- null-safe flow JSON parsing in `src/flows/json.ts`
- compatibility with newer `oxlint` and ACP SDK behavior

## Test Plan
- [x] `pnpm run check`
- [x] `node dist/cli.js --format quiet --approve-all codex exec "Reply with exactly OK and nothing else."`
- [x] `node dist/cli.js --format quiet --approve-all claude exec "Reply with exactly OK and nothing else."`
- [x] repro with newer `@agentclientprotocol/sdk@0.18.1` in a scratch worktree
- [x] repro with newer type-aware lint rules via `oxlint@1.59.0` and native preview updates
