### PR TITLE
fix: block replay viewer runId traversal outside runs dir

### DIFF
--- a/examples/flows/replay-viewer/server/run-bundles.ts
+++ b/examples/flows/replay-viewer/server/run-bundles.ts
@@ -51,10 +51,14 @@ export function resolveRunBundleFilePath(
   relativePath: string,
 ): string {
   const normalizedRelativePath = normalizeRelativePath(relativePath);
-  const runDir = path.resolve(runsDir, runId);
+  const resolvedRunsDir = path.resolve(runsDir);
+  const runDir = path.resolve(resolvedRunsDir, runId);
+  if (!isPathInsideDirectory(resolvedRunsDir, runDir, { allowSamePath: false })) {
+    throw new Error(`Refusing to read run bundle outside runs directory: ${runId}`);
+  }
   const resolvedPath = path.resolve(runDir, normalizedRelativePath);
 
-  if (!resolvedPath.startsWith(`${runDir}${path.sep}`) && resolvedPath !== runDir) {
+  if (!isPathInsideDirectory(runDir, resolvedPath)) {
     throw new Error(`Refusing to read outside run bundle: ${relativePath}`);
   }
 
@@ -101,4 +105,21 @@ function normalizeRelativePath(relativePath: string): string {
     throw new Error("Parent directory traversal is not allowed");
   }
   return normalized;
+}
+
+function isPathInsideDirectory(
+  rootDir: string,
+  candidatePath: string,
+  options: { allowSamePath?: boolean } = {},
+): boolean {
+  const relativePath = path.relative(rootDir, candidatePath);
+  if (!options.allowSamePath && relativePath.length === 0) {
+    return false;
+  }
+  return (
+    relativePath.length === 0 ||
+    (!relativePath.startsWith(`..${path.sep}`) &&
+      relativePath !== ".." &&
+      !path.isAbsolute(relativePath))
+  );
 }

--- a/examples/flows/replay-viewer/server/viewer-server.ts
+++ b/examples/flows/replay-viewer/server/viewer-server.ts
@@ -191,7 +191,8 @@ export async function handleApiRequest(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const code =
-        error instanceof Error && /outside run bundle|not allowed|required/.test(error.message)
+        error instanceof Error &&
+        /outside run bundle|outside runs directory|not allowed|required/.test(error.message)
           ? 400
           : 404;
       writeJson(response, code, { error: message });

--- a/test/replay-viewer-run-bundles.test.ts
+++ b/test/replay-viewer-run-bundles.test.ts
@@ -78,6 +78,10 @@ test("resolveRunBundleFilePath rejects traversal outside a run bundle", () => {
     () => resolveRunBundleFilePath(runsDir, "run-id", "/tmp/manifest.json"),
     /not allowed/,
   );
+  assert.throws(
+    () => resolveRunBundleFilePath(runsDir, "../sessions", "session.json"),
+    /outside runs directory/,
+  );
 });
 
 async function writeRunBundle(

--- a/test/replay-viewer-server.test.ts
+++ b/test/replay-viewer-server.test.ts
@@ -123,6 +123,33 @@ test("replay viewer start rejects reusing a server for a different runs dir", as
   }
 });
 
+test("replay viewer blocks file reads that escape the runs directory via runId", async () => {
+  const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-replay-traversal-"));
+  const runsDir = path.join(fakeHome, ".acpx", "flows", "runs");
+  const sessionsDir = path.join(fakeHome, ".acpx", "sessions");
+  await fs.mkdir(runsDir, { recursive: true });
+  await fs.mkdir(sessionsDir, { recursive: true });
+  await fs.writeFile(path.join(sessionsDir, "session-secret.json"), '{"token":"SESSION_SECRET"}');
+
+  const viewerServer = await createReplayViewerServer({
+    host: "127.0.0.1",
+    port: 0,
+    runsDir,
+    disableDependencyOptimization: true,
+  });
+
+  try {
+    const response = await fetch(
+      `${viewerServer.baseUrl}/api/runs/..%2F..%2Fsessions/files/session-secret.json`,
+    );
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /outside runs directory/i);
+  } finally {
+    await viewerServer.close().catch(() => {});
+    await fs.rm(fakeHome, { recursive: true, force: true });
+  }
+});
+
 async function waitFor(check: () => Promise<boolean>, timeoutMs: number = 5_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
 


### PR DESCRIPTION
## Summary
- reject replay-viewer `runId` values that resolve outside the configured `runsDir`
- preserve the existing in-bundle `relativePath` traversal guard
- return `400` for rejected out-of-root requests
- add unit and HTTP regression coverage for the exploit path

Fixes #254.

## Why
The replay viewer already rejected `relativePath` traversal inside a selected bundle, but it did not verify that the selected `runId` itself resolved under the configured runs directory. That meant a request like:

```text
/api/runs/..%2F..%2Fsessions/files/session-secret.json
```

could escape the intended replay-bundle root and read adjacent local acpx files.

This stays within the viewer's existing design: valid in-root bundle reads still work, but out-of-root bundle selection now fails fast at the actual filesystem boundary.

## Validation
- `pnpm run build:test && node --test dist-test/test/replay-viewer-*.test.js`
- `pnpm run viewer:typecheck`

## Embedded proof
- before the fix, the new unit regression for `resolveRunBundleFilePath(runsDir, '../sessions', 'session.json')` failed because no exception was raised
- before the fix, the new HTTP regression returned `200` for `/api/runs/..%2F..%2Fsessions/files/session-secret.json`
- after the fix, the full replay-viewer test suite passed (`55` passing, `0` failing)
- after the fix, the out-of-root HTTP request returned `400`
- after the fix, a normal in-root request to `/api/runs/<valid-run-id>/files/manifest.json` still returned `200`

## Scope note
This keeps the change intentionally narrow to the replay-viewer server boundary check and its regression tests. It does not change bundle format, run id conventions, or viewer semantics for valid bundles.

## AI assistance
- AI-assisted: yes
- Testing scope: fully tested locally for the replay-viewer change set