### PR TITLE
test(conformance): add post-success drain foundation guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Conformance/ACP: add a post-success drain case that catches late tool updates emitted after `session/prompt` resolves. (#252) Thanks @logofet85-ai.
 - Conformance/ACP: add a data-driven ACP core v1 conformance suite with CI smoke coverage, nightly coverage, and a hardened runner that reports startup failures cleanly and scopes filesystem checks to the session cwd. (#130) Thanks @lynnzc.
 - CLI/prompts: add `--prompt-retries` to retry transient prompt failures with exponential backoff while preserving strict JSON behavior and avoiding replay after prompt side effects. (#142) Thanks @lupuletic and @dutifulbob.
 - Output: add `--suppress-reads` to mask raw file-read bodies in text and JSON output while keeping normal tool activity visible. (#136) Thanks @hayatosc.

--- a/conformance/cases/021-prompt-post-success-drain.json
+++ b/conformance/cases/021-prompt-post-success-drain.json
@@ -36,7 +36,7 @@
     },
     {
       "type": "updates_text_includes",
-      "text": "сейчас пишу"
+      "text": "writing now"
     },
     {
       "type": "updates_session_update_includes",

--- a/conformance/cases/021-prompt-post-success-drain.json
+++ b/conformance/cases/021-prompt-post-success-drain.json
@@ -1,0 +1,51 @@
+{
+  "id": "acp.v1.session.prompt.post_success_drain",
+  "profile": "acp-core-v1",
+  "title": "Late post-success tool updates remain observable",
+  "description": "Verify the harness can still observe tool updates emitted shortly after a successful prompt response.",
+  "steps": [
+    {
+      "action": "new_session",
+      "save_as": "session_id"
+    },
+    {
+      "action": "prompt",
+      "session": "$session_id",
+      "prompt": [
+        {
+          "type": "text",
+          "text": "late-tool 40 follow-up"
+        }
+      ],
+      "save_as": "prompt_result"
+    }
+  ],
+  "checks": [
+    {
+      "type": "saved_stop_reason_in",
+      "key": "prompt_result",
+      "values": ["end_turn", "completed", "done"]
+    },
+    {
+      "type": "updates_count_at_least",
+      "min": 4
+    },
+    {
+      "type": "updates_all_session",
+      "session": "$session_id"
+    },
+    {
+      "type": "updates_text_includes",
+      "text": "сейчас пишу"
+    },
+    {
+      "type": "updates_session_update_includes",
+      "values": ["tool_call", "tool_call_update"]
+    }
+  ],
+  "timeouts": {
+    "request_timeout_ms": 10000,
+    "update_timeout_ms": 10000,
+    "settle_timeout_ms": 160
+  }
+}

--- a/conformance/profiles/acp-core-v1.json
+++ b/conformance/profiles/acp-core-v1.json
@@ -23,7 +23,8 @@
     "acp.v1.permissions.read.approved",
     "acp.v1.permissions.write.approved",
     "acp.v1.session.prompt.background_completion",
-    "acp.v1.session.cancel.followup_prompt"
+    "acp.v1.session.cancel.followup_prompt",
+    "acp.v1.session.prompt.post_success_drain"
   ],
   "optional_cases": []
 }

--- a/conformance/runner/run.ts
+++ b/conformance/runner/run.ts
@@ -126,6 +126,10 @@ type CaseCheck =
   | {
       type: "updates_text_includes";
       text: string;
+    }
+  | {
+      type: "updates_session_update_includes";
+      values: string[];
     };
 
 type CaseResult = {
@@ -429,6 +433,14 @@ function resolveTimeoutMs(
     return Math.round(value);
   }
   return fallbackMs;
+}
+
+function resolveSettleTimeoutMs(caseDefinition: CaseDefinition): number {
+  const value = caseDefinition.timeouts?.settle_timeout_ms;
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.round(value);
+  }
+  return 0;
 }
 
 function splitCommandLine(value: string): ParsedCommand {
@@ -944,6 +956,22 @@ function evaluateCaseChecks(params: {
         assert.equal(matched, true, `expected at least one update text including "${check.text}"`);
         break;
       }
+      case "updates_session_update_includes": {
+        const seen = new Set(
+          params.harness.client.updates
+            .map((update) => update.update?.sessionUpdate)
+            .filter((value): value is string => typeof value === "string"),
+        );
+
+        for (const value of check.values) {
+          assert.equal(
+            seen.has(value),
+            true,
+            `expected at least one update with sessionUpdate="${value}"`,
+          );
+        }
+        break;
+      }
     }
   }
 }
@@ -954,6 +982,7 @@ async function runCase(
 ): Promise<{ passed: true } | { passed: false; error: string }> {
   const requestTimeoutMs = resolveTimeoutMs(caseDefinition, "request", DEFAULT_REQUEST_TIMEOUT_MS);
   const updateTimeoutMs = resolveTimeoutMs(caseDefinition, "update", DEFAULT_UPDATE_TIMEOUT_MS);
+  const settleTimeoutMs = resolveSettleTimeoutMs(caseDefinition);
   const effectiveOptions: CliOptions =
     caseDefinition.permission_mode && caseDefinition.permission_mode !== options.permissionMode
       ? { ...options, permissionMode: caseDefinition.permission_mode }
@@ -974,6 +1003,12 @@ async function runCase(
         options: effectiveOptions,
         requestTimeoutMs,
         updateTimeoutMs,
+      });
+    }
+
+    if (settleTimeoutMs > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, settleTimeoutMs);
       });
     }
 

--- a/src/runtime/engine/prompt-turn.ts
+++ b/src/runtime/engine/prompt-turn.ts
@@ -26,20 +26,15 @@ export async function runPromptTurn(params: {
     const promptPromise = params.client.prompt(params.sessionId, params.prompt);
     await params.onPromptStarted?.();
     const response = await withTimeout(promptPromise, params.timeoutMs);
-    if (
-      params.promptMessageId &&
-      !hasAgentReplyAfterPrompt(params.conversation, params.promptMessageId)
-    ) {
-      await params.client
-        .waitForSessionUpdatesIdle?.({
-          idleMs: SESSION_REPLY_IDLE_MS,
-          timeoutMs: SESSION_REPLY_DRAIN_TIMEOUT_MS,
-        })
-        .catch(() => {
-          // Best effort. The prompt already completed successfully, so keep the
-          // original stop reason if late update draining itself times out.
-        });
-    }
+    await params.client
+      .waitForSessionUpdatesIdle?.({
+        idleMs: SESSION_REPLY_IDLE_MS,
+        timeoutMs: SESSION_REPLY_DRAIN_TIMEOUT_MS,
+      })
+      .catch(() => {
+        // Best effort. The prompt already completed successfully, so keep the
+        // original stop reason if late update draining itself times out.
+      });
     return {
       stopReason: response.stopReason,
       source: "rpc",

--- a/test/conformance-runner.test.ts
+++ b/test/conformance-runner.test.ts
@@ -239,7 +239,7 @@ test("runner observes late post-success tool updates after settle timeout", asyn
           },
           {
             type: "updates_text_includes",
-            text: "сейчас пишу",
+            text: "writing now",
           },
           {
             type: "updates_session_update_includes",

--- a/test/conformance-runner.test.ts
+++ b/test/conformance-runner.test.ts
@@ -215,6 +215,69 @@ test("runner rejects reads outside the session cwd root", async () => {
   }
 });
 
+test("runner observes late post-success tool updates after settle timeout", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-conformance-runner-"));
+  try {
+    const { profilePath, casesDir } = await writeFixture(tmp, [
+      {
+        id: "custom.prompt.post_success_drain",
+        title: "Late post-success tool updates remain observable",
+        steps: [
+          { action: "new_session", save_as: "session_id" },
+          {
+            action: "prompt",
+            session: "$session_id",
+            prompt: [{ type: "text", text: "late-tool 40 follow-up" }],
+            save_as: "prompt_result",
+          },
+        ],
+        checks: [
+          {
+            type: "saved_stop_reason_in",
+            key: "prompt_result",
+            values: ["end_turn"],
+          },
+          {
+            type: "updates_text_includes",
+            text: "сейчас пишу",
+          },
+          {
+            type: "updates_session_update_includes",
+            values: ["tool_call", "tool_call_update"],
+          },
+        ],
+        timeouts: {
+          settle_timeout_ms: 160,
+        },
+      },
+    ]);
+
+    const result = await runRunner(
+      [
+        "--profile",
+        profilePath,
+        "--cases-dir",
+        casesDir,
+        "--agent-command",
+        MOCK_AGENT_COMMAND,
+        "--format",
+        "json",
+      ],
+      { timeoutMs: 20_000 },
+    );
+
+    assert.equal(result.code, 0, result.stderr);
+    const report = parseReport(result.stdout);
+    assert.deepEqual(report.totals, {
+      cases: 1,
+      passed: 1,
+      failed: 0,
+    });
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 async function writeFixture(
   rootDir: string,
   cases: Array<Record<string, unknown>>,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2071,7 +2071,7 @@ test("integration: late post-success tool updates are rendered before prompt exi
         homeDir,
       );
       assert.equal(result.code, 0, result.stderr);
-      assert.match(result.stdout, /сейчас пишу/);
+      assert.match(result.stdout, /writing now/);
       assert.match(result.stdout, /\[tool\] LateTool/);
       assert.match(result.stdout, /follow-up/);
 
@@ -3599,7 +3599,7 @@ test("runPromptTurn: missing waitForSessionUpdatesIdle still returns cleanly on 
   assert.equal(result.stopReason, "end_turn");
 });
 
-test("runPromptTurn: existing agent reply skips post-success drain", async () => {
+test("runPromptTurn: existing agent reply still allows post-success drain", async () => {
   const calls: string[] = [];
   const conversation = createSessionConversation();
   const promptMessageId = recordPromptSubmission(conversation, "hello");
@@ -3631,5 +3631,5 @@ test("runPromptTurn: existing agent reply skips post-success drain", async () =>
 
   assert.equal(result.source, "rpc");
   assert.equal(result.stopReason, "end_turn");
-  assert.deepEqual(calls, ["prompt"]);
+  assert.deepEqual(calls, ["prompt", "drain"]);
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2055,6 +2055,37 @@ test("integration: --suppress-reads hides read file body in json format", async 
   });
 });
 
+test("integration: late post-success tool updates are rendered before prompt exits", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const created = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      const result = await runCli(
+        [...baseAgentArgs(cwd), "--format", "text", "prompt", "late-tool 40 follow-up"],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /сейчас пишу/);
+      assert.match(result.stdout, /\[tool\] LateTool/);
+      assert.match(result.stdout, /follow-up/);
+
+      const closed = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "sessions", "close"],
+        homeDir,
+      );
+      assert.equal(closed.code, 0, closed.stderr);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: fs/write_text_file through mock agent", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -843,7 +843,7 @@ class MockAgent implements Agent {
         throw new Error("Usage: late-tool <milliseconds> <text>");
       }
 
-      await this.sendAssistantMessage(sessionId, "сейчас пишу");
+      await this.sendAssistantMessage(sessionId, "writing now");
       this.emitLateToolCall(sessionId, delayMs, lateText);
       return `late-tool scheduled: ${lateText}`;
     }

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -755,6 +755,52 @@ class MockAgent implements Agent {
     });
   }
 
+  private emitLateToolCall(sessionId: SessionId, delayMs: number, text: string): void {
+    const scheduledDelay = Math.max(0, Math.round(delayMs));
+    const toolCallId = randomUUID();
+
+    setTimeout(() => {
+      void (async () => {
+        await this.connection.sessionUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            title: "LateTool",
+            kind: "other",
+            status: "in_progress",
+            rawInput: {
+              text,
+            },
+          },
+        });
+
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 5);
+        });
+
+        await this.connection.sessionUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId,
+            title: "LateTool",
+            kind: "other",
+            status: "completed",
+            rawInput: {
+              text,
+            },
+            rawOutput: {
+              echoedText: text,
+            },
+          },
+        });
+      })().catch((error: unknown) => {
+        process.stderr.write(`late-tool failed: ${toErrorMessage(error)}\n`);
+      });
+    }, scheduledDelay);
+  }
+
   private ensureSession(sessionId: SessionId): SessionState {
     let session = this.sessions.get(sessionId);
     if (!session) {
@@ -779,6 +825,27 @@ class MockAgent implements Agent {
     }
     if (text === "retryable-error-once") {
       return "recovered after retry";
+    }
+
+    if (text.startsWith("late-tool ")) {
+      const rest = text.slice("late-tool ".length).trim();
+      const firstSpace = rest.search(/\s/);
+
+      if (firstSpace <= 0) {
+        throw new Error("Usage: late-tool <milliseconds> <text>");
+      }
+
+      const rawMs = rest.slice(0, firstSpace).trim();
+      const lateText = rest.slice(firstSpace + 1).trim();
+      const delayMs = Number(rawMs);
+
+      if (!Number.isFinite(delayMs) || delayMs < 0 || lateText.length === 0) {
+        throw new Error("Usage: late-tool <milliseconds> <text>");
+      }
+
+      await this.sendAssistantMessage(sessionId, "сейчас пишу");
+      this.emitLateToolCall(sessionId, delayMs, lateText);
+      return `late-tool scheduled: ${lateText}`;
     }
 
     if (text.startsWith("read ")) {


### PR DESCRIPTION
## Summary

- Stacked context: this branch is intentionally **on top of #251**. The prerequisite runtime fix commit (1eac925) is already under review there; the **new review scope here is the foundation guard commit 4285e67**.

- Problem: after fixing the runtime-side post-success drain in #251, the repo still had no honest guardrail for the exact late post-success race. The bundled conformance path only covered synchronous update delivery, so a future regression could reintroduce dropped late assistant_delta / tool_call / tool_call_update events without any red signal.

- Why it matters: this is the missing foundation step before broader ACP agent verification. Without a real late-update guard, we could claim the runtime fix works while the mock/conformance stack still failed to detect the race that originally caused the breakage.

- What changed: added a dedicated late-update mock path (late-tool) in test/mock-agent.ts, restored conformance case 021 as acp.v1.session.prompt.post_success_drain, registered it in acp-core-v1, taught the conformance runner to wait briefly for late post-success updates via bounded settle/check glue, and added both runner smoke coverage and a CLI integration proof that exercises the real output path.

- What did NOT change (scope boundary): no new runtime behavior changed in this PR beyond the prerequisite commit already in #251. The foundation scope here is test/conformance guard coverage.

## Change Type (select all)

- Bug fix
- Refactor required for the fix
- Chore/infra

## Scope (select all touched areas)

- API / contracts
- UI / DX

## Linked Issue/PR

- Stacked follow-up on top of #251
- New review scope: foundation guard for late post-success updates

## Root Cause (if applicable)

- Root cause: #251 fixes the runtime seam, but without this follow-up the repo still lacks a conformance/integration path that can honestly model late post-success updates. The previous mock agent emitted updates synchronously before returning, so coverage stayed green even if the real race came back.

- Missing detection / guardrail: no mock/conformance scenario emitted text first and the tool event later, after prompt success but before bounded idle drain finished.

- Contributing context (if known): the original bug was observed against a real ACP adapter that emits intent text first and tool activity on the following tick.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - Seam / integration test
  - End-to-end test

- Target tests or files:
  - test/conformance-runner.test.ts
  - test/integration.test.ts
  - conformance/cases/021-prompt-post-success-drain.json

- Scenarios the tests lock in:
  - runner observes late post-success tool updates after settle timeout
  - CLI integration keeps late post-success tool updates visible before prompt exit
  - baseline tree without the runtime drain fails the same late-update scenario

- Why this is the smallest reliable guardrail: it keeps runtime-scope expansion closed while forcing the mock/conformance stack to model the exact race that mattered in production.

## User-visible / Behavior Changes

- No new user-facing runtime behavior change.
- Repo behavior change: conformance/integration now fail if late post-success updates are dropped again.

## Security Impact (required)

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.

## Repro + Verification

### Environment

- OS: macOS 15 (Darwin 25.3.0)
- Runtime: Node v22.22.0 via pnpm 10.23.0
- Harness / adapter under test: bundled test/mock-agent.ts plus CLI/conformance runner
- Integration/channel: ACP core profile (acp-core-v1)
- Relevant config: defaults

### Steps

Patched tree (4285e67, stacked on 1eac925):

- pnpm install --frozen-lockfile
- pnpm run build:test
- node --test dist-test/test/integration.test.js --test-name-pattern='late post-success tool updates are rendered before prompt exits'
- pnpm run conformance:run -- --case acp.v1.session.prompt.post_success_drain

Baseline tree (087f820 + same guard diff, without runtime drain):

- git worktree add --detach /tmp/acpx-guard-baseline 087f8207d58aebc6efd3ea455488aad0cd07d3af
- pnpm install --frozen-lockfile
- pnpm run build:test
- node --test dist-test/test/integration.test.js --test-name-pattern='late post-success tool updates are rendered before prompt exits'

### Expected

- Patched tree: targeted integration passes and conformance case acp.v1.session.prompt.post_success_drain passes.
- Baseline tree: the same late-update scenario fails, proving the guard is not decorative.

### Actual (patched)

- pnpm run build:test — PASS
- targeted integration suite — PASS (63/63)
- pnpm run conformance:run -- --case acp.v1.session.prompt.post_success_drain — PASS (Cases: 1 Passed: 1 Failed: 0)

### Actual (baseline)

- targeted integration suite — FAIL
- missing [tool] LateTool in rendered output
- runPromptTurn late-update checks fail (60 pass / 3 fail)

## Evidence

- Failing baseline output vs passing patched output
- conformance pass on the patched tree
- new review commit: 4285e67

## Human Verification (required)

- Verified scenarios:
  - mock agent emits late post-success tool events after early text
  - conformance runner waits long enough to observe those events
  - CLI output still shows the late tool event before turn close on the patched tree
  - baseline without the runtime drain fails the same scenario

- What was not verified:
  - no additional real-agent run in this PR; this is a foundation guard for the already-separate runtime fix

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.

## Risks and Mitigations

- Risk: mock/conformance case could become flaky if the late-update settle window is too small.
  - Mitigation: bounded settle/check glue is explicit in the case/runner and proved locally against both patched and baseline trees.

- Risk: this could be mistaken for another runtime fix.
  - Mitigation: the body explicitly marks #251 / 1eac925 as prerequisite context and 4285e67 as the new review scope.

## AI Assistance

- AI-assisted
- Testing: fully tested locally with patched and baseline red/green proof, including targeted integration and the new conformance case.