### PR TITLE
fix(runtime): preserve persistent client across turns instead of closing

### DIFF
--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -645,6 +645,11 @@ export class AcpRuntimeManager {
         reset_on_next_ensure: true,
       };
     }
+    const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
+    if (pendingClient) {
+      this.pendingPersistentClients.delete(record.acpxRecordId);
+      await pendingClient.close().catch(() => {});
+    }
     record.closed = true;
     record.closedAt = isoNow();
     await this.options.sessionStore.save(record);

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -528,7 +528,11 @@ export class AcpRuntimeManager {
         applyConversation(record, conversation);
         record.lastUsedAt = isoNow();
         await this.options.sessionStore.save(record).catch(() => {});
-        await client.close().catch(() => {});
+        if (input.sessionMode === "persistent" && client.hasReusableSession(record.acpSessionId)) {
+          this.pendingPersistentClients.set(record.acpxRecordId, client);
+        } else {
+          await client.close().catch(() => {});
+        }
         queue.close();
       }
     })();


### PR DESCRIPTION
## Summary

- In `AcpRuntimeManager.runTurn()`, the finally block unconditionally calls `client.close()`, which kills the underlying agent process
- For persistent sessions, this destroys the reusable process that should survive between turns, causing each subsequent turn to spawn a fresh process and lose in-memory state
- This change conditionally caches the client in `pendingPersistentClients` when `sessionMode === "persistent"` and the client has a reusable session, matching the existing caching logic in `openSession()`
- Oneshot sessions continue to close the client as before

## Problem

The `openSession()` method (line 293-294) correctly caches persistent clients:

```ts
if (input.mode === "persistent") {
    const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);
    this.pendingPersistentClients.set(record.acpxRecordId, client);
    keepClientOpen = true;
    await previousClient?.close().catch(() => {});
}
```

But `runTurn()` ignores this and unconditionally closes the client in its finally block (line 531), negating the caching done by `openSession()`.

## Test plan

- [ ] Spawn a persistent ACP session, verify the agent process survives after the first turn completes
- [ ] Send a second turn via `sessions_send`, verify the cached client is reused (no new process spawned)
- [ ] Verify oneshot sessions still close the client after turn completion
- [ ] Verify client is not cached when `hasReusableSession()` returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)