### PR TITLE
fix(runtime): retain persistent ACP client across turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Runtime/persistent sessions: keep reusable persistent ACP clients warm across turns and close pooled clients during runtime close. (#265) Thanks @Sway-Chan.
 - Runtime/ACP: drain late post-success session updates before closing prompt turns so adapters that resolve `session/prompt` before final updates do not drop assistant output. (#251) Thanks @logofet85-ai.
 - Sessions/reset: close the live backend session when discarding persistent state so reset flows start a fresh ACP session instead of silently reopening the old one.
 - Agents/kiro: use `kiro-cli-chat acp` for the built-in Kiro adapter command to avoid orphan child processes. (#129) Thanks @vokako.

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -542,7 +542,9 @@ export class AcpRuntimeManager {
             await previousClient.close().catch(() => {});
           }
         }
-        if (!pooled) {await client.close().catch(() => {});}
+        if (!pooled) {
+          await client.close().catch(() => {});
+        }
         queue.close();
       }
     })();

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -528,7 +528,21 @@ export class AcpRuntimeManager {
         applyConversation(record, conversation);
         record.lastUsedAt = isoNow();
         await this.options.sessionStore.save(record).catch(() => {});
-        await client.close().catch(() => {});
+        const isPersistentRecord = !record.acpxRecordId.includes(":oneshot:");
+        let pooled = false;
+        if (
+          isPersistentRecord &&
+          !record.closed &&
+          client.hasReusableSession(record.acpSessionId)
+        ) {
+          const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);
+          this.pendingPersistentClients.set(record.acpxRecordId, client);
+          pooled = true;
+          if (previousClient && previousClient !== client) {
+            await previousClient.close().catch(() => {});
+          }
+        }
+        if (!pooled) {await client.close().catch(() => {});}
         queue.close();
       }
     })();
@@ -640,6 +654,12 @@ export class AcpRuntimeManager {
         ...record.acpx,
         reset_on_next_ensure: true,
       };
+    } else {
+      const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
+      if (pendingClient) {
+        this.pendingPersistentClients.delete(record.acpxRecordId);
+        await pendingClient.close().catch(() => {});
+      }
     }
     record.closed = true;
     record.closedAt = isoNow();

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -312,6 +312,110 @@ test("AcpRuntimeManager streams runtime events and saves updated status", async 
   assert.equal(saved?.protocolVersion, 1);
 });
 
+test("AcpRuntimeManager keeps reusable persistent clients pooled across turns and closes them on runtime close", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "pooled-persistent-session",
+    acpSessionId: "pooled-sid",
+    agentCommand: "gemini --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let factoryCalls = 0;
+  let closeCalls = 0;
+  let promptCalls = 0;
+  let handlers: FakeClientHandlers = {};
+  const client: FakeClient = {
+    initializeResult: {
+      protocolVersion: 1,
+      agentCapabilities: { prompt: true },
+    },
+    start: async () => {},
+    close: async () => {
+      closeCalls += 1;
+    },
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: (sessionId) => sessionId === "pooled-sid",
+    supportsLoadSession: () => true,
+    loadSessionWithOptions: async () => ({ agentSessionId: "pooled-agent" }),
+    getAgentLifecycleSnapshot: () => ({
+      pid: 104_981,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      running: true,
+    }),
+    prompt: async (sessionId) => {
+      promptCalls += 1;
+      assert.equal(sessionId, "pooled-sid");
+      handlers.onSessionUpdate?.({
+        sessionId: "pooled-sid",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: `turn ${promptCalls}` },
+        },
+      });
+      return { stopReason: "end_turn" };
+    },
+    waitForSessionUpdatesIdle: async () => {},
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      handlers = {};
+    },
+    setEventHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => {
+        factoryCalls += 1;
+        return client as never;
+      },
+    },
+  );
+
+  const firstEvents = await collectEvents(
+    manager.runTurn({
+      handle: createHandle("pooled-persistent-session"),
+      text: "first",
+      mode: "prompt",
+      sessionMode: "persistent",
+      requestId: "req-pooled-1",
+    }),
+  );
+  const secondEvents = await collectEvents(
+    manager.runTurn({
+      handle: createHandle("pooled-persistent-session"),
+      text: "second",
+      mode: "prompt",
+      sessionMode: "persistent",
+      requestId: "req-pooled-2",
+    }),
+  );
+
+  assert.equal(factoryCalls, 1);
+  assert.equal(promptCalls, 2);
+  assert.equal(closeCalls, 0);
+  assert.deepEqual(firstEvents, [
+    { type: "text_delta", text: "turn 1", stream: "output", tag: "agent_message_chunk" },
+    { type: "done", stopReason: "end_turn" },
+  ]);
+  assert.deepEqual(secondEvents, [
+    { type: "text_delta", text: "turn 2", stream: "output", tag: "agent_message_chunk" },
+    { type: "done", stopReason: "end_turn" },
+  ]);
+
+  await manager.close(createHandle("pooled-persistent-session"));
+
+  assert.equal(closeCalls, 1);
+  const closed = await store.load("pooled-persistent-session");
+  assert.equal(closed?.closed, true);
+  assert.equal(typeof closed?.closedAt, "string");
+});
+
 test("AcpRuntimeManager accepts a session reply even when the prompt RPC times out", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "late-reply-session",


### PR DESCRIPTION
## Summary
Fixes #264.

Two edits to `src/runtime/engine/manager.ts`:

1. `runTurn` finally now returns the client to `pendingPersistentClients` when the record is persistent (recordId does not contain `":oneshot:"`) and the backend reports a reusable session, restoring lifecycle symmetry with `ensureSession`.
2. `close()` now cleans the pool on the non-`discardPersistentState` path, so `AcpxManager.evictIdleRuntimeHandles` (reason=`"idle-evicted"`) does not leak pooled CLI processes.

## Test plan
- [x] Manual functional verification via equivalent edits to the distributed `register.runtime-*.js`, then restarting the gateway: two turns against the same persistent `gemini-acp` label; `pid` and `agent_started_at` stable across turns; pooled process reaped on next unrelated spawn (see issue for details).
- [ ] CI / upstream test suite (for maintainer review).

## Related
- Linked issue describes the lifecycle asymmetry, reproduction, and validation data.
