### PR TITLE
fix: require explicit ACPX auth envs for ACP auth selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Repo: https://github.com/openclaw/acpx
 - Sessions/load: fall back to a fresh ACP session when adapters reject `session/load` with JSON-RPC `-32601` or `-32602`, so persistent session reconnects do not crash on partial load support. (#174) Thanks @Bortlesboat.
 - Flows/runtime: finalize interrupted `flow run` bundles as failed instead of leaving them stuck at `running` when the process receives `SIGHUP`, `SIGINT`, or `SIGTERM`.
 - Client/auth: cache derived auth env key lists per auth method to avoid repeated allocations during credential lookup. (#167) Thanks @Yuan-ManX.
+- Client/auth: require explicit `ACPX_AUTH_*` env vars or config `auth` entries for ACP auth-method selection, so ambient provider env like `OPENAI_API_KEY` no longer triggers unintended login flows in adapters such as `codex-acp`.
 
 ## 2026.3.12 (v0.3.0)
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ Supported keys:
 
 Use `acpx config show` to inspect the resolved result and `acpx config init` to create the global template.
 
+For ACP `authenticate` handshakes, use either config `auth` entries or explicit
+`ACPX_AUTH_<METHOD_ID>` environment variables such as `ACPX_AUTH_OPENAI_API_KEY`.
+Ambient provider env vars such as `OPENAI_API_KEY` are still passed through to
+child agents, but they do not trigger ACP auth-method selection on their own.
+
 ## Output formats
 
 ```bash

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -380,6 +380,11 @@ Supported keys:
 
 CLI flags always override config values.
 
+For ACP `authenticate` handshakes, use either config `auth` entries or explicit
+`ACPX_AUTH_<METHOD_ID>` environment variables such as `ACPX_AUTH_OPENAI_API_KEY`.
+Ambient provider env vars such as `OPENAI_API_KEY` are still passed through to
+child agents, but they do not trigger ACP auth-method selection on their own.
+
 ## `--agent` escape hatch
 
 `--agent <command>` sets a raw adapter command explicitly.

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -226,6 +226,11 @@ Supported keys:
 
 Use `acpx config show` to inspect the resolved config and `acpx config init` to create the global template.
 
+For ACP `authenticate` handshakes, use either config `auth` entries or explicit
+`ACPX_AUTH_<METHOD_ID>` environment variables such as `ACPX_AUTH_OPENAI_API_KEY`.
+Ambient provider env vars such as `OPENAI_API_KEY` are still passed through to
+child agents, but they do not trigger ACP auth-method selection on their own.
+
 ## Session behavior
 
 Persistent prompt sessions are scoped by:

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -1,5 +1,7 @@
 import type { AcpClientOptions } from "../types.js";
 
+const AUTH_ENV_PREFIX = "ACPX_AUTH_";
+
 function toEnvToken(value: string): string {
   return value
     .trim()
@@ -8,42 +10,58 @@ function toEnvToken(value: string): string {
     .toUpperCase();
 }
 
-function buildAuthEnvKeys(methodId: string): string[] {
+function buildAuthEnvKey(methodId: string): string | undefined {
   const token = toEnvToken(methodId);
-  const keys = new Set<string>([methodId]);
-  if (token) {
-    keys.add(token);
-    keys.add(`ACPX_AUTH_${token}`);
-  }
-  return [...keys];
+  return token.length > 0 ? `${AUTH_ENV_PREFIX}${token}` : undefined;
 }
 
-const authEnvKeysCache = new Map<string, string[]>();
+const authEnvKeyCache = new Map<string, string | undefined>();
 
-function authEnvKeys(methodId: string): string[] {
-  const cached = authEnvKeysCache.get(methodId);
-  if (cached) {
+function authEnvKey(methodId: string): string | undefined {
+  const cached = authEnvKeyCache.get(methodId);
+  if (cached !== undefined) {
     return cached;
   }
-  const keys = buildAuthEnvKeys(methodId);
-  authEnvKeysCache.set(methodId, keys);
-  return keys;
+  const key = buildAuthEnvKey(methodId);
+  authEnvKeyCache.set(methodId, key);
+  return key;
 }
 
 export function readEnvCredential(methodId: string): string | undefined {
-  for (const key of authEnvKeys(methodId)) {
-    const value = process.env[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value;
-    }
+  const key = authEnvKey(methodId);
+  if (!key) {
+    return undefined;
+  }
+  const value = process.env[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
   }
   return undefined;
+}
+
+function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (!key.startsWith(AUTH_ENV_PREFIX)) {
+      continue;
+    }
+    if (typeof value !== "string" || value.trim().length === 0) {
+      continue;
+    }
+
+    const normalized = key.slice(AUTH_ENV_PREFIX.length);
+    if (!normalized || env[normalized] != null) {
+      continue;
+    }
+
+    env[normalized] = value;
+  }
 }
 
 function buildAgentEnvironment(
   authCredentials: Record<string, string> | undefined,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
+  promotePrefixedAuthEnvironment(env);
   if (!authCredentials) {
     return env;
   }
@@ -59,7 +77,7 @@ function buildAgentEnvironment(
 
     const normalized = toEnvToken(methodId);
     if (normalized) {
-      const prefixed = `ACPX_AUTH_${normalized}`;
+      const prefixed = `${AUTH_ENV_PREFIX}${normalized}`;
       if (env[prefixed] == null) {
         env[prefixed] = credential;
       }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -246,6 +246,34 @@ test("AcpClient prefers env auth credentials over config credentials", async () 
   );
 });
 
+test("AcpClient ignores ambient normalized provider env vars for auth selection", async () => {
+  await withEnv(
+    {
+      OPENAI_API_KEY: "sk-ambient",
+      ACPX_AUTH_OPENAI_API_KEY: undefined,
+    },
+    async () => {
+      const client = makeClient();
+      const internals = asInternals(client);
+
+      const selection = internals.selectAuthMethod?.([{ id: "openai-api-key" }]);
+      assert.equal(selection, undefined);
+
+      let authenticatedMethod: string | undefined;
+      await internals.authenticateIfRequired?.(
+        {
+          authenticate: async ({ methodId }: { methodId: string }) => {
+            authenticatedMethod = methodId;
+          },
+        },
+        [{ id: "openai-api-key" }],
+      );
+
+      assert.equal(authenticatedMethod, undefined);
+    },
+  );
+});
+
 test("AcpClient authenticateIfRequired throws when auth policy is fail and credentials are missing", async () => {
   const client = makeClient({ authPolicy: "fail" });
   const internals = asInternals(client);

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -18,6 +18,32 @@ test("buildAgentSpawnOptions hides Windows console windows and preserves auth en
   assert.equal(options.env.ACPX_AUTH_TOKEN, "secret-token");
 });
 
+test("buildAgentSpawnOptions promotes explicit ACPX auth env vars into agent auth env", () => {
+  const previousPrefixed = process.env.ACPX_AUTH_OPENAI_API_KEY;
+  const previousNormalized = process.env.OPENAI_API_KEY;
+
+  process.env.ACPX_AUTH_OPENAI_API_KEY = "sk-explicit";
+  delete process.env.OPENAI_API_KEY;
+
+  try {
+    const options = buildAgentSpawnOptions("/tmp/acpx-agent", undefined);
+    assert.equal(options.env.ACPX_AUTH_OPENAI_API_KEY, "sk-explicit");
+    assert.equal(options.env.OPENAI_API_KEY, "sk-explicit");
+  } finally {
+    if (previousPrefixed == null) {
+      delete process.env.ACPX_AUTH_OPENAI_API_KEY;
+    } else {
+      process.env.ACPX_AUTH_OPENAI_API_KEY = previousPrefixed;
+    }
+
+    if (previousNormalized == null) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = previousNormalized;
+    }
+  }
+});
+
 test("buildTerminalSpawnOptions hides Windows console windows and maps env entries", () => {
   const options = buildTerminalSpawnOptions("node", "/tmp/acpx-terminal", [
     { name: "TMUX", value: "/tmp/tmux-1000/default,123,0" },


### PR DESCRIPTION
Fixes #247

`acpx` and the normal `codex` CLI intentionally share the same Codex auth state. That part is fine.

The bug is that starting a Codex session through `acpx` could overwrite that shared auth instead of just reusing it.

If the parent environment had `OPENAI_API_KEY` set, `acpx` could treat it as an ACP auth credential, select `openai-api-key` during startup, and send `codex-acp` down its API-key login path. In practice that meant an existing ChatGPT OAuth login could be replaced on disk, and later `codex` CLI runs would start using the API key instead.

This change keeps explicit ACP auth working, but stops ambient provider env from participating in auth-method selection.

Only these should drive ACP `authenticate` selection:

- config `auth` entries
- explicit `ACPX_AUTH_<METHOD_ID>` env vars

Ambient provider env like `OPENAI_API_KEY` can still exist in the process environment, but it should not be enough on its own to rewrite shared Codex auth.

## What changed

- only `ACPX_AUTH_*` env vars count as ACP auth input during auth-method selection
- config `auth` entries still work as before
- explicit `ACPX_AUTH_*` values are still promoted into the child environment for adapters that expect normalized names like `OPENAI_API_KEY`
- docs were updated to make the explicit-auth requirement clear
- regression tests were added for both auth selection and child env propagation

## Verification

- `pnpm run check`
- `pnpm run check:docs`

_AI-assisted change._
