### PR TITLE
fix: bump Claude agent ACP pin for Opus 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Agents/claude: bump the built-in `@agentclientprotocol/claude-agent-acp` range to the first release that exposes Opus 4.7 by default, and sync the Claude built-in docs.
 - Sessions/reset: close the live backend session when discarding persistent state so reset flows start a fresh ACP session instead of silently reopening the old one.
 - Agents/kiro: use `kiro-cli-chat acp` for the built-in Kiro adapter command to avoid orphan child processes. (#129) Thanks @vokako.
 - Agents/cursor: recognize Cursor's `Session \"...\" not found` `session/load` error format so reconnects fall back to `session/new` instead of failing. (#162) Thanks @log-li.

--- a/agents/Claude.md
+++ b/agents/Claude.md
@@ -1,0 +1,7 @@
+# Claude
+
+- Built-in name: `claude`
+- Default command: `npx -y @agentclientprotocol/claude-agent-acp`
+- Upstream: https://github.com/agentclientprotocol/claude-agent-acp
+- Runtime config options exposed by current claude-agent-acp releases include `mode` and `model`.
+- `acpx --model <id> claude ...` requests the target Claude model during session startup, and `acpx claude set model <id>` uses the adapter's advertised model-switching support when available.

--- a/agents/README.md
+++ b/agents/README.md
@@ -5,7 +5,7 @@ Built-in agents:
 - `pi -> npx pi-acp`
 - `openclaw -> openclaw acp`
 - `codex -> npx @zed-industries/codex-acp`
-- `claude -> npx -y @zed-industries/claude-agent-acp`
+- `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - `gemini -> gemini --acp`
 - `cursor -> cursor-agent acp`
 - `copilot -> copilot --acp --stdio`
@@ -22,6 +22,7 @@ Built-in agents:
 Harness-specific docs in this directory:
 
 - [Codex](Codex.md): built-in `codex -> npx @zed-industries/codex-acp`
+- [Claude](Claude.md): built-in `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - [Copilot](Copilot.md): built-in `copilot -> copilot --acp --stdio`
 - [Droid](Droid.md): built-in `droid -> droid exec --output-format acp` with `factory-droid` and `factorydroid` aliases
 - [Cursor](Cursor.md): built-in `cursor -> cursor-agent acp`

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -92,6 +92,7 @@ Friendly agent names resolve to commands:
 Rules:
 
 - Default agent is `codex` for top-level `prompt`, `exec`, and `sessions`.
+- The built-in `claude` route should use the shipped `claude-agent-acp` defaults unless you intentionally override it with `--agent` or config.
 - Unknown positional agent tokens are treated as raw agent commands.
 - `--agent <command>` explicitly sets a raw ACP adapter command.
 - Do not combine a positional agent and `--agent` in the same command.

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.22",
   codex: "^0.11.1",
-  claude: "^0.25.0",
+  claude: "^0.29.0",
 } as const;
 
 type BuiltInAgentPackageSpec = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -78,6 +78,11 @@ test("default agent is codex", () => {
   assert.equal(DEFAULT_AGENT_NAME, "codex");
 });
 
+test("claude built-in pins the first adapter release with Opus 4.7 support", () => {
+  assert.equal(BUILT_IN_AGENT_PACKAGES.claude.packageRange, "^0.29.0");
+  assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.29.0");
+});
+
 test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when available", (t) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "acpx-agent-registry-"));
   t.after(() => {
@@ -96,7 +101,7 @@ test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when a
     path.join(packageRoot, "package.json"),
     JSON.stringify({
       name: BUILT_IN_AGENT_PACKAGES.claude.packageName,
-      version: "0.25.0",
+      version: "0.29.0",
       bin: {
         "claude-agent-acp": "bin/claude-agent-acp.js",
       },
@@ -115,7 +120,7 @@ test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when a
     args: [path.join(packageRoot, "bin", "claude-agent-acp.js")],
     packageName: BUILT_IN_AGENT_PACKAGES.claude.packageName,
     packageRange: BUILT_IN_AGENT_PACKAGES.claude.packageRange,
-    packageVersion: "0.25.0",
+    packageVersion: "0.29.0",
     binPath: path.join(packageRoot, "bin", "claude-agent-acp.js"),
   });
 });


### PR DESCRIPTION
## Summary
- bump the built-in `claude` adapter range from `^0.25.0` to `^0.29.0`
- add a regression test locking the first Opus 4.7-capable Claude adapter release
- sync the Claude built-in docs and skill guidance

## Verification
- `npx -y pnpm@10.23.0 run check`
- `npx -y pnpm@10.23.0 run check:docs`

## Context
OpenClaw embedded Claude ACP sessions were still surfacing Opus 4.6 because ACPX was pinning `@agentclientprotocol/claude-agent-acp` to `^0.25.0`.