### PR TITLE
Reuse runtime sessions for controls

### DIFF
--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { AcpClient } from "../../acp/client.js";
 import { normalizeOutputError } from "../../acp/error-normalization.js";
 import { extractAcpError, isAcpResourceNotFoundError } from "../../acp/error-shapes.js";
@@ -68,6 +69,18 @@ function createDeferred<T>(): Deferred<T> {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+function applyConfigOptionsToRecord(
+  record: SessionRecord,
+  configOptions: SetSessionConfigOptionResponse["configOptions"] | undefined,
+): void {
+  if (!configOptions) {
+    return;
+  }
+  const acpxState = cloneSessionAcpxState(record.acpx) ?? {};
+  acpxState.config_options = structuredClone(configOptions);
+  record.acpx = acpxState;
 }
 
 class AsyncEventQueue {
@@ -310,6 +323,46 @@ export class AcpRuntimeManager {
       await previousClient.close().catch(() => {});
     }
     return true;
+  }
+
+  private async withRuntimeControlSession<T>(
+    record: SessionRecord,
+    sessionMode: "persistent" | "oneshot",
+    run: (context: { client: AcpClient; sessionId: string; record: SessionRecord }) => Promise<T>,
+  ): Promise<{ value: T; record: SessionRecord }> {
+    const pendingClient = await this.readPendingPersistentClient(record, { consume: false });
+    if (pendingClient) {
+      const value = await run({
+        client: pendingClient,
+        sessionId: record.acpSessionId,
+        record,
+      });
+      record.lastUsedAt = isoNow();
+      record.closed = false;
+      record.closedAt = undefined;
+      record.protocolVersion = pendingClient.initializeResult?.protocolVersion;
+      record.agentCapabilities = pendingClient.initializeResult?.agentCapabilities;
+      applyLifecycleSnapshotToRecord(record, pendingClient.getAgentLifecycleSnapshot());
+      return { value, record };
+    }
+
+    const result = await withConnectedSession({
+      sessionRecordId: record.acpxRecordId,
+      loadRecord: async (sessionRecordId) => await this.requireRecord(sessionRecordId),
+      saveRecord: async (connectedRecord) => await this.options.sessionStore.save(connectedRecord),
+      createClient: (options) => this.createClient(options),
+      mcpServers: [...(this.options.mcpServers ?? [])],
+      permissionMode: this.options.permissionMode,
+      nonInteractivePermissions: this.options.nonInteractivePermissions,
+      verbose: this.options.verbose,
+      timeoutMs: this.options.timeoutMs,
+      resumePolicy: resumePolicyForSessionMode(sessionMode),
+      run,
+    });
+    return {
+      value: result.value,
+      record: result.record,
+    };
   }
   async ensureSession(input: {
     sessionKey: string;
@@ -711,6 +764,9 @@ export class AcpRuntimeManager {
         cwd: record.cwd,
         lastUsedAt: record.lastUsedAt,
         closed: record.closed === true,
+        ...(record.acpx?.config_options !== undefined
+          ? { configOptions: structuredClone(record.acpx.config_options) }
+          : {}),
       },
     };
   }
@@ -726,22 +782,13 @@ export class AcpRuntimeManager {
     if (controller) {
       await controller.setSessionMode(mode);
     } else {
-      const result = await withConnectedSession({
-        sessionRecordId: record.acpxRecordId,
-        loadRecord: async (sessionRecordId) => await this.requireRecord(sessionRecordId),
-        saveRecord: async (connectedRecord) =>
-          await this.options.sessionStore.save(connectedRecord),
-        createClient: (options) => this.createClient(options),
-        mcpServers: [...(this.options.mcpServers ?? [])],
-        permissionMode: this.options.permissionMode,
-        nonInteractivePermissions: this.options.nonInteractivePermissions,
-        verbose: this.options.verbose,
-        timeoutMs: this.options.timeoutMs,
-        resumePolicy: resumePolicyForSessionMode(sessionMode),
-        run: async ({ client, sessionId }) => {
+      const result = await this.withRuntimeControlSession(
+        record,
+        sessionMode,
+        async ({ client, sessionId }) => {
           await client.setSessionMode(sessionId, mode);
         },
-      });
+      );
       targetRecord = result.record;
     }
     setDesiredModeId(targetRecord, mode);
@@ -758,27 +805,20 @@ export class AcpRuntimeManager {
     const controller = this.activeControllers.get(record.acpxRecordId);
     let targetRecord = record;
     if (controller) {
-      await controller.setSessionConfigOption(key, value);
+      const response = await controller.setSessionConfigOption(key, value);
+      applyConfigOptionsToRecord(targetRecord, response?.configOptions);
     } else {
-      const result = await withConnectedSession({
-        sessionRecordId: record.acpxRecordId,
-        loadRecord: async (sessionRecordId) => await this.requireRecord(sessionRecordId),
-        saveRecord: async (connectedRecord) =>
-          await this.options.sessionStore.save(connectedRecord),
-        createClient: (options) => this.createClient(options),
-        mcpServers: [...(this.options.mcpServers ?? [])],
-        permissionMode: this.options.permissionMode,
-        nonInteractivePermissions: this.options.nonInteractivePermissions,
-        verbose: this.options.verbose,
-        timeoutMs: this.options.timeoutMs,
-        resumePolicy: resumePolicyForSessionMode(sessionMode),
-        run: async ({ client, sessionId, record: connectedRecord }) => {
-          await client.setSessionConfigOption(sessionId, key, value);
+      const result = await this.withRuntimeControlSession(
+        record,
+        sessionMode,
+        async ({ client, sessionId, record: connectedRecord }) => {
+          const response = await client.setSessionConfigOption(sessionId, key, value);
+          applyConfigOptionsToRecord(connectedRecord, response?.configOptions);
           if (key === "mode") {
             setDesiredModeId(connectedRecord, value);
           }
         },
-      });
+      );
       targetRecord = result.record;
     }
     if (key === "mode") {

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -577,7 +577,17 @@ export class AcpRuntimeManager {
             if (!runtimeClient.hasActivePrompt()) {
               await sessionReady.promise;
             }
-            return await runtimeClient.setSessionConfigOption(activeSessionId, configId, value);
+            const response = await runtimeClient.setSessionConfigOption(
+              activeSessionId,
+              configId,
+              value,
+            );
+            if (response?.configOptions) {
+              const nextState = cloneSessionAcpxState(acpxState) ?? {};
+              nextState.config_options = structuredClone(response.configOptions);
+              acpxState = nextState;
+            }
+            return response;
           },
         };
 

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -995,12 +995,22 @@ test("AcpRuntimeManager routes controls through the active controller while a tu
   await promptStarted;
   await manager.setMode(createHandle("live-session"), "plan");
   await manager.setConfigOption(createHandle("live-session"), "approval", "manual");
+  const liveStatus = await manager.getStatus(createHandle("live-session"));
   await turn.cancel();
   const events = await eventsPromise;
   const result = await turn.result;
 
   assert.equal(setModeCalls, 1);
   assert.equal(setConfigCalls, 1);
+  assert.deepEqual(liveStatus.details?.configOptions, [
+    {
+      id: "approval",
+      name: "Approval",
+      type: "select",
+      currentValue: "manual",
+      options: [{ value: "manual", name: "Manual" }],
+    },
+  ]);
   assert.equal(cancelRequested, 1);
   assert.deepEqual(events, []);
   assert.deepEqual(result, { status: "cancelled", stopReason: "cancelled" });
@@ -1788,4 +1798,119 @@ test("AcpRuntimeManager falls back when a kept-open persistent client is no long
   assert.equal(firstClientPromptCalls, 0);
   assert.equal(secondClientPromptCalls, 1);
   assert.equal(constructed, 2);
+});
+
+test("AcpRuntimeManager reuses a kept-open persistent client for controls before the first turn", async () => {
+  const store = new InMemorySessionStore();
+  let constructed = 0;
+  let createSessionCalls = 0;
+  let loadSessionCalls = 0;
+  let promptCalls = 0;
+  let closeCalls = 0;
+  const setModeSessions: string[] = [];
+  const setConfigCalls: Array<{ sessionId: string; key: string; value: string }> = [];
+
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => {
+        constructed += 1;
+        return {
+          start: async () => {},
+          close: async () => {
+            closeCalls += 1;
+          },
+          createSession: async () => {
+            createSessionCalls += 1;
+            return {
+              sessionId: "pending-session-id",
+              agentSessionId: "pending-agent-id",
+            };
+          },
+          loadSession: async () => {
+            loadSessionCalls += 1;
+            return { agentSessionId: "unexpected-agent-id" };
+          },
+          hasReusableSession: (sessionId: string) => sessionId === "pending-session-id",
+          supportsLoadSession: () => true,
+          loadSessionWithOptions: async () => {
+            loadSessionCalls += 1;
+            return { agentSessionId: "unexpected-agent-id" };
+          },
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async (sessionId: string) => {
+            promptCalls += 1;
+            assert.equal(sessionId, "pending-session-id");
+            return { stopReason: "end_turn" };
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async (sessionId: string, modeId: string) => {
+            assert.equal(modeId, "auto");
+            setModeSessions.push(sessionId);
+          },
+          setSessionConfigOption: async (sessionId: string, key: string, value: string) => {
+            setConfigCalls.push({ sessionId, key, value });
+            return {
+              configOptions: [
+                {
+                  id: key,
+                  name: "Approval",
+                  type: "select",
+                  currentValue: value,
+                  options: [{ value, name: "Manual" }],
+                },
+              ],
+            };
+          },
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        } as never;
+      },
+    },
+  );
+
+  const record = await manager.ensureSession({
+    sessionKey: "pending-control-session",
+    agent: "codex",
+    mode: "persistent",
+  });
+  const handle = createHandle("pending-control-session", record.acpxRecordId);
+
+  await manager.setMode(handle, "auto");
+  await manager.setConfigOption(handle, "approval", "manual");
+  const status = await manager.getStatus(handle);
+  const events = await collectEvents(
+    manager.runTurn({
+      handle,
+      text: "hello",
+      mode: "prompt",
+      sessionMode: "persistent",
+      requestId: "req-pending-control-session",
+    }),
+  );
+
+  assert.deepEqual(events, [{ type: "done", stopReason: "end_turn" }]);
+  assert.equal(constructed, 1);
+  assert.equal(createSessionCalls, 1);
+  assert.equal(loadSessionCalls, 0);
+  assert.equal(promptCalls, 1);
+  assert.deepEqual(setModeSessions, ["pending-session-id"]);
+  assert.deepEqual(setConfigCalls, [
+    {
+      sessionId: "pending-session-id",
+      key: "approval",
+      value: "manual",
+    },
+  ]);
+  assert.deepEqual(status.details?.configOptions, [
+    {
+      id: "approval",
+      name: "Approval",
+      type: "select",
+      currentValue: "manual",
+      options: [{ value: "manual", name: "Manual" }],
+    },
+  ]);
+  assert.equal(closeCalls, 1);
 });

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -995,14 +995,15 @@ test("AcpRuntimeManager routes controls through the active controller while a tu
   await promptStarted;
   await manager.setMode(createHandle("live-session"), "plan");
   await manager.setConfigOption(createHandle("live-session"), "approval", "manual");
-  const liveStatus = await manager.getStatus(createHandle("live-session"));
+  const liveStatusDuringTurn = await manager.getStatus(createHandle("live-session"));
   await turn.cancel();
   const events = await eventsPromise;
   const result = await turn.result;
+  const liveStatusAfterTurn = await manager.getStatus(createHandle("live-session"));
 
   assert.equal(setModeCalls, 1);
   assert.equal(setConfigCalls, 1);
-  assert.deepEqual(liveStatus.details?.configOptions, [
+  const expectedConfigOptions = [
     {
       id: "approval",
       name: "Approval",
@@ -1010,7 +1011,9 @@ test("AcpRuntimeManager routes controls through the active controller while a tu
       currentValue: "manual",
       options: [{ value: "manual", name: "Manual" }],
     },
-  ]);
+  ];
+  assert.deepEqual(liveStatusDuringTurn.details?.configOptions, expectedConfigOptions);
+  assert.deepEqual(liveStatusAfterTurn.details?.configOptions, expectedConfigOptions);
   assert.equal(cancelRequested, 1);
   assert.deepEqual(events, []);
   assert.deepEqual(result, { status: "cancelled", stopReason: "cancelled" });
@@ -1912,5 +1915,9 @@ test("AcpRuntimeManager reuses a kept-open persistent client for controls before
       options: [{ value: "manual", name: "Manual" }],
     },
   ]);
+  assert.equal(closeCalls, 0);
+
+  await manager.close(handle);
+
   assert.equal(closeCalls, 1);
 });


### PR DESCRIPTION
## Summary

This makes runtime controls reuse an already-open persistent client when one exists, and preserves returned config option state in runtime status.

- Reuses a kept-open persistent client for mode/config controls before the first prompt turn.
- Centralizes runtime control session acquisition for active, pending, and reconnect paths.
- Persists returned config option state into the session record.
- Exposes persisted config option state through runtime status details.
- Adds manager tests for active controls and pending persistent-client control reuse.

## Validation

- `pnpm run build:test`
- `node --test dist-test/test/runtime-manager.test.js`
