### PR TITLE
fix: add text remediation hints for ACP session errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Repo: https://github.com/openclaw/acpx
 - CLI/queue: tighten persistent queue and IPC socket directories to owner-only permissions, including previously-created permissive directories. (#216) Thanks @garagon.
 - Config/agents: honor custom agent `args` arrays from config instead of silently dropping required adapter subcommands. (#199) Thanks @log-li.
 - CLI/queue: use cryptographically random owner generation IDs so rapid queue owner restarts cannot reuse a stale generation token. (#207) Thanks @Yuan-ManX.
+- Output/errors: add text-mode remediation hints for auth-required, missing-session, and common ACP session failures while keeping JSON error payloads stable. (#256) Thanks @SJeffZhang.
 - Runtime/ACP: drain late post-success session updates before closing prompt turns so adapters that resolve `session/prompt` before final updates do not drop assistant output. (#251) Thanks @logofet85-ai.
 - Sessions/reset: close the live backend session when discarding persistent state so reset flows start a fresh ACP session instead of silently reopening the old one.
 - Agents/kiro: use `kiro-cli-chat acp` for the built-in Kiro adapter command to avoid orphan child processes. (#129) Thanks @vokako.

--- a/docs/ACPX_ERROR_STRATEGY.md
+++ b/docs/ACPX_ERROR_STRATEGY.md
@@ -22,7 +22,7 @@ This document defines how `acpx` should represent errors across:
 - Keep ACP semantics intact when available.
 - Provide stable `acpx` codes for orchestrator logic.
 - Avoid parsing free-form message text.
-- Keep text mode UX unchanged.
+- Keep the JSON/machine contract stable; text mode may add additive remediation hints.
 - Make changes additive to preserve backward compatibility.
 
 ## Two-layer contract
@@ -108,7 +108,7 @@ Cancellation is a normal completion path, not an error path:
 ## Rollout and compatibility
 
 - Queue error parsing should accept both old (`message` only) and new (`code/detailCode/message`) payload shapes during migration.
-- Text mode output and existing exit codes stay unchanged.
+- Text mode may add additive remediation hints; existing exit codes and JSON fields stay unchanged.
 - New JSON fields remain additive.
 - `--json-strict` is the recommended mode for orchestrators that need JSON-only output channels.
 

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -20,7 +20,7 @@ import {
   parseTtlSeconds,
   resolveOutputPolicy,
 } from "./cli/flags.js";
-import { createOutputFormatter } from "./cli/output/output.js";
+import { createOutputFormatter, getTextErrorRemediationHints } from "./cli/output/output.js";
 import { runQueueOwnerFromEnv } from "./cli/queue/owner-env.js";
 import { flushPerfMetricsCapture, installPerfMetricsCapture } from "./perf-metrics-capture.js";
 import { EXIT_CODES, OUTPUT_FORMATS, type OutputFormat, type OutputPolicy } from "./types.js";
@@ -245,6 +245,11 @@ async function emitRequestedError(
 
   if (!outputPolicy.suppressNonJsonStderr) {
     process.stderr.write(`${normalized.message}\n`);
+    if (outputPolicy.format === "text") {
+      for (const hint of getTextErrorRemediationHints(normalized)) {
+        process.stderr.write(`${hint}\n`);
+      }
+    }
   }
 }
 

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -31,6 +31,16 @@ type WritableLike = {
   isTTY?: boolean;
 };
 
+type RenderableOutputError = {
+  code: OutputErrorCode;
+  detailCode?: string;
+  origin?: OutputErrorOrigin;
+  message: string;
+  retryable?: boolean;
+  acp?: OutputErrorAcpPayload;
+  timestamp?: string;
+};
+
 type OutputFormatterOptions = {
   stdout?: WritableLike;
   jsonContext?: OutputFormatterContext;
@@ -209,6 +219,134 @@ function readFirstStringArray(
     }
   }
   return undefined;
+}
+
+function formatDisjunction(values: string[]): string {
+  if (values.length <= 1) {
+    return values[0] ?? "";
+  }
+  if (values.length === 2) {
+    return `${values[0]} or ${values[1]}`;
+  }
+  return `${values.slice(0, -1).join(", ")}, or ${values.at(-1)}`;
+}
+
+function parseAuthMethodIdsFromMessage(message: string): string[] {
+  const methods: string[] = [];
+  const methodListMatch = message.match(/auth methods \[([^\]]+)\]/iu);
+  if (methodListMatch) {
+    methods.push(
+      ...methodListMatch[1]
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    );
+  }
+
+  const singleMethodMatch = message.match(/auth method ([\w.-]+)/iu);
+  if (singleMethodMatch) {
+    methods.push(singleMethodMatch[1]);
+  }
+
+  return dedupeStrings(methods);
+}
+
+function parseAuthMethodIdsFromAcpData(data: unknown): string[] {
+  const record = asRecord(data);
+  if (!record) {
+    return [];
+  }
+
+  const methodIds: string[] = [];
+  if (typeof record.methodId === "string" && record.methodId.trim().length > 0) {
+    methodIds.push(record.methodId.trim());
+  }
+
+  if (Array.isArray(record.methods)) {
+    for (const entry of record.methods) {
+      if (typeof entry === "string" && entry.trim().length > 0) {
+        methodIds.push(entry.trim());
+        continue;
+      }
+
+      const id = asRecord(entry)?.id;
+      if (typeof id === "string" && id.trim().length > 0) {
+        methodIds.push(id.trim());
+      }
+    }
+  }
+
+  return dedupeStrings(methodIds);
+}
+
+function renderAuthRequiredHint(params: RenderableOutputError): string {
+  const methodIds = dedupeStrings([
+    ...parseAuthMethodIdsFromAcpData(params.acp?.data),
+    ...parseAuthMethodIdsFromMessage(params.message),
+  ]);
+
+  if (methodIds.length === 0) {
+    return "hint: run `acpx config show` to locate the active config, then add the required credential under `auth` and retry.";
+  }
+
+  const configKeys = methodIds.map((methodId) => `\`auth.${methodId}\``);
+  return `hint: run \`acpx config show\` to locate the active config, then add ${formatDisjunction(configKeys)} and retry.`;
+}
+
+export function getTextErrorRemediationHints(params: RenderableOutputError): string[] {
+  const lowerMessage = params.message.toLowerCase();
+
+  if (params.detailCode === "AUTH_REQUIRED") {
+    return [renderAuthRequiredHint(params)];
+  }
+
+  if (params.code === "NO_SESSION") {
+    if (lowerMessage.includes("create one:")) {
+      return [];
+    }
+
+    return [
+      "hint: the saved ACP session is missing or stale; start a fresh session with `acpx <agent> sessions new`, then retry.",
+    ];
+  }
+
+  if (lowerMessage.includes("does not support session/load")) {
+    return [
+      "hint: this adapter cannot resume saved ACP sessions; create a fresh one with `acpx <agent> sessions new` instead of reusing `--resume-session`.",
+    ];
+  }
+
+  if (
+    lowerMessage.includes("failed to resume acp session") ||
+    lowerMessage.includes("session/load")
+  ) {
+    return [
+      "hint: rerun with `--verbose` to capture the ACP load failure details.",
+      "hint: if you do not need the old backend session, start a fresh one with `acpx <agent> sessions new` and retry.",
+    ];
+  }
+
+  if (
+    lowerMessage.includes("session/set_mode") ||
+    lowerMessage.includes("session/set_model") ||
+    lowerMessage.includes("session/set_config_option")
+  ) {
+    return [
+      "hint: rerun with `--verbose` to capture the ACP method/error details before retrying.",
+    ];
+  }
+
+  if (
+    params.origin === "acp" &&
+    params.code === "RUNTIME" &&
+    (params.acp?.code === -32602 ||
+      params.acp?.code === -32603 ||
+      lowerMessage.includes("internal error"))
+  ) {
+    return ["hint: rerun with `--verbose` to capture the underlying ACP error details."];
+  }
+
+  return [];
 }
 
 function summarizeToolInput(rawInput: unknown): string | undefined {
@@ -579,18 +717,13 @@ class TextOutputFormatter implements OutputFormatter {
     this.writeLine(this.dim(`[done] ${stopReason}`));
   }
 
-  onError(params: {
-    code: OutputErrorCode;
-    detailCode?: string;
-    origin?: OutputErrorOrigin;
-    message: string;
-    retryable?: boolean;
-    acp?: OutputErrorAcpPayload;
-    timestamp?: string;
-  }): void {
+  onError(params: RenderableOutputError): void {
     this.flushThoughtBuffer();
     this.beginSection("done");
     this.writeLine(this.formatAnsi(`[error] ${params.code}: ${params.message}`, "31"));
+    for (const hint of getTextErrorRemediationHints(params)) {
+      this.writeLine(this.dim(hint));
+    }
   }
 
   onClientOperation(operation: ClientOperation): void {

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createOutputFormatter } from "../src/cli/output/output.js";
+import { createOutputFormatter, getTextErrorRemediationHints } from "../src/cli/output/output.js";
 
 class CaptureWriter {
   public readonly chunks: string[] = [];
@@ -181,6 +181,86 @@ test("json formatter emits ACP JSON-RPC error response from onError", () => {
   assert.equal(parsed.error?.data?.acpxCode, "RUNTIME");
   assert.equal(parsed.error?.data?.origin, "runtime");
   assert.equal(parsed.error?.data?.sessionId, "session-err");
+});
+
+test("json formatter keeps remediation hints out of JSON error payloads", () => {
+  const writer = new CaptureWriter();
+  const formatter = createOutputFormatter("json", {
+    stdout: writer,
+    jsonContext: {
+      sessionId: "session-auth",
+    },
+  });
+
+  formatter.onError({
+    code: "RUNTIME",
+    detailCode: "AUTH_REQUIRED",
+    message: "missing credentials for auth method openai-api-key",
+    origin: "acp",
+    acp: {
+      code: -32000,
+      message: "Authentication required",
+      data: {
+        methodId: "openai-api-key",
+      },
+    },
+  });
+
+  const parsed = JSON.parse(writer.toString().trim()) as {
+    error?: {
+      message?: string;
+      data?: {
+        acpxCode?: string;
+        detailCode?: string;
+      };
+    };
+  };
+  assert.equal(parsed.error?.message, "Authentication required");
+  assert.equal(parsed.error?.data?.acpxCode, "RUNTIME");
+  assert.equal(parsed.error?.data?.detailCode, "AUTH_REQUIRED");
+  assert.doesNotMatch(writer.toString(), /hint:/);
+});
+
+test("text formatter prints auth remediation hints", () => {
+  const writer = new CaptureWriter();
+  const formatter = createOutputFormatter("text", { stdout: writer });
+
+  formatter.onError({
+    code: "RUNTIME",
+    detailCode: "AUTH_REQUIRED",
+    message: "missing credentials for auth method openai-api-key",
+    origin: "acp",
+    acp: {
+      code: -32000,
+      message: "Authentication required",
+      data: {
+        methodId: "openai-api-key",
+      },
+    },
+  });
+
+  const output = writer.toString();
+  assert.match(output, /\[error\] RUNTIME: missing credentials/);
+  assert.match(output, /hint: run `acpx config show`/);
+  assert.match(output, /`auth\.openai-api-key`/);
+});
+
+test("text remediation hints cover missing session and ACP runtime failures", () => {
+  assert.deepEqual(getTextErrorRemediationHints({ code: "NO_SESSION", message: "No session" }), [
+    "hint: the saved ACP session is missing or stale; start a fresh session with `acpx <agent> sessions new`, then retry.",
+  ]);
+  assert.deepEqual(
+    getTextErrorRemediationHints({
+      code: "RUNTIME",
+      message: "Failed session/set_mode for mode plan: Invalid params",
+      origin: "acp",
+      acp: {
+        code: -32602,
+        message: "Invalid params",
+      },
+    }),
+    ["hint: rerun with `--verbose` to capture the ACP method/error details before retrying."],
+  );
 });
 
 test("text formatter suppresses read output when requested", () => {


### PR DESCRIPTION
## Summary

This is a small first pass for #176.

It keeps the JSON / machine-readable error contract unchanged and adds additive remediation hints only to text-mode error output.

Initial text-mode coverage in this pass:

- `AUTH_REQUIRED`
- `NO_SESSION`
- common ACP runtime/session-control failures such as `session/load`, `session/set_mode`, `session/set_model`, and `session/set_config_option`

## Why

`acpx` already normalizes these failures into stable `code`, `detailCode`, `origin`, and raw `acp` metadata, but text mode usually stopped at the raw error message. That left users without a clear next step even when the client already had enough information to point them in the right direction.

## User Impact

Text-mode CLI failures now include short next-step hints in a few high-value cases, for example:

- add the missing auth credential under `auth.<method>`
- start a fresh session with `acpx <agent> sessions new`
- rerun with `--verbose` to capture ACP method/error details

JSON output and machine-readable error fields stay unchanged.

## Root Cause

The existing text formatter and top-level stderr path emitted normalized error messages, but they did not translate the existing normalized metadata into actionable remediation guidance for human readers.

## Validation

Targeted local validation:

- `corepack pnpm run build:test`
- `node --test --test-name-pattern 'normalizeOutputError maps ACP resource not found errors to NO_SESSION|normalizeOutputError maps AuthPolicyError to AUTH_REQUIRED detail|normalizeOutputError infers AUTH_REQUIRED detail from ACP payload|sessions new --resume-session fails when agent does not support session/load|sessions new --resume-session surfaces not-found loadSession errors without fallback|set-mode surfaces actionable guidance when agent rejects session/set_mode params|prompt exits with NO_SESSION when no session exists \(no auto-create\)' dist-test/test/error-normalization.test.js dist-test/test/cli.test.js`
- local `node --input-type=module -e ...` assertions for generated remediation hints
- `corepack pnpm run typecheck`
- `corepack pnpm run format:check`
- `oxlint --type-aware src`
- `./node_modules/.bin/tsx scripts/lint-persisted-key-casing.ts`
- `./node_modules/.bin/tsx scripts/lint-flow-schema-terms.ts`

Manual text-mode end-to-end stderr checks:

- `AUTH_REQUIRED`
- failed `session/load` / `NO_SESSION`
- `session/set_mode` invalid params

## AI Assistance

AI-assisted with Codex. I reviewed the touched code paths and local validation results directly.
