### PR TITLE
feat(skills): add coding skill with agent references

### DIFF
--- a/skills/coding/SKILL.md
+++ b/skills/coding/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: coding
+description: "Run coding agents (codex, droid, opencode, etc.) via acpx. Unified interface for agent-to-agent communication, session management, and structured output. Triggers on coding task, implement, fix bug, refactor, code review."
+---
+
+# coding
+
+## When to use this skill
+
+Use this skill when you need to delegate coding tasks to specialized AI agents. Choose the right agent based on your needs:
+
+| Scenario | Agent | Why |
+|----------|-------|-----|
+| General coding, refactoring | **codex** | Strong reasoning, broad knowledge |
+| Fast iteration, Kimi model | **droid** | Quick execution, plan-oriented |
+| oh-my-opencode setup | **opencode** | Custom agent system, ulw workflows |
+
+## Quick start
+
+```bash
+# Install acpx globally (required)
+npm i -g acpx
+
+# One-shot execution (no session state)
+acpx exec "fix the failing test in src/auth.ts"
+
+# Persistent session (remembers context)
+acpx codex "review the changed files and suggest improvements"
+acpx codex "apply the suggested fixes"
+
+# Different agents
+acpx droid "implement pagination for the API endpoints"
+acpx opencode "explore the codebase and create a plan"
+```
+
+## Core commands
+
+```bash
+# Start a coding session
+acpx <agent> "your prompt"
+
+# One-shot (no session persistence)
+acpx <agent> exec "your prompt"
+
+# Named parallel sessions
+acpx codex -s backend "fix API bug"
+acpx codex -s frontend "update UI components"
+
+# Session management
+acpx sessions list          # show active sessions
+acpx sessions new           # create fresh session
+acpx sessions close         # close current session
+acpx status                 # check agent status
+```
+
+## Supported agents
+
+### codex (default)
+
+```bash
+acpx codex "implement retry logic for API calls"
+acpx "fix the failing tests"  # codex is default
+```
+
+**Details:** See [references/codex.md](references/codex.md)
+
+### droid
+
+```bash
+acpx droid "add unit tests for the auth module"
+```
+
+**Details:** See [references/droid.md](references/droid.md)
+
+### opencode (oh-my-opencode)
+
+> **Note:** For opencode with oh-my-opencode agents (Sisyphus, Atlas, etc.), use the dedicated `oc-work` toolchain instead of acpx. See [references/opencode.md](references/opencode.md) for both approaches.
+
+```bash
+# Via acpx (vanilla opencode)
+acpx opencode "review the codebase structure"
+
+# Via oc-work (oh-my-opencode with Sisyphus/Atlas/etc.)
+oc-work start --topic my-task --message "implement feature X. ulw"
+```
+
+**Details:** See [references/opencode.md](references/opencode.md)
+
+## Output formats
+
+```bash
+# Human-readable (default)
+acpx codex "explain the bug"
+
+# JSON stream (for automation)
+acpx --format json codex exec "list all API endpoints" > output.ndjson
+
+# Final text only
+acpx --format quiet exec "summarize the repo" > summary.txt
+```
+
+## Permission modes
+
+```bash
+# Auto-approve reads only (default)
+acpx codex "review code"
+
+# Auto-approve everything
+acpx --approve-all codex "fix and commit"
+
+# Deny all (dry run)
+acpx --deny-all codex "what would you change?"
+```
+
+## Best practices
+
+1. **English prompts**: All agents work best with English prompts
+2. **Be specific**: Include file paths, function names, expected behavior
+3. **Use sessions**: For multi-step tasks, use persistent sessions to maintain context
+4. **Named sessions**: Use `-s <name>` for parallel work streams
+5. **Check status**: Run `acpx status` before starting if unsure about current state
+
+## Installation
+
+See [references/installation.md](references/installation.md) for detailed setup instructions.
+
+## Troubleshooting
+
+**"command not found: acpx"**
+```bash
+npm i -g acpx
+```
+
+**Agent auth expired**
+- codex: Run `codex auth login`
+- droid: Run `droid auth login`
+
+**Session stuck**
+```bash
+acpx sessions close
+acpx sessions new
+```
+
+## Full reference
+
+- [Installation](references/installation.md) - Setup acpx and agent dependencies
+- [Codex](references/codex.md) - OpenAI Codex agent details
+- [Droid](references/droid.md) - Factory Droid agent details
+- [OpenCode](references/opencode.md) - OpenCode and oh-my-opencode details

--- a/skills/coding/references/codex.md
+++ b/skills/coding/references/codex.md
@@ -1,0 +1,118 @@
+# Codex
+
+OpenAI's Codex agent via the ACP adapter.
+
+## Quick reference
+
+- **Built-in name:** `codex`
+- **Command:** `npx @zed-industries/codex-acp`
+- **Default model:** gpt-5.4/high
+- **Auth:** `~/.codex/auth.json` (ChatGPT Pro subscription required)
+- **Upstream:** https://github.com/zed-industries/codex-acp
+
+## Usage
+
+```bash
+# Basic prompt
+acpx codex "fix the failing tests"
+
+# codex is the default agent, so this also works
+acpx "fix the failing tests"
+
+# One-shot execution
+acpx codex exec "summarize this repo in 3 lines"
+
+# Named session
+acpx codex -s refactor "start refactoring the auth module"
+```
+
+## Models
+
+Available models (specify with `--model`):
+
+| Model | Description |
+|-------|-------------|
+| `gpt-5.4/high` | Default, best reasoning |
+| `gpt-5.4/xhigh` | Extended reasoning |
+| `gpt-5.3-codex` | Legacy codex model |
+
+```bash
+acpx --model gpt-5.4/xhigh codex "complex refactoring task"
+```
+
+## Configuration options
+
+Set via `acpx codex set`:
+
+```bash
+# Set reasoning effort (thought_level is an alias)
+acpx codex set reasoning_effort high
+acpx codex set thought_level high  # alias
+
+# Set model mid-session
+acpx codex set model gpt-5.4/xhigh
+
+# Set mode
+acpx codex set-mode auto
+```
+
+## Authentication
+
+Codex requires a ChatGPT Pro subscription:
+
+```bash
+# Initial auth (opens browser)
+codex auth login
+
+# Check auth status
+acpx codex status
+```
+
+**Auth file:** `~/.codex/auth.json`
+
+When auth expires:
+1. Run `codex auth login`
+2. Complete browser authentication
+3. Resume work with `acpx codex`
+
+## Slash commands
+
+Codex supports these in-session commands:
+
+| Command | Description |
+|---------|-------------|
+| `/review` | Review current changes |
+| `/compact` | Compact session history |
+| `/planner` | Switch to planning mode |
+| `/executor` | Switch to execution mode |
+| `/verifier` | Switch to verification mode |
+
+## Best practices
+
+1. **Use English prompts** - Codex performs best with English
+2. **Be specific** - Include file paths and expected behavior
+3. **Use sessions** - Maintain context across related tasks
+4. **Set reasoning level** - Use `xhigh` for complex tasks
+
+## Environment notes
+
+If `OPENAI_API_KEY` or `OPENAI_BASE_URL` are set in your environment, acpx automatically strips them to avoid conflicts with Codex's native auth.
+
+## Troubleshooting
+
+**"Auth expired" or "Unauthorized"**
+```bash
+codex auth login
+```
+
+**Session stuck**
+```bash
+acpx codex cancel
+# or
+acpx sessions close && acpx sessions new
+```
+
+**Wrong model being used**
+```bash
+acpx codex set model gpt-5.4/high
+```

--- a/skills/coding/references/droid.md
+++ b/skills/coding/references/droid.md
@@ -1,0 +1,105 @@
+# Droid
+
+Factory AI's Droid agent for fast, plan-oriented coding.
+
+## Quick reference
+
+- **Built-in name:** `droid`
+- **Aliases:** `factory-droid`, `factorydroid`
+- **Command:** `droid exec --output-format acp`
+- **Default model:** Kimi-K2.5-Turbo
+- **Auth:** `~/.factory/auth.v2.file` + `~/.factory/auth.v2.key`
+- **Upstream:** https://www.factory.ai
+
+## Usage
+
+```bash
+# Basic prompt
+acpx droid "implement pagination for the API"
+
+# One-shot execution
+acpx droid exec "add unit tests for auth module"
+
+# Named session
+acpx droid -s api "work on API improvements"
+
+# Using aliases
+acpx factory-droid "your prompt"
+acpx factorydroid "your prompt"
+```
+
+## Droid-specific features
+
+### Plan events
+
+Droid uniquely emits `plan.updated` events during execution, providing visibility into its task planning:
+
+```bash
+# Watch plan updates in JSON format
+acpx --format json droid "implement feature X" | grep plan
+```
+
+Plan events include:
+- Task entries with priority and status
+- Estimated effort
+- Dependencies between tasks
+
+### Fast iteration
+
+Droid is optimized for quick iterations:
+- Faster response times than Codex
+- Good for straightforward implementation tasks
+- Plan-oriented approach shows work breakdown
+
+## Authentication
+
+```bash
+# Initial auth
+droid auth login
+
+# Check status
+acpx droid status
+```
+
+**Auth files:**
+- `~/.factory/auth.v2.file`
+- `~/.factory/auth.v2.key`
+
+When auth expires:
+```bash
+droid auth login
+```
+
+## Best practices
+
+1. **Use for implementation** - Droid excels at clear implementation tasks
+2. **English prompts** - Required for best results
+3. **Watch the plan** - Use JSON format to see task breakdown
+4. **Quick iterations** - Good for "try this, then this" workflows
+
+## Comparison with Codex
+
+| Aspect | Droid | Codex |
+|--------|-------|-------|
+| Speed | Faster | More thorough |
+| Planning | Visible plan events | Internal reasoning |
+| Model | Kimi-K2.5-Turbo | GPT-5.4 |
+| Best for | Quick implementations | Complex reasoning |
+
+## Troubleshooting
+
+**"Auth expired"**
+```bash
+droid auth login
+```
+
+**"Command not found: droid"**
+```bash
+npm i -g factory-ai
+```
+
+**Session issues**
+```bash
+acpx droid cancel
+acpx sessions close
+```

--- a/skills/coding/references/installation.md
+++ b/skills/coding/references/installation.md
@@ -1,0 +1,148 @@
+# Installation
+
+## Prerequisites
+
+- Node.js 20+ (for acpx and npm-based agents)
+- npm or pnpm
+
+## Install acpx
+
+```bash
+# Global install (recommended for session reuse)
+npm i -g acpx
+
+# Verify installation
+acpx --version
+```
+
+> **Note:** Prefer global install over `npx acpx` for persistent session support.
+
+## Agent-specific setup
+
+### Codex (default agent)
+
+Codex requires authentication with ChatGPT Pro subscription:
+
+```bash
+# Install codex-acp adapter
+npm i -g @zed-industries/codex-acp
+
+# Authenticate (opens browser)
+codex auth login
+
+# Verify
+acpx codex status
+```
+
+**Auth location:** `~/.codex/auth.json`
+
+**If auth expires:**
+```bash
+codex auth login
+```
+
+### Droid (Factory AI)
+
+```bash
+# Install droid CLI
+npm i -g factory-ai
+
+# Authenticate
+droid auth login
+
+# Verify
+acpx droid status
+```
+
+**Auth location:** `~/.factory/auth.v2.file` + `~/.factory/auth.v2.key`
+
+### OpenCode
+
+Two options:
+
+**Option A: Vanilla opencode (via acpx)**
+```bash
+npm i -g opencode-ai
+acpx opencode "your prompt"
+```
+
+**Option B: oh-my-opencode (via oc-work)**
+
+oh-my-opencode provides enhanced agents (Sisyphus, Atlas, Hephaestus, Prometheus) with ultrawork workflows. It uses its own session management instead of acpx.
+
+```bash
+# Install oh-my-opencode
+git clone https://github.com/code-yeongyu/oh-my-opencode
+cd oh-my-opencode
+bun install
+bun link
+
+# Use via oc-work (not acpx)
+oc-work start --topic my-task --message "implement X. ulw"
+oc-work status
+oc-work stop --topic my-task
+```
+
+See [opencode.md](opencode.md) for detailed oh-my-opencode usage.
+
+### Other agents
+
+```bash
+# Claude
+npm i -g @agentclientprotocol/claude-agent-acp
+acpx claude "your prompt"
+
+# Gemini
+npm i -g gemini-cli
+acpx gemini "your prompt"
+
+# Cursor
+npm i -g cursor-agent
+acpx cursor "your prompt"
+```
+
+## Configuration
+
+Create global config at `~/.acpx/config.json`:
+
+```json
+{
+  "defaultAgent": "codex",
+  "defaultPermissions": "approve-reads",
+  "ttl": 300,
+  "format": "text"
+}
+```
+
+Create project config at `.acpxrc.json` in your repo:
+
+```json
+{
+  "defaultAgent": "droid",
+  "defaultPermissions": "approve-all"
+}
+```
+
+Project config merges with and overrides global config.
+
+## Verify setup
+
+```bash
+# Check acpx
+acpx --version
+
+# Check default agent (codex)
+acpx status
+
+# Test one-shot execution
+acpx exec "echo hello world"
+```
+
+## Environment variables
+
+Avoid setting these when using acpx (they may conflict with agent auth):
+
+- `OPENAI_API_KEY` - acpx strips this automatically for codex
+- `OPENAI_BASE_URL` - acpx strips this automatically for codex
+
+If you need API proxies, configure them in agent-specific config files.

--- a/skills/coding/references/opencode.md
+++ b/skills/coding/references/opencode.md
@@ -1,0 +1,160 @@
+# OpenCode
+
+Two approaches: vanilla opencode via acpx, or oh-my-opencode with enhanced agents.
+
+## Option A: Vanilla OpenCode (via acpx)
+
+- **Built-in name:** `opencode`
+- **Command:** `npx -y opencode-ai acp`
+- **Upstream:** https://opencode.ai
+
+```bash
+# Basic usage
+acpx opencode "review the codebase structure"
+
+# One-shot
+acpx opencode exec "summarize the architecture"
+
+# Session management
+acpx opencode sessions list
+```
+
+## Option B: oh-my-opencode (recommended for advanced workflows)
+
+oh-my-opencode provides specialized agents and ultrawork capabilities. It uses its own session management via `oc-work` instead of acpx.
+
+### Agents
+
+| Agent | Purpose | Best for |
+|-------|---------|----------|
+| **Sisyphus** | Ultraworker | End-to-end tasks with `ulw` |
+| **Hephaestus** | Deep worker | Single-file focused work |
+| **Atlas** | Orchestrator | Todo-based task coordination |
+| **Prometheus** | Planner | Planning without code execution |
+
+### Quick start
+
+```bash
+# Install oh-my-opencode
+git clone https://github.com/code-yeongyu/oh-my-opencode
+cd oh-my-opencode
+bun install
+bun link
+
+# Start a task
+oc-work start \
+  --topic my-task \
+  --discord $CHANNEL \
+  --dir ~/project \
+  --message "implement feature X. ulw"
+
+# Check status
+oc-work status
+
+# Send additional prompt
+oc-work send --topic my-task --message "also add tests"
+
+# Stop session
+oc-work stop --topic my-task
+```
+
+### The `ulw` keyword
+
+Adding `ulw` (ultrawork) to your prompt triggers Sisyphus's maximum effort mode:
+
+```bash
+oc-work start --topic fix \
+  --message "fix the failing tests. ulw"
+```
+
+This runs the full workflow:
+1. **Explore** - Understand the codebase
+2. **Plan** - Create actionable plan
+3. **Work** - Execute with persistence
+
+### Agent selection guide
+
+```bash
+# Clear direction + single focus → Hephaestus
+oc-work start --topic impl \
+  --message "implement the auth middleware" \
+  --agent hephaestus
+
+# Needs exploration + coordination → Sisyphus (default)
+oc-work start --topic feature \
+  --message "implement OAuth integration. ulw"
+
+# Todo-based orchestration → Atlas
+oc-work start --topic orchestrate \
+  --message "coordinate the refactoring tasks" \
+  --agent atlas
+
+# Planning only (no code) → Prometheus
+oc-work start --topic plan \
+  --message "create implementation plan for v2 API" \
+  --agent prometheus
+```
+
+### Multiple parallel sessions
+
+```bash
+# Different topics = different sessions
+oc-work start --topic backend --message "fix API bug"
+oc-work start --topic frontend --message "update components"
+
+# Check all
+oc-work status
+
+# Stop all
+oc-work stop --all
+```
+
+### Session recovery
+
+If a session gets stuck:
+
+```bash
+# Recover with new message
+oc-work recover --topic my-task --message "continue from where you left off"
+
+# Or clean restart
+oc-work stop --topic my-task
+oc-work start --topic my-task --message "restart: ..."
+```
+
+## When to use which
+
+| Scenario | Approach |
+|----------|----------|
+| Quick one-off task | `acpx opencode exec "..."` |
+| Simple session | `acpx opencode "..."` |
+| Complex multi-step work | `oc-work` with Sisyphus |
+| Need ultrawork (`ulw`) | `oc-work` (required) |
+| Custom agents (Atlas, etc.) | `oc-work` (required) |
+| Integration with Agentika | `oc-work` (built-in bridge) |
+
+## Troubleshooting
+
+**For vanilla opencode:**
+```bash
+npm i -g opencode-ai
+acpx opencode status
+```
+
+**For oh-my-opencode:**
+```bash
+# Check status
+oc-work status
+
+# Orphan sessions
+oc-work stop --all
+
+# PATH issues
+export PATH=/opt/homebrew/bin:$PATH
+```
+
+## Related resources
+
+- oh-my-opencode: https://github.com/code-yeongyu/oh-my-opencode
+- OpenCode: https://opencode.ai
+- Agentika (for oc-work bridge): https://github.com/code-yeongyu/agentika


### PR DESCRIPTION
## Summary

Add a unified `coding` skill that provides a single entry point for delegating tasks to AI coding agents via acpx.

## Structure

```
skills/coding/
├── SKILL.md                    # Main skill file
└── references/
    ├── installation.md         # Setup instructions
    ├── codex.md               # OpenAI Codex details
    ├── droid.md               # Factory Droid details
    └── opencode.md            # OpenCode + oh-my-opencode details
```

## Features

- **Unified interface**: One skill to delegate coding tasks
- **Agent selection guide**: Helps choose between codex, droid, opencode
- **Installation docs**: Step-by-step setup including auth
- **OpenCode distinction**: Documents both vanilla opencode (via acpx) and oh-my-opencode (via oc-work for Sisyphus/Atlas/etc.)

## Agent coverage

| Agent | Via | Notes |
|-------|-----|-------|
| codex | acpx | Default agent, GPT-5.4 |
| droid | acpx | Kimi-K2.5-Turbo, plan events |
| opencode | acpx | Vanilla opencode |
| oh-my-opencode | oc-work | Sisyphus, Atlas, ulw workflows |

## Why separate opencode handling?

oh-my-opencode uses its own session management (`oc-work`) with Agentika integration, which doesn't go through acpx. The skill documents both approaches so users know which to use.
