### PR TITLE
Add runtime turn handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Repo: https://github.com/openclaw/acpx
 ### Changes
 
 - CLI/claude: add `--system-prompt <text>` and `--append-system-prompt <text>` global flags that forward through ACP `_meta.systemPrompt` on `session/new`, letting callers replace or append to the Claude Code system prompt without dropping out of persistent acpx sessions. The value is persisted in `session_options.system_prompt` so ensure/reuse flows keep the override. Codex and other agents ignore the field. (#229) Thanks @Vercantez.
+- Runtime/embedding: add `startTurn(...)` turn handles so embedders can observe live runtime events separately from terminal completion, cancel a turn, or close only the event stream while preserving `runTurn(...)` compatibility. (#262) Thanks @enki.
 
 ### Breaking
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prepack": "pnpm run build",
     "prepare": "husky",
     "test": "pnpm run build:test && node --test dist-test/test/*.test.js",
-    "test:coverage": "pnpm run build:test && node --experimental-test-coverage --test-coverage-lines=83 --test-coverage-branches=76 --test-coverage-functions=86 --test dist-test/test/*.test.js",
+    "test:coverage": "pnpm run build:test && node --experimental-test-coverage --test-coverage-exclude=dist-test/test/**/*.js --test-coverage-lines=83 --test-coverage-branches=76 --test-coverage-functions=86 --test dist-test/test/*.test.js",
     "test:live": "pnpm run build:test && node --test dist-test/test/cursor-live.integration.js",
     "typecheck": "tsgo --noEmit",
     "typecheck:tsc": "tsc --noEmit",

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1099,11 +1099,12 @@ export class AcpClient {
 
     const connectionClosedDuringInitialize =
       error instanceof Error && /acp connection closed/i.test(error.message);
-    if (!connectionClosedDuringInitialize) {
+    await waitForChildExit(child, 100);
+    const childExited = child.exitCode !== null || child.signalCode !== null;
+    if (!connectionClosedDuringInitialize && !childExited) {
       return error;
     }
 
-    await waitForChildExit(child, 100);
     return new AgentStartupError({
       agentCommand: this.options.agentCommand,
       exitCode: child.exitCode ?? null,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -175,7 +175,7 @@ export class AcpxRuntime implements AcpxRuntimeLike {
         },
       },
       get result() {
-        return turnPromise.then((turn) => turn.result).then(async (result) => await result);
+        return turnPromise.then((turn) => turn.result);
       },
       cancel(inputArgs?: { reason?: string }) {
         return turnPromise.then((turn) => turn.cancel(inputArgs));

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6,9 +6,11 @@ import type {
   AcpRuntimeCapabilities,
   AcpRuntimeDoctorReport,
   AcpRuntimeEnsureInput,
+  AcpRuntimeEvent,
   AcpRuntimeHandle,
   AcpRuntimeOptions,
   AcpRuntimeStatus,
+  AcpRuntimeTurnInput,
   AcpSessionStore,
 } from "./runtime/public/contract.js";
 import { AcpRuntimeError } from "./runtime/public/errors.js";
@@ -37,8 +39,11 @@ export type {
   AcpRuntimePromptMode,
   AcpRuntimeSessionMode,
   AcpRuntimeStatus,
+  AcpRuntimeTurn,
   AcpRuntimeTurnAttachment,
   AcpRuntimeTurnInput,
+  AcpRuntimeTurnResult,
+  AcpRuntimeTurnResultError,
   AcpSessionRecord,
   AcpSessionStore,
   AcpSessionUpdateTag,
@@ -146,16 +151,46 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     return handle;
   }
 
-  async *runTurn(
-    input: import("./runtime/public/contract.js").AcpRuntimeTurnInput,
-  ): AsyncIterable<import("./runtime/public/contract.js").AcpRuntimeEvent> {
-    const state = this.resolveHandleState(input.handle);
+  startTurn(input: AcpRuntimeTurnInput) {
+    const { handle, state } = this.resolveManagerHandle(input.handle);
+    const managerPromise = this.getManager();
+    const turnPromise = managerPromise.then((manager) =>
+      manager.startTurn({
+        handle,
+        text: input.text,
+        attachments: input.attachments,
+        mode: input.mode,
+        sessionMode: state.mode,
+        requestId: input.requestId,
+        timeoutMs: input.timeoutMs,
+        signal: input.signal,
+      }),
+    );
+    return {
+      requestId: input.requestId,
+      events: {
+        async *[Symbol.asyncIterator]() {
+          const turn = await turnPromise;
+          yield* turn.events;
+        },
+      },
+      get result() {
+        return turnPromise.then((turn) => turn.result).then(async (result) => await result);
+      },
+      cancel(inputArgs?: { reason?: string }) {
+        return turnPromise.then((turn) => turn.cancel(inputArgs));
+      },
+      closeStream(inputArgs?: { reason?: string }) {
+        return turnPromise.then((turn) => turn.closeStream(inputArgs));
+      },
+    };
+  }
+
+  async *runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent> {
+    const { handle, state } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
     yield* manager.runTurn({
-      handle: {
-        ...input.handle,
-        acpxRecordId: state.acpxRecordId ?? input.handle.acpxRecordId ?? input.handle.sessionKey,
-      },
+      handle,
       text: input.text,
       attachments: input.attachments,
       mode: input.mode,
@@ -166,7 +201,7 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     });
   }
 
-  getCapabilities(): AcpRuntimeCapabilities {
+  getCapabilities(_input?: { handle?: AcpRuntimeHandle }): AcpRuntimeCapabilities {
     return ACPX_CAPABILITIES;
   }
 
@@ -174,25 +209,15 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     handle: AcpRuntimeHandle;
     signal?: AbortSignal;
   }): Promise<AcpRuntimeStatus> {
-    const state = this.resolveHandleState(input.handle);
+    const { handle } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
-    return await manager.getStatus({
-      ...input.handle,
-      acpxRecordId: state.acpxRecordId ?? input.handle.acpxRecordId ?? input.handle.sessionKey,
-    });
+    return await manager.getStatus(handle);
   }
 
   async setMode(input: { handle: AcpRuntimeHandle; mode: string }): Promise<void> {
-    const state = this.resolveHandleState(input.handle);
+    const { handle, state } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
-    await manager.setMode(
-      {
-        ...input.handle,
-        acpxRecordId: state.acpxRecordId ?? input.handle.acpxRecordId ?? input.handle.sessionKey,
-      },
-      input.mode,
-      state.mode,
-    );
+    await manager.setMode(handle, input.mode, state.mode);
   }
 
   async setConfigOption(input: {
@@ -200,26 +225,15 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     key: string;
     value: string;
   }): Promise<void> {
-    const state = this.resolveHandleState(input.handle);
+    const { handle, state } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
-    await manager.setConfigOption(
-      {
-        ...input.handle,
-        acpxRecordId: state.acpxRecordId ?? input.handle.acpxRecordId ?? input.handle.sessionKey,
-      },
-      input.key,
-      input.value,
-      state.mode,
-    );
+    await manager.setConfigOption(handle, input.key, input.value, state.mode);
   }
 
   async cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void> {
-    const state = this.resolveHandleState(input.handle);
+    const { handle } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
-    await manager.cancel({
-      ...input.handle,
-      acpxRecordId: state.acpxRecordId ?? input.handle.acpxRecordId ?? input.handle.sessionKey,
-    });
+    await manager.cancel(handle);
   }
 
   async close(input: {
@@ -227,17 +241,11 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     reason: string;
     discardPersistentState?: boolean;
   }): Promise<void> {
-    const state = this.resolveHandleState(input.handle);
+    const { handle } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
-    await manager.close(
-      {
-        ...input.handle,
-        acpxRecordId: state.acpxRecordId ?? input.handle.acpxRecordId ?? input.handle.sessionKey,
-      },
-      {
-        discardPersistentState: input.discardPersistentState,
-      },
-    );
+    await manager.close(handle, {
+      discardPersistentState: input.discardPersistentState,
+    });
   }
 
   private async getManager(): Promise<AcpRuntimeManager> {
@@ -257,6 +265,20 @@ export class AcpxRuntime implements AcpxRuntimeLike {
 
   private async runProbe() {
     return await (this.testOptions?.probeRunner?.(this.options) ?? probeRuntime(this.options));
+  }
+
+  private resolveManagerHandle(handle: AcpRuntimeHandle): {
+    handle: AcpRuntimeHandle;
+    state: AcpxHandleState;
+  } {
+    const state = this.resolveHandleState(handle);
+    return {
+      handle: {
+        ...handle,
+        acpxRecordId: state.acpxRecordId ?? handle.acpxRecordId ?? handle.sessionKey,
+      },
+      state,
+    };
   }
 
   private resolveHandleState(handle: AcpRuntimeHandle): AcpxHandleState {

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -24,6 +24,8 @@ import type {
   AcpRuntimePromptMode,
   AcpRuntimeStatus,
   AcpRuntimeTurnAttachment,
+  AcpRuntimeTurn,
+  AcpRuntimeTurnResult,
 } from "../public/contract.js";
 import { AcpRuntimeError } from "../public/errors.js";
 import { parsePromptEventLine } from "../public/events.js";
@@ -93,6 +95,10 @@ class AsyncEventQueue {
     for (const waiter of this.waits.splice(0)) {
       waiter.resolve(null);
     }
+  }
+
+  clear(): void {
+    this.items.length = 0;
   }
 
   async next(): Promise<AcpRuntimeEvent | null> {
@@ -205,6 +211,21 @@ function resumePolicyForSessionMode(mode: "persistent" | "oneshot"): SessionResu
   return mode === "persistent" ? "same-session-only" : "allow-new";
 }
 
+function legacyTerminalEventFromTurnResult(result: AcpRuntimeTurnResult): AcpRuntimeEvent {
+  if (result.status === "failed") {
+    return {
+      type: "error",
+      message: result.error.message,
+      ...(result.error.code ? { code: result.error.code } : {}),
+      ...(result.error.retryable === undefined ? {} : { retryable: result.error.retryable }),
+    };
+  }
+  return {
+    type: "done",
+    ...(result.stopReason ? { stopReason: result.stopReason } : {}),
+  };
+}
+
 function statusSummary(record: SessionRecord): string {
   const parts = [
     `session=${record.acpxRecordId}`,
@@ -227,6 +248,25 @@ export class AcpRuntimeManager {
 
   private createClient(options: ConstructorParameters<typeof AcpClient>[0]): AcpClient {
     return this.deps.clientFactory?.(options) ?? new AcpClient(options);
+  }
+
+  private async readPendingPersistentClient(
+    record: SessionRecord,
+    options: { consume: boolean },
+  ): Promise<AcpClient | undefined> {
+    const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
+    if (!pendingClient) {
+      return undefined;
+    }
+    if (!pendingClient.hasReusableSession(record.acpSessionId)) {
+      this.pendingPersistentClients.delete(record.acpxRecordId);
+      await pendingClient.close().catch(() => {});
+      return undefined;
+    }
+    if (options.consume) {
+      this.pendingPersistentClients.delete(record.acpxRecordId);
+    }
+    return pendingClient;
   }
 
   async ensureSession(input: {
@@ -303,7 +343,7 @@ export class AcpRuntimeManager {
     }
   }
 
-  async *runTurn(input: {
+  startTurn(input: {
     handle: AcpRuntimeHandle;
     text: string;
     attachments?: AcpRuntimeTurnAttachment[];
@@ -312,113 +352,154 @@ export class AcpRuntimeManager {
     requestId: string;
     timeoutMs?: number;
     signal?: AbortSignal;
-  }): AsyncIterable<AcpRuntimeEvent> {
-    const record = await this.requireRecord(input.handle.acpxRecordId ?? input.handle.sessionKey);
-    const conversation = cloneSessionConversation(record);
-    let acpxState = cloneSessionAcpxState(record.acpx);
+  }): AcpRuntimeTurn {
     const promptInput = toPromptInput(input.text, input.attachments);
-    const promptMessageId = recordPromptSubmission(conversation, promptInput, isoNow());
-    trimConversationForRuntime(conversation);
-
     const queue = new AsyncEventQueue();
-    let pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
-    if (pendingClient) {
-      this.pendingPersistentClients.delete(record.acpxRecordId);
-      if (!pendingClient.hasReusableSession(record.acpSessionId)) {
-        await pendingClient.close().catch(() => {});
-        pendingClient = undefined;
-      }
-    }
-    const client =
-      pendingClient ??
-      this.createClient({
-        agentCommand: record.agentCommand,
-        cwd: record.cwd,
-        mcpServers: [...(this.options.mcpServers ?? [])],
-        permissionMode: this.options.permissionMode,
-        nonInteractivePermissions: this.options.nonInteractivePermissions,
-        verbose: this.options.verbose,
-      });
-    let activeSessionId = record.acpSessionId;
-    let sawDone = false;
-    let pendingCancel = false;
-    let turnActive = true;
+    const result = createDeferred<AcpRuntimeTurnResult>();
     const sessionReady = createDeferred<void>();
     void sessionReady.promise.catch(() => {});
+    let resultSettled = false;
+    let pendingCancel = false;
+    let turnActive = true;
+    let streamClosed = false;
+    let activeController: ActiveSessionController | null = null;
 
-    const applyPendingCancel = async (): Promise<boolean> => {
-      if (!pendingCancel || !client.hasActivePrompt()) {
-        return false;
-      }
-      const cancelled = await client.requestCancelActivePrompt();
-      if (cancelled) {
-        pendingCancel = false;
-      }
-      return cancelled;
-    };
-
-    const activeController: ActiveSessionController = {
-      hasActivePrompt: () => client.hasActivePrompt(),
-      requestCancelActivePrompt: async () => {
-        if (client.hasActivePrompt()) {
-          return await client.requestCancelActivePrompt();
-        }
-        if (!turnActive) {
-          return false;
-        }
-        pendingCancel = true;
-        return true;
-      },
-      setSessionMode: async (modeId: string) => {
-        if (!client.hasActivePrompt()) {
-          await sessionReady.promise;
-        }
-        await client.setSessionMode(activeSessionId, modeId);
-      },
-      setSessionModel: async (modelId: string) => {
-        if (!client.hasActivePrompt()) {
-          await sessionReady.promise;
-        }
-        await client.setSessionModel(activeSessionId, modelId);
-      },
-      setSessionConfigOption: async (configId: string, value: string) => {
-        if (!client.hasActivePrompt()) {
-          await sessionReady.promise;
-        }
-        return await client.setSessionConfigOption(activeSessionId, configId, value);
-      },
-    };
-
-    const emitParsed = (payload: Record<string, unknown>): void => {
-      const parsed = parsePromptEventLine(JSON.stringify(payload));
-      if (!parsed) {
+    const settleResult = (next: AcpRuntimeTurnResult): void => {
+      if (resultSettled) {
         return;
       }
-      if (parsed.type === "done") {
-        sawDone = true;
+      resultSettled = true;
+      result.resolve(next);
+    };
+
+    const closeStream = (): void => {
+      if (streamClosed) {
+        return;
       }
-      queue.push(parsed);
+      streamClosed = true;
+      queue.clear();
+      queue.close();
+    };
+
+    const requestCancel = async (): Promise<boolean> => {
+      if (activeController) {
+        return await activeController.requestCancelActivePrompt();
+      }
+      if (!turnActive) {
+        return false;
+      }
+      pendingCancel = true;
+      return true;
     };
 
     const abortHandler = () => {
-      void activeController.requestCancelActivePrompt();
+      void requestCancel();
     };
     if (input.signal) {
       if (input.signal.aborted) {
-        queue.close();
-        return;
+        closeStream();
+        settleResult({
+          status: "cancelled",
+          stopReason: "cancelled",
+        });
+        return {
+          requestId: input.requestId,
+          events: queue.iterate(),
+          result: result.promise,
+          cancel: async () => {},
+          closeStream: async () => {},
+        };
       }
       input.signal.addEventListener("abort", abortHandler, { once: true });
     }
 
-    this.activeControllers.set(record.acpxRecordId, activeController);
-
     void (async () => {
+      let record: SessionRecord | null = null;
+      let conversation: ReturnType<typeof cloneSessionConversation> | null = null;
+      let acpxState: ReturnType<typeof cloneSessionAcpxState>;
+      let client: AcpClient | null = null;
       try {
-        client.setEventHandlers({
+        record = await this.requireRecord(input.handle.acpxRecordId ?? input.handle.sessionKey);
+        conversation = cloneSessionConversation(record);
+        acpxState = cloneSessionAcpxState(record.acpx);
+        const promptMessageId = recordPromptSubmission(conversation, promptInput, isoNow());
+        trimConversationForRuntime(conversation);
+
+        const pendingClient = await this.readPendingPersistentClient(record, { consume: true });
+        client =
+          pendingClient ??
+          this.createClient({
+            agentCommand: record.agentCommand,
+            cwd: record.cwd,
+            mcpServers: [...(this.options.mcpServers ?? [])],
+            permissionMode: this.options.permissionMode,
+            nonInteractivePermissions: this.options.nonInteractivePermissions,
+            verbose: this.options.verbose,
+          });
+        const runtimeClient = client;
+        const runtimeConversation = conversation;
+        const runtimeRecord = record;
+        let activeSessionId = record.acpSessionId;
+
+        const applyPendingCancel = async (): Promise<boolean> => {
+          if (!pendingCancel || !runtimeClient.hasActivePrompt()) {
+            return false;
+          }
+          const cancelled = await runtimeClient.requestCancelActivePrompt();
+          if (cancelled) {
+            pendingCancel = false;
+          }
+          return cancelled;
+        };
+
+        activeController = {
+          hasActivePrompt: () => runtimeClient.hasActivePrompt(),
+          requestCancelActivePrompt: async () => {
+            if (runtimeClient.hasActivePrompt()) {
+              return await runtimeClient.requestCancelActivePrompt();
+            }
+            if (!turnActive) {
+              return false;
+            }
+            pendingCancel = true;
+            return true;
+          },
+          setSessionMode: async (modeId: string) => {
+            if (!runtimeClient.hasActivePrompt()) {
+              await sessionReady.promise;
+            }
+            await runtimeClient.setSessionMode(activeSessionId, modeId);
+          },
+          setSessionModel: async (modelId: string) => {
+            if (!runtimeClient.hasActivePrompt()) {
+              await sessionReady.promise;
+            }
+            await runtimeClient.setSessionModel(activeSessionId, modelId);
+          },
+          setSessionConfigOption: async (configId: string, value: string) => {
+            if (!runtimeClient.hasActivePrompt()) {
+              await sessionReady.promise;
+            }
+            return await runtimeClient.setSessionConfigOption(activeSessionId, configId, value);
+          },
+        };
+
+        const emitParsed = (payload: Record<string, unknown>): void => {
+          if (streamClosed) {
+            return;
+          }
+          const parsed = parsePromptEventLine(JSON.stringify(payload));
+          if (!parsed) {
+            return;
+          }
+          queue.push(parsed);
+        };
+
+        this.activeControllers.set(runtimeRecord.acpxRecordId, activeController);
+        runtimeClient.setEventHandlers({
           onSessionUpdate: (notification) => {
-            acpxState = recordSessionUpdate(conversation, acpxState, notification);
-            trimConversationForRuntime(conversation);
+            acpxState = recordSessionUpdate(runtimeConversation, acpxState, notification);
+            trimConversationForRuntime(runtimeConversation);
             emitParsed({
               jsonrpc: "2.0",
               method: "session/update",
@@ -426,8 +507,8 @@ export class AcpRuntimeManager {
             });
           },
           onClientOperation: (operation: ClientOperation) => {
-            acpxState = recordClientOperation(conversation, acpxState, operation);
-            trimConversationForRuntime(conversation);
+            acpxState = recordClientOperation(runtimeConversation, acpxState, operation);
+            trimConversationForRuntime(runtimeConversation);
             emitParsed({
               type: "client_operation",
               ...operation,
@@ -442,13 +523,14 @@ export class AcpRuntimeManager {
               loadError: undefined,
             }
           : await connectAndLoadSession({
-              client,
-              record,
+              client: runtimeClient,
+              record: runtimeRecord,
               resumePolicy: resumePolicyForSessionMode(input.sessionMode),
               timeoutMs: this.options.timeoutMs,
               activeController,
               onClientAvailable: (controller) => {
-                this.activeControllers.set(record.acpxRecordId, controller);
+                activeController = controller;
+                this.activeControllers.set(runtimeRecord.acpxRecordId, controller);
               },
               onConnectedRecord: (connectedRecord) => {
                 connectedRecord.lastPromptAt = isoNow();
@@ -459,11 +541,11 @@ export class AcpRuntimeManager {
             });
         sessionReady.resolve();
 
-        record.lastRequestId = input.requestId;
-        record.lastPromptAt = isoNow();
-        record.closed = false;
-        record.closedAt = undefined;
-        record.lastUsedAt = isoNow();
+        runtimeRecord.lastRequestId = input.requestId;
+        runtimeRecord.lastPromptAt = isoNow();
+        runtimeRecord.closed = false;
+        runtimeRecord.closedAt = undefined;
+        runtimeRecord.lastUsedAt = isoNow();
         if (resumed || loadError) {
           emitParsed({
             type: "status",
@@ -473,83 +555,113 @@ export class AcpRuntimeManager {
 
         if (pendingCancel || input.signal?.aborted) {
           pendingCancel = false;
-          if (!sawDone) {
-            queue.push({
-              type: "done",
-              stopReason: "cancelled",
-            });
-          }
+          settleResult({
+            status: "cancelled",
+            stopReason: "cancelled",
+          });
           return;
         }
 
         await applyPendingCancel();
         const response = await runPromptTurn({
-          client,
+          client: runtimeClient,
           sessionId,
           prompt: promptInput,
           timeoutMs: input.timeoutMs ?? this.options.timeoutMs,
-          conversation,
+          conversation: runtimeConversation,
           promptMessageId,
         });
 
-        record.acpSessionId = activeSessionId;
-        reconcileAgentSessionId(record, record.agentSessionId);
-        record.protocolVersion = client.initializeResult?.protocolVersion;
-        record.agentCapabilities = client.initializeResult?.agentCapabilities;
-        record.acpx = acpxState;
-        applyConversation(record, conversation);
-        applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
-        await this.options.sessionStore.save(record);
+        runtimeRecord.acpSessionId = activeSessionId;
+        reconcileAgentSessionId(runtimeRecord, runtimeRecord.agentSessionId);
+        runtimeRecord.protocolVersion = runtimeClient.initializeResult?.protocolVersion;
+        runtimeRecord.agentCapabilities = runtimeClient.initializeResult?.agentCapabilities;
+        runtimeRecord.acpx = acpxState;
+        applyConversation(runtimeRecord, runtimeConversation);
+        applyLifecycleSnapshotToRecord(runtimeRecord, runtimeClient.getAgentLifecycleSnapshot());
+        await this.options.sessionStore.save(runtimeRecord);
 
-        if (!sawDone) {
-          queue.push({
-            type: "done",
-            stopReason: response.stopReason,
-          });
-        }
+        settleResult({
+          status: response.stopReason === "cancelled" ? "cancelled" : "completed",
+          ...(response.stopReason ? { stopReason: response.stopReason } : {}),
+        });
       } catch (error) {
         sessionReady.reject(error);
         const normalized = normalizeOutputError(error, { origin: "runtime" });
-        queue.push({
-          type: "error",
-          message: normalized.message,
-          code: normalized.code,
-          retryable: normalized.retryable,
+        settleResult({
+          status: "failed",
+          error: {
+            message: normalized.message,
+            ...(normalized.code ? { code: normalized.code } : {}),
+            ...(normalized.retryable !== undefined ? { retryable: normalized.retryable } : {}),
+          },
         });
       } finally {
         turnActive = false;
         if (input.signal) {
           input.signal.removeEventListener("abort", abortHandler);
         }
-        this.activeControllers.delete(record.acpxRecordId);
-        client.clearEventHandlers();
-        applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
-        record.acpx = acpxState;
-        applyConversation(record, conversation);
-        record.lastUsedAt = isoNow();
-        await this.options.sessionStore.save(record).catch(() => {});
-        const isPersistentRecord = !record.acpxRecordId.includes(":oneshot:");
+        if (record) {
+          this.activeControllers.delete(record.acpxRecordId);
+        }
+        client?.clearEventHandlers();
         let pooled = false;
-        if (
-          isPersistentRecord &&
-          !record.closed &&
-          client.hasReusableSession(record.acpSessionId)
-        ) {
-          const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);
-          this.pendingPersistentClients.set(record.acpxRecordId, client);
-          pooled = true;
-          if (previousClient && previousClient !== client) {
-            await previousClient.close().catch(() => {});
+        if (record && conversation) {
+          applyLifecycleSnapshotToRecord(
+            record,
+            client?.getAgentLifecycleSnapshot() ?? { running: false },
+          );
+          record.acpx = acpxState;
+          applyConversation(record, conversation);
+          record.lastUsedAt = isoNow();
+          await this.options.sessionStore.save(record).catch(() => {});
+          const isPersistentRecord = !record.acpxRecordId.includes(":oneshot:");
+          if (
+            isPersistentRecord &&
+            !record.closed &&
+            client?.hasReusableSession(record.acpSessionId)
+          ) {
+            const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);
+            this.pendingPersistentClients.set(record.acpxRecordId, client);
+            pooled = true;
+            if (previousClient && previousClient !== client) {
+              await previousClient.close().catch(() => {});
+            }
           }
         }
         if (!pooled) {
-          await client.close().catch(() => {});
+          await client?.close().catch(() => {});
         }
         queue.close();
       }
     })();
 
-    yield* queue.iterate();
+    return {
+      requestId: input.requestId,
+      events: queue.iterate(),
+      result: result.promise,
+      cancel: async () => {
+        await requestCancel();
+      },
+      closeStream: async () => {
+        closeStream();
+      },
+    };
+  }
+
+  async *runTurn(input: {
+    handle: AcpRuntimeHandle;
+    text: string;
+    attachments?: AcpRuntimeTurnAttachment[];
+    mode: AcpRuntimePromptMode;
+    sessionMode: "persistent" | "oneshot";
+    requestId: string;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): AsyncIterable<AcpRuntimeEvent> {
+    const turn = this.startTurn(input);
+    yield* turn.events;
+    yield legacyTerminalEventFromTurnResult(await turn.result);
   }
 
   async getStatus(handle: AcpRuntimeHandle): Promise<AcpRuntimeStatus> {
@@ -669,18 +781,10 @@ export class AcpRuntimeManager {
   }
 
   private async closeBackendSession(record: SessionRecord): Promise<void> {
-    const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
-    if (pendingClient) {
-      this.pendingPersistentClients.delete(record.acpxRecordId);
-    }
-    const reusablePendingClient =
-      pendingClient?.hasReusableSession(record.acpSessionId) === true ? pendingClient : undefined;
-    if (pendingClient && !reusablePendingClient) {
-      await pendingClient.close().catch(() => {});
-    }
+    const pendingClient = await this.readPendingPersistentClient(record, { consume: true });
 
     const client =
-      reusablePendingClient ??
+      pendingClient ??
       this.createClient({
         agentCommand: record.agentCommand,
         cwd: record.cwd,
@@ -691,7 +795,7 @@ export class AcpRuntimeManager {
       });
 
     try {
-      if (!reusablePendingClient) {
+      if (!pendingClient) {
         await withTimeout(client.start(), this.options.timeoutMs);
       }
       if (!client.supportsCloseSession()) {

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -240,6 +240,7 @@ function statusSummary(record: SessionRecord): string {
 export class AcpRuntimeManager {
   private readonly activeControllers = new Map<string, ActiveSessionController>();
   private readonly pendingPersistentClients = new Map<string, AcpClient>();
+  private readonly closingActiveRecords = new Set<string>();
 
   constructor(
     private readonly options: AcpRuntimeOptions,
@@ -269,6 +270,47 @@ export class AcpRuntimeManager {
     return pendingClient;
   }
 
+  private async closePendingPersistentClient(recordId: string): Promise<void> {
+    const pendingClient = this.pendingPersistentClients.get(recordId);
+    if (!pendingClient) {
+      return;
+    }
+    this.pendingPersistentClients.delete(recordId);
+    await pendingClient.close().catch(() => {});
+  }
+
+  private async refreshClosedState(record: SessionRecord): Promise<boolean> {
+    if (!this.closingActiveRecords.has(record.acpxRecordId)) {
+      return record.closed === true;
+    }
+    const latest = await this.options.sessionStore.load(record.acpxRecordId).catch(() => undefined);
+    record.closed = true;
+    record.closedAt = latest?.closedAt ?? record.closedAt ?? isoNow();
+    if (latest?.acpx) {
+      record.acpx = {
+        ...record.acpx,
+        ...latest.acpx,
+      };
+    }
+    return true;
+  }
+
+  private async retainPersistentClientAfterTurn(input: {
+    record: SessionRecord;
+    client: AcpClient;
+  }): Promise<boolean> {
+    const { record, client } = input;
+    const isPersistentRecord = !record.acpxRecordId.includes(":oneshot:");
+    if (!isPersistentRecord || record.closed || !client.hasReusableSession(record.acpSessionId)) {
+      return false;
+    }
+    const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);
+    this.pendingPersistentClients.set(record.acpxRecordId, client);
+    if (previousClient && previousClient !== client) {
+      await previousClient.close().catch(() => {});
+    }
+    return true;
+  }
   async ensureSession(input: {
     sessionKey: string;
     agent: string;
@@ -290,6 +332,7 @@ export class AcpRuntimeManager {
     ) {
       existing.closed = false;
       existing.closedAt = undefined;
+      this.closingActiveRecords.delete(existing.acpxRecordId);
       await this.options.sessionStore.save(existing);
       return existing;
     }
@@ -325,6 +368,7 @@ export class AcpRuntimeManager {
         cwd,
         agentSessionId,
       });
+      this.closingActiveRecords.delete(record.acpxRecordId);
       record.protocolVersion = client.initializeResult?.protocolVersion;
       record.agentCapabilities = client.initializeResult?.agentCapabilities;
       applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
@@ -601,9 +645,6 @@ export class AcpRuntimeManager {
         if (input.signal) {
           input.signal.removeEventListener("abort", abortHandler);
         }
-        if (record) {
-          this.activeControllers.delete(record.acpxRecordId);
-        }
         client?.clearEventHandlers();
         let pooled = false;
         if (record && conversation) {
@@ -614,23 +655,18 @@ export class AcpRuntimeManager {
           record.acpx = acpxState;
           applyConversation(record, conversation);
           record.lastUsedAt = isoNow();
+          const closed = await this.refreshClosedState(record);
           await this.options.sessionStore.save(record).catch(() => {});
-          const isPersistentRecord = !record.acpxRecordId.includes(":oneshot:");
-          if (
-            isPersistentRecord &&
-            !record.closed &&
-            client?.hasReusableSession(record.acpSessionId)
-          ) {
-            const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);
-            this.pendingPersistentClients.set(record.acpxRecordId, client);
-            pooled = true;
-            if (previousClient && previousClient !== client) {
-              await previousClient.close().catch(() => {});
-            }
+          if (!closed && client) {
+            pooled = await this.retainPersistentClientAfterTurn({ record, client });
           }
         }
         if (!pooled) {
           await client?.close().catch(() => {});
+        }
+        if (record) {
+          this.activeControllers.delete(record.acpxRecordId);
+          this.closingActiveRecords.delete(record.acpxRecordId);
         }
         queue.close();
       }
@@ -761,6 +797,9 @@ export class AcpRuntimeManager {
     options: { discardPersistentState?: boolean } = {},
   ): Promise<void> {
     const record = await this.requireRecord(handle.acpxRecordId ?? handle.sessionKey);
+    if (this.activeControllers.has(record.acpxRecordId)) {
+      this.closingActiveRecords.add(record.acpxRecordId);
+    }
     await this.cancel(handle);
     if (options.discardPersistentState) {
       await this.closeBackendSession(record);
@@ -769,11 +808,7 @@ export class AcpRuntimeManager {
         reset_on_next_ensure: true,
       };
     } else {
-      const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
-      if (pendingClient) {
-        this.pendingPersistentClients.delete(record.acpxRecordId);
-        await pendingClient.close().catch(() => {});
-      }
+      await this.closePendingPersistentClient(record.acpxRecordId);
     }
     record.closed = true;
     record.closedAt = isoNow();

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -100,10 +100,18 @@ export type AcpRuntimeEvent =
       status?: string;
       title?: string;
     }
+  /**
+   * Compatibility terminal event emitted by runTurn(...). startTurn(...).events
+   * does not emit terminal events; use AcpRuntimeTurn.result instead.
+   */
   | {
       type: "done";
       stopReason?: string;
     }
+  /**
+   * Compatibility failure event emitted by runTurn(...). startTurn(...).events
+   * does not emit terminal events; use AcpRuntimeTurn.result instead.
+   */
   | {
       type: "error";
       message: string;
@@ -111,8 +119,42 @@ export type AcpRuntimeEvent =
       retryable?: boolean;
     };
 
+export type AcpRuntimeTurnResultError = {
+  message: string;
+  code?: string;
+  retryable?: boolean;
+};
+
+export type AcpRuntimeTurnResult =
+  | {
+      status: "completed";
+      stopReason?: string;
+    }
+  | {
+      status: "cancelled";
+      stopReason?: string;
+    }
+  | {
+      status: "failed";
+      error: AcpRuntimeTurnResultError;
+    };
+
+export interface AcpRuntimeTurn {
+  readonly requestId: string;
+  readonly events: AsyncIterable<AcpRuntimeEvent>;
+  readonly result: Promise<AcpRuntimeTurnResult>;
+  cancel(input?: { reason?: string }): Promise<void>;
+  closeStream(input?: { reason?: string }): Promise<void>;
+}
+
 export interface AcpRuntime {
   ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle>;
+  startTurn(input: AcpRuntimeTurnInput): AcpRuntimeTurn;
+  /**
+   * Compatibility adapter for consumers that expect terminal status in the
+   * event stream. Prefer startTurn(...), which separates live events from the
+   * terminal result.
+   */
   runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent>;
   getCapabilities?(input: {
     handle?: AcpRuntimeHandle;

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -1,11 +1,5 @@
 import type { AcpRuntimeEvent, AcpSessionUpdateTag } from "./contract.js";
-import {
-  asOptionalBoolean,
-  asOptionalString,
-  asString,
-  asTrimmedString,
-  isRecord,
-} from "./shared.js";
+import { asOptionalString, asString, asTrimmedString, isRecord } from "./shared.js";
 
 function safeParseJsonObject(line: string): Record<string, unknown> | null {
   try {
@@ -152,16 +146,86 @@ function createTextDeltaEvent(params: {
   };
 }
 
+function readFirstString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = asOptionalString(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readFirstStringArray(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string[] | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    const entries = value
+      .map((entry) => asOptionalString(entry))
+      .filter((entry): entry is string => entry !== undefined);
+    if (entries.length > 0) {
+      return entries;
+    }
+  }
+  return undefined;
+}
+
+function summarizeToolInput(rawInput: unknown): string | undefined {
+  if (rawInput == null) {
+    return undefined;
+  }
+  if (
+    typeof rawInput === "string" ||
+    typeof rawInput === "number" ||
+    typeof rawInput === "boolean"
+  ) {
+    return String(rawInput);
+  }
+  if (!isRecord(rawInput)) {
+    return undefined;
+  }
+
+  const command = readFirstString(rawInput, ["command", "cmd", "program"]);
+  const args = readFirstStringArray(rawInput, ["args", "arguments"]);
+  if (command) {
+    return [command, ...(args ?? [])].join(" ");
+  }
+
+  return readFirstString(rawInput, [
+    "path",
+    "file",
+    "filePath",
+    "filepath",
+    "target",
+    "uri",
+    "url",
+    "query",
+    "pattern",
+    "text",
+    "search",
+  ]);
+}
+
 function createToolCallEvent(params: {
   payload: Record<string, unknown>;
   tag: AcpSessionUpdateTag;
 }): AcpRuntimeEvent {
   const title = asTrimmedString(params.payload.title) || "tool call";
   const status = asTrimmedString(params.payload.status);
+  const inputSummary = summarizeToolInput(params.payload.rawInput);
   const toolCallId = asOptionalString(params.payload.toolCallId);
+  const summaryText = status ? `${title} (${status})` : title;
   return {
     type: "tool_call",
-    text: status ? `${title} (${status})` : title,
+    text: inputSummary ? `${summaryText}: ${inputSummary}` : summaryText,
     tag: params.tag,
     ...(toolCallId ? { toolCallId } : {}),
     ...(status ? { status } : {}),
@@ -271,19 +335,8 @@ export function parsePromptEventLine(line: string): AcpRuntimeEvent | null {
       return { type: "status", text: update, ...(tag ? { tag } : {}) };
     }
     case "done":
-      return {
-        type: "done",
-        stopReason: asOptionalString(payload.stopReason),
-      };
-    case "error": {
-      const message = asTrimmedString(payload.message) || "acpx runtime error";
-      return {
-        type: "error",
-        message,
-        code: asOptionalString(payload.code),
-        retryable: asOptionalBoolean(payload.retryable),
-      };
-    }
+    case "error":
+      return null;
     default:
       return null;
   }

--- a/test/runtime-events.test.ts
+++ b/test/runtime-events.test.ts
@@ -96,15 +96,45 @@ test("parsePromptEventLine handles text chunks, usage updates, tool updates, and
     },
   );
 
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s1",
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: "call_SEARCH",
+            title: "Search",
+            status: "in_progress",
+            rawInput: {
+              command: "rg",
+              args: ["-n", "needle"],
+            },
+          },
+        },
+      }),
+    ),
+    {
+      type: "tool_call",
+      text: "Search (in_progress): rg -n needle",
+      tag: "tool_call",
+      toolCallId: "call_SEARCH",
+      status: "in_progress",
+      title: "Search",
+    },
+  );
+
   assert.deepEqual(parsePromptEventLine(JSON.stringify({ type: "text", content: "alpha" })), {
     type: "text_delta",
     text: "alpha",
     stream: "output",
   });
-  assert.deepEqual(parsePromptEventLine(JSON.stringify({ type: "done", stopReason: "end_turn" })), {
-    type: "done",
-    stopReason: "end_turn",
-  });
+  assert.equal(
+    parsePromptEventLine(JSON.stringify({ type: "done", stopReason: "end_turn" })),
+    null,
+  );
 });
 
 test("parsePromptEventLine handles runtime status-style updates", () => {
@@ -202,16 +232,11 @@ test("parsePromptEventLine handles runtime status-style updates", () => {
     },
   );
 
-  assert.deepEqual(
+  assert.equal(
     parsePromptEventLine(
       JSON.stringify({ type: "error", message: "broken", code: "E1", retryable: true }),
     ),
-    {
-      type: "error",
-      message: "broken",
-      code: "E1",
-      retryable: true,
-    },
+    null,
   );
 });
 

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -495,6 +495,93 @@ test("AcpRuntimeManager runTurn remains a compatibility adapter over startTurn",
   ]);
 });
 
+test("AcpRuntimeManager retains a reusable persistent client across turns", async () => {
+  const store = new InMemorySessionStore();
+  let constructed = 0;
+  let createSessionCalls = 0;
+  let loadSessionCalls = 0;
+  let promptCalls = 0;
+  let closeCalls = 0;
+  const promptSessionIds: string[] = [];
+
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => {
+        constructed += 1;
+        return {
+          initializeResult: {
+            protocolVersion: 1,
+            agentCapabilities: { loadSession: true },
+          },
+          start: async () => {},
+          close: async () => {
+            closeCalls += 1;
+          },
+          createSession: async () => {
+            createSessionCalls += 1;
+            return { sessionId: "pooled-persistent-sid", agentSessionId: "pooled-agent-id" };
+          },
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: (sessionId: string) => sessionId === "pooled-persistent-sid",
+          supportsLoadSession: () => true,
+          loadSessionWithOptions: async () => {
+            loadSessionCalls += 1;
+            return { agentSessionId: "unexpected-load-agent-id" };
+          },
+          getAgentLifecycleSnapshot: () => ({
+            pid: 1234,
+            startedAt: "2026-01-01T00:00:00.000Z",
+            running: true,
+          }),
+          prompt: async (sessionId: string) => {
+            promptCalls += 1;
+            promptSessionIds.push(sessionId);
+            return { stopReason: "end_turn" };
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        } as never;
+      },
+    },
+  );
+
+  const record = await manager.ensureSession({
+    sessionKey: "pooled-persistent-session",
+    agent: "codex",
+    mode: "persistent",
+  });
+  const handle = createHandle("pooled-persistent-session", record.acpxRecordId);
+
+  for (const requestId of ["req-pooled-1", "req-pooled-2"]) {
+    const turn = manager.startTurn({
+      handle,
+      text: "hello",
+      mode: "prompt",
+      sessionMode: "persistent",
+      requestId,
+    });
+    const { events, result } = await collectTurn(turn);
+    assert.deepEqual(events, []);
+    assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
+  }
+
+  assert.equal(constructed, 1);
+  assert.equal(createSessionCalls, 1);
+  assert.equal(loadSessionCalls, 0);
+  assert.equal(promptCalls, 2);
+  assert.deepEqual(promptSessionIds, ["pooled-persistent-sid", "pooled-persistent-sid"]);
+  assert.equal(closeCalls, 0);
+
+  await manager.close(handle);
+
+  assert.equal(closeCalls, 1);
+});
+
 test("AcpRuntimeManager closeStream suppresses future live events while preserving terminal completion", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "stream-close-session",
@@ -592,6 +679,85 @@ test("AcpRuntimeManager closeStream suppresses future live events while preservi
     done: true,
     value: undefined,
   });
+});
+
+test("AcpRuntimeManager does not pool a persistent client after active close", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "active-close-session",
+    acpSessionId: "active-close-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let closeCalls = 0;
+  let promptActive = false;
+  let resolvePromptStart!: () => void;
+  let resolvePrompt!: (value: { stopReason: string }) => void;
+  const promptStarted = new Promise<void>((resolve) => {
+    resolvePromptStart = resolve;
+  });
+  const promptResult = new Promise<{ stopReason: string }>((resolve) => {
+    resolvePrompt = resolve;
+  });
+  const client: FakeClient = {
+    start: async () => {},
+    close: async () => {
+      closeCalls += 1;
+      promptActive = false;
+    },
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: (sessionId) => sessionId === "active-close-sid",
+    supportsLoadSession: () => true,
+    loadSessionWithOptions: async () => ({ agentSessionId: "active-close-agent-id" }),
+    getAgentLifecycleSnapshot: () => ({ running: promptActive }),
+    prompt: async () => {
+      promptActive = true;
+      resolvePromptStart();
+      return await promptResult;
+    },
+    requestCancelActivePrompt: async () => true,
+    hasActivePrompt: () => promptActive,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {},
+    setEventHandlers: () => {},
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => client as never,
+    },
+  );
+  const handle = createHandle("active-close-session");
+
+  const turn = manager.startTurn({
+    handle,
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-active-close",
+  });
+  const eventsPromise = collectEvents(turn.events);
+  await promptStarted;
+
+  await manager.close(handle);
+
+  let closed = await store.load("active-close-session");
+  assert.equal(closed?.closed, true);
+  assert.equal(closeCalls, 0);
+
+  resolvePrompt({ stopReason: "cancelled" });
+
+  const events = await eventsPromise;
+  const result = await turn.result;
+  closed = await store.load("active-close-session");
+
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, { status: "cancelled", stopReason: "cancelled" });
+  assert.equal(closeCalls, 1);
+  assert.equal(closed?.closed, true);
+  assert.equal(typeof closed?.closedAt, "string");
 });
 
 test("AcpRuntimeManager accepts a session reply even when the prompt RPC times out", async () => {

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { AcpRuntimeManager } from "../src/runtime/engine/manager.js";
-import type { AcpRuntimeEvent, AcpRuntimeHandle } from "../src/runtime/public/contract.js";
+import type {
+  AcpRuntimeEvent,
+  AcpRuntimeHandle,
+  AcpRuntimeTurn,
+  AcpRuntimeTurnResult,
+} from "../src/runtime/public/contract.js";
 import {
   createRuntimeOptions,
   InMemorySessionStore,
@@ -52,7 +58,11 @@ type FakeClient = {
   requestCancelActivePrompt: () => Promise<boolean>;
   hasActivePrompt: () => boolean;
   setSessionMode: (sessionId: string, modeId: string) => Promise<void>;
-  setSessionConfigOption: (sessionId: string, configId: string, value: string) => Promise<void>;
+  setSessionConfigOption: (
+    sessionId: string,
+    configId: string,
+    value: string,
+  ) => Promise<SetSessionConfigOptionResponse | void>;
   clearEventHandlers: () => void;
   setEventHandlers: (handlers: FakeClientHandlers) => void;
 };
@@ -72,6 +82,14 @@ async function collectEvents(iterable: AsyncIterable<AcpRuntimeEvent>): Promise<
     events.push(event);
   }
   return events;
+}
+
+async function collectTurn(turn: AcpRuntimeTurn): Promise<{
+  events: AcpRuntimeEvent[];
+  result: AcpRuntimeTurnResult;
+}> {
+  const [events, result] = await Promise.all([collectEvents(turn.events), turn.result]);
+  return { events, result };
 }
 
 test("AcpRuntimeManager reuses compatible records without spawning a new client", async () => {
@@ -289,21 +307,20 @@ test("AcpRuntimeManager streams runtime events and saves updated status", async 
     },
   );
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("turn-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-1",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("turn-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-1",
+  });
+  const { events, result } = await collectTurn(turn);
 
   assert.deepEqual(events, [
     { type: "text_delta", text: "hello", stream: "output", tag: "agent_message_chunk" },
     { type: "status", text: "write_file ok saved notes.md" },
-    { type: "done", stopReason: "end_turn" },
   ]);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
 
   const saved = await store.load("turn-session");
   assert.equal(saved?.lastRequestId, "req-1");
@@ -416,6 +433,167 @@ test("AcpRuntimeManager keeps reusable persistent clients pooled across turns an
   assert.equal(typeof closed?.closedAt, "string");
 });
 
+test("AcpRuntimeManager runTurn remains a compatibility adapter over startTurn", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "legacy-turn-session",
+    acpSessionId: "legacy-turn-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let handlers: FakeClientHandlers = {};
+  const client: FakeClient = {
+    start: async () => {},
+    close: async () => {},
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: (sessionId) => sessionId === "legacy-turn-sid",
+    supportsLoadSession: () => true,
+    loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+    getAgentLifecycleSnapshot: () => ({ running: true }),
+    prompt: async () => {
+      handlers.onSessionUpdate?.({
+        sessionId: "legacy-turn-sid",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "legacy" },
+        },
+      });
+      return { stopReason: "end_turn" };
+    },
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      handlers = {};
+    },
+    setEventHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => client as never,
+    },
+  );
+
+  const events = await collectEvents(
+    manager.runTurn({
+      handle: createHandle("legacy-turn-session"),
+      text: "hello",
+      mode: "prompt",
+      sessionMode: "persistent",
+      requestId: "req-legacy",
+    }),
+  );
+
+  assert.deepEqual(events, [
+    { type: "text_delta", text: "legacy", stream: "output", tag: "agent_message_chunk" },
+    { type: "done", stopReason: "end_turn" },
+  ]);
+});
+
+test("AcpRuntimeManager closeStream suppresses future live events while preserving terminal completion", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "stream-close-session",
+    acpSessionId: "stream-close-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let handlers: FakeClientHandlers = {};
+  let resolvePromptStart!: () => void;
+  let resolvePrompt!: (value: { stopReason: string }) => void;
+  const promptStarted = new Promise<void>((resolve) => {
+    resolvePromptStart = resolve;
+  });
+  const promptResult = new Promise<{ stopReason: string }>((resolve) => {
+    resolvePrompt = resolve;
+  });
+  const client: FakeClient = {
+    start: async () => {},
+    close: async () => {},
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: () => true,
+    supportsLoadSession: () => true,
+    loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+    getAgentLifecycleSnapshot: () => ({ running: true }),
+    prompt: async () => {
+      resolvePromptStart();
+      return await promptResult;
+    },
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => true,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      handlers = {};
+    },
+    setEventHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => client as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("stream-close-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-close-stream",
+  });
+  const iterator = turn.events[Symbol.asyncIterator]();
+
+  const firstEventPromise = iterator.next();
+  await promptStarted;
+  handlers.onSessionUpdate?.({
+    sessionId: "stream-close-sid",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "visible" },
+    },
+  });
+
+  assert.deepEqual(await firstEventPromise, {
+    done: false,
+    value: { type: "text_delta", text: "visible", stream: "output", tag: "agent_message_chunk" },
+  });
+
+  await turn.closeStream({
+    reason: "observer closed stream",
+  });
+
+  handlers.onSessionUpdate?.({
+    sessionId: "stream-close-sid",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "suppressed" },
+    },
+  });
+  resolvePrompt({ stopReason: "end_turn" });
+
+  assert.deepEqual(await iterator.next(), {
+    done: true,
+    value: undefined,
+  });
+  assert.deepEqual(await turn.result, {
+    status: "completed",
+    stopReason: "end_turn",
+  });
+  assert.deepEqual(await iterator.next(), {
+    done: true,
+    value: undefined,
+  });
+});
+
 test("AcpRuntimeManager accepts a session reply even when the prompt RPC times out", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "late-reply-session",
@@ -464,21 +642,20 @@ test("AcpRuntimeManager accepts a session reply even when the prompt RPC times o
     },
   );
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("late-reply-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-late-reply",
-      timeoutMs: 20,
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("late-reply-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-late-reply",
+    timeoutMs: 20,
+  });
+  const { events, result } = await collectTurn(turn);
 
   assert.deepEqual(events, [
     { type: "text_delta", text: "late reply", stream: "output", tag: "agent_message_chunk" },
-    { type: "done", stopReason: "end_turn" },
   ]);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
 });
 
 test("AcpRuntimeManager waits for late reply chunks to settle before ending a salvaged turn", async () => {
@@ -551,22 +728,21 @@ test("AcpRuntimeManager waits for late reply chunks to settle before ending a sa
     },
   );
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("late-reply-stream-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-late-reply-stream",
-      timeoutMs: 20,
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("late-reply-stream-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-late-reply-stream",
+    timeoutMs: 20,
+  });
+  const { events, result } = await collectTurn(turn);
 
   assert.deepEqual(events, [
     { type: "text_delta", text: "late", stream: "output", tag: "agent_message_chunk" },
     { type: "text_delta", text: " reply", stream: "output", tag: "agent_message_chunk" },
-    { type: "done", stopReason: "end_turn" },
   ]);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
 });
 
 test("AcpRuntimeManager routes controls through the active controller while a turn is running", async () => {
@@ -616,6 +792,17 @@ test("AcpRuntimeManager routes controls through the active controller while a tu
       assert.equal(key, "approval");
       assert.equal(value, "manual");
       setConfigCalls += 1;
+      return {
+        configOptions: [
+          {
+            id: "approval",
+            name: "Approval",
+            type: "select",
+            currentValue: "manual",
+            options: [{ value: "manual", name: "Manual" }],
+          },
+        ],
+      };
     },
     clearEventHandlers: () => {
       handlers = {};
@@ -631,25 +818,26 @@ test("AcpRuntimeManager routes controls through the active controller while a tu
     },
   );
 
-  const eventsPromise = collectEvents(
-    manager.runTurn({
-      handle: createHandle("live-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-live",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("live-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-live",
+  });
+  const eventsPromise = collectEvents(turn.events);
   await promptStarted;
   await manager.setMode(createHandle("live-session"), "plan");
   await manager.setConfigOption(createHandle("live-session"), "approval", "manual");
-  await manager.cancel(createHandle("live-session"));
+  await turn.cancel();
   const events = await eventsPromise;
+  const result = await turn.result;
 
   assert.equal(setModeCalls, 1);
   assert.equal(setConfigCalls, 1);
   assert.equal(cancelRequested, 1);
-  assert.deepEqual(events, [{ type: "done", stopReason: "cancelled" }]);
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, { status: "cancelled", stopReason: "cancelled" });
   assert.equal(handlers.onSessionUpdate, undefined);
 });
 
@@ -715,25 +903,26 @@ test("AcpRuntimeManager waits for oneshot load fallback to resolve before sendin
     },
   );
 
-  const eventsPromise = collectEvents(
-    manager.runTurn({
-      handle: createHandle("fallback-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "oneshot",
-      requestId: "req-fallback",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("fallback-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "oneshot",
+    requestId: "req-fallback",
+  });
+  const eventsPromise = collectEvents(turn.events);
   const setModePromise = manager.setMode(createHandle("fallback-session"), "plan", "oneshot");
   resolveLoadFailure();
   await setModePromise;
   await promptStarted;
-  await manager.cancel(createHandle("fallback-session"));
+  await turn.cancel();
   const events = await eventsPromise;
+  const result = await turn.result;
 
   assert.equal(setModeSessionId, "fresh-session");
   assert.equal(promptSessionId, "fresh-session");
-  assert.deepEqual(events, [{ type: "done", stopReason: "cancelled" }]);
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, { status: "cancelled", stopReason: "cancelled" });
 });
 
 test("AcpRuntimeManager honors aborts requested before prompt starts after oneshot load fallback", async () => {
@@ -784,24 +973,25 @@ test("AcpRuntimeManager honors aborts requested before prompt starts after onesh
   );
   const controller = new AbortController();
 
-  const eventsPromise = collectEvents(
-    manager.runTurn({
-      handle: createHandle("aborted-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "oneshot",
-      requestId: "req-abort",
-      signal: controller.signal,
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("aborted-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "oneshot",
+    requestId: "req-abort",
+    signal: controller.signal,
+  });
+  const eventsPromise = collectEvents(turn.events);
   await new Promise((resolve) => setTimeout(resolve, 0));
   controller.abort();
   resolveLoadFailure();
   const events = await eventsPromise;
+  const result = await turn.result;
 
   assert.equal(promptCalled, false);
   assert.equal(cancelCalls, 0);
-  assert.deepEqual(events, [{ type: "done", stopReason: "cancelled" }]);
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, { status: "cancelled", stopReason: "cancelled" });
 });
 
 test("AcpRuntimeManager handles offline oneshot controls, status, close, and missing records", async () => {
@@ -1166,19 +1356,18 @@ test("AcpRuntimeManager surfaces normalized prompt failures", async () => {
     },
   );
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("error-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-error",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("error-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-error",
+  });
+  const { events, result } = await collectTurn(turn);
 
-  assert.equal(events.length, 1);
-  assert.equal(events[0]?.type, "error");
-  assert.match((events[0] as { message: string }).message, /prompt exploded/);
+  assert.deepEqual(events, []);
+  assert.equal(result.status, "failed");
+  assert.match(result.error?.message ?? "", /prompt exploded/);
 });
 
 test("AcpRuntimeManager rejects unsupported runtime attachment media types", async () => {
@@ -1213,18 +1402,16 @@ test("AcpRuntimeManager rejects unsupported runtime attachment media types", asy
     },
   );
 
-  await assert.rejects(
-    async () =>
-      await collectEvents(
-        manager.runTurn({
-          handle: createHandle("attachment-session"),
-          text: "",
-          attachments: [{ mediaType: "application/pdf", data: "Zm9v" }],
-          mode: "prompt",
-          sessionMode: "persistent",
-          requestId: "req-attachment",
-        }),
-      ),
+  assert.throws(
+    () =>
+      manager.startTurn({
+        handle: createHandle("attachment-session"),
+        text: "",
+        attachments: [{ mediaType: "application/pdf", data: "Zm9v" }],
+        mode: "prompt",
+        sessionMode: "persistent",
+        requestId: "req-attachment",
+      }),
     /Unsupported ACP runtime attachment media type: application\/pdf/,
   );
 });
@@ -1269,25 +1456,25 @@ test("AcpRuntimeManager fails persistent turns clearly when session/load is unav
     },
   );
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("persistent-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-persistent",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("persistent-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-persistent",
+  });
+  const { events, result } = await collectTurn(turn);
 
-  assert.deepEqual(events, [
-    {
-      type: "error",
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, {
+    status: "failed",
+    error: {
       code: "RUNTIME",
       message:
         "Persistent ACP session persistent-backend-session could not be resumed: agent does not support session/load",
       retryable: true,
     },
-  ]);
+  });
   assert.equal(createSessionCalls, 0);
   assert.equal(promptCalls, 0);
 });
@@ -1331,17 +1518,17 @@ test("AcpRuntimeManager still falls back to a fresh session for oneshot turns", 
     },
   );
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("oneshot-session", "oneshot-session:oneshot:1"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "oneshot",
-      requestId: "req-oneshot",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("oneshot-session", "oneshot-session:oneshot:1"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "oneshot",
+    requestId: "req-oneshot",
+  });
+  const { events, result } = await collectTurn(turn);
 
-  assert.deepEqual(events, [{ type: "done", stopReason: "end_turn" }]);
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
   assert.equal(promptSessionId, "fresh-session");
   const saved = await store.load("oneshot-session:oneshot:1");
   assert.equal(saved?.acpSessionId, "fresh-session");
@@ -1420,17 +1607,17 @@ test("AcpRuntimeManager falls back when a kept-open persistent client is no long
   });
   firstClientReusable = false;
 
-  const events = await collectEvents(
-    manager.runTurn({
-      handle: createHandle("pending-persistent-session", record.acpxRecordId),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-pending-persistent-session",
-    }),
-  );
+  const turn = manager.startTurn({
+    handle: createHandle("pending-persistent-session", record.acpxRecordId),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-pending-persistent-session",
+  });
+  const { events, result } = await collectTurn(turn);
 
-  assert.deepEqual(events, [{ type: "done", stopReason: "end_turn" }]);
+  assert.deepEqual(events, []);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
   assert.equal(firstClientCloseCalls, 1);
   assert.equal(firstClientPromptCalls, 0);
   assert.equal(secondClientPromptCalls, 1);

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -12,6 +12,7 @@ import {
   createRuntimeStore,
   decodeAcpxRuntimeHandleState,
   encodeAcpxRuntimeHandleState,
+  type AcpRuntimeEvent,
   type AcpSessionRecord,
 } from "../src/runtime.js";
 
@@ -45,6 +46,18 @@ function createSessionRecord(overrides: Partial<AcpSessionRecord> = {}): AcpSess
   };
 }
 
+function emptyRuntimeEvents(): AsyncIterable<AcpRuntimeEvent> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<AcpRuntimeEvent> {
+      return {
+        async next() {
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+}
+
 test("AcpxRuntime delegates session lifecycle to the runtime manager", async () => {
   const encoded = encodeAcpxRuntimeHandleState({
     name: "agent:codex:acp:test",
@@ -71,13 +84,42 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
   let turnMode: string | undefined;
   let turnSessionMode: string | undefined;
   let turnTimeoutMs: number | undefined;
+  let closedStreamRequestId: string | undefined;
+  let cancelCalls = 0;
+  let managerCancelCalls = 0;
   let closeDiscardPersistentState: boolean | undefined;
   const manager = {
     ensureSession: async (input: { mode: string }) => {
       ensuredMode = input.mode;
       return record;
     },
-    async *runTurn(input: { mode: string; sessionMode: string; timeoutMs?: number }) {
+    startTurn(input: { mode: string; sessionMode: string; timeoutMs?: number; requestId: string }) {
+      turnMode = input.mode;
+      turnSessionMode = input.sessionMode;
+      turnTimeoutMs = input.timeoutMs;
+      return {
+        requestId: input.requestId,
+        events: (async function* () {
+          yield { type: "text_delta" as const, text: "hello", stream: "output" as const };
+        })(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: async () => {
+          cancelCalls += 1;
+        },
+        closeStream: async (_input?: { reason?: string }) => {
+          closedStreamRequestId = input.requestId;
+        },
+      };
+    },
+    async *runTurn(input: {
+      mode: string;
+      sessionMode: string;
+      timeoutMs?: number;
+      requestId: string;
+    }) {
       turnMode = input.mode;
       turnSessionMode = input.sessionMode;
       turnTimeoutMs = input.timeoutMs;
@@ -90,7 +132,9 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
     }),
     setMode: async () => {},
     setConfigOption: async () => {},
-    cancel: async () => {},
+    cancel: async () => {
+      managerCancelCalls += 1;
+    },
     close: async (_handle: unknown, options?: { discardPersistentState?: boolean }) => {
       closeDiscardPersistentState = options?.discardPersistentState;
     },
@@ -119,21 +163,35 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
   assert.equal(handle.backendSessionId, "sid-1");
   assert.equal(handle.agentSessionId, "inner-1");
 
-  const events = [];
-  for await (const event of runtime.runTurn({
+  const turn = runtime.startTurn({
     handle,
     text: "hello",
     mode: "steer",
     requestId: "req-1",
     timeoutMs: 42,
-  })) {
+  });
+  const events = [];
+  for await (const event of turn.events) {
     events.push(event);
   }
+  const result = await turn.result;
 
   assert.equal(turnMode, "steer");
   assert.equal(turnSessionMode, "oneshot");
   assert.equal(turnTimeoutMs, 42);
-  assert.deepEqual(events, [
+  assert.deepEqual(events, [{ type: "text_delta", text: "hello", stream: "output" }]);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
+
+  const legacyEvents: AcpRuntimeEvent[] = [];
+  for await (const event of runtime.runTurn({
+    handle,
+    text: "legacy",
+    mode: "prompt",
+    requestId: "req-legacy",
+  })) {
+    legacyEvents.push(event);
+  }
+  assert.deepEqual(legacyEvents, [
     { type: "text_delta", text: "hello", stream: "output" },
     { type: "done", stopReason: "end_turn" },
   ]);
@@ -141,8 +199,13 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
   await runtime.getStatus({ handle });
   await runtime.setMode({ handle, mode: "architect" });
   await runtime.setConfigOption({ handle, key: "approval", value: "manual" });
-  await runtime.cancel({ handle });
+  await runtime.cancel({ handle, reason: "legacy cancel" });
+  await turn.closeStream({ reason: "observer closed stream" });
+  await turn.cancel();
   await runtime.close({ handle, reason: "test", discardPersistentState: true });
+  assert.equal(closedStreamRequestId, "req-1");
+  assert.equal(cancelCalls, 1);
+  assert.equal(managerCancelCalls, 1);
   assert.equal(closeDiscardPersistentState, true);
 });
 
@@ -256,8 +319,17 @@ test("AcpxRuntime falls back to plain runtimeSessionName handles and reuses a si
   let managerFactoryCalls = 0;
   const manager = {
     ensureSession: async () => record,
-    async *runTurn() {
-      yield { type: "done" as const, stopReason: "end_turn" };
+    startTurn(input: { requestId: string }) {
+      return {
+        requestId: input.requestId,
+        events: emptyRuntimeEvents(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: async () => {},
+        closeStream: async () => {},
+      };
     },
     getStatus: async (handle: { acpxRecordId?: string; cwd?: string }) => ({
       summary: `status=${handle.acpxRecordId}`,
@@ -268,6 +340,7 @@ test("AcpxRuntime falls back to plain runtimeSessionName handles and reuses a si
     }),
     setMode: async () => {},
     setConfigOption: async () => {},
+    closeStream: async () => {},
     cancel: async () => {},
     close: async () => {},
   };
@@ -307,16 +380,19 @@ test("AcpxRuntime falls back to plain runtimeSessionName handles and reuses a si
   assert.equal(status.acpxRecordId, "session-from-handle");
   assert.equal(status.details?.cwd, "/workspace/plain");
 
-  const turnEvents = [];
-  for await (const event of runtime.runTurn({
+  const turn = runtime.startTurn({
     handle: plainHandle,
     text: "hello",
     mode: "prompt",
     requestId: "req-plain",
-  })) {
+  });
+  const turnEvents = [];
+  for await (const event of turn.events) {
     turnEvents.push(event);
   }
-  assert.deepEqual(turnEvents, [{ type: "done", stopReason: "end_turn" }]);
+  const result = await turn.result;
+  assert.deepEqual(turnEvents, []);
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
   assert.equal(managerFactoryCalls, 1);
 });
 


### PR DESCRIPTION
## Summary

This adds a runtime turn-handle API for embedders that need to observe live turn events separately from terminal turn completion.

- Adds `startTurn(...)` with live `events`, terminal `result`, per-turn `cancel(...)`, and `closeStream(...)`.
- Keeps `runTurn(...)` as a compatibility adapter over the new handle API.
- Stops treating raw prompt `done`/`error` lines as live events; terminal state is now provided by the turn result.
- Adds concise tool-call input summaries to runtime tool events so live observers can see what action is in progress.
- Adds focused runtime, manager, and event parser coverage.

## Validation

- `pnpm run build:test`
- `node --test dist-test/test/runtime.test.js dist-test/test/runtime-manager.test.js dist-test/test/runtime-events.test.js`
