### PR TITLE
fix(claude): bump built-in adapter range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Claude/built-in: bump the owned `@agentclientprotocol/claude-agent-acp` package range to `^0.31.0` so fresh built-in launches include the Opus 4.7 adapter update and later ACP compatibility fixes. (#253) Thanks @flowforgelab.
+
 ## 2026.4.25 (v0.6.0)
 
 ### Changes

--- a/agents/Claude.md
+++ b/agents/Claude.md
@@ -1,0 +1,6 @@
+# Claude
+
+- Built-in name: `claude`
+- Default command: `npx -y @agentclientprotocol/claude-agent-acp`
+- Upstream: https://github.com/agentclientprotocol/claude-agent-acp
+- ACPX pins the built-in package range so fresh installs pick up Claude model and ACP adapter fixes without depending on a global adapter binary.

--- a/agents/README.md
+++ b/agents/README.md
@@ -5,7 +5,7 @@ Built-in agents:
 - `pi -> npx pi-acp`
 - `openclaw -> openclaw acp`
 - `codex -> npx @zed-industries/codex-acp`
-- `claude -> npx -y @zed-industries/claude-agent-acp`
+- `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - `gemini -> gemini --acp`
 - `cursor -> cursor-agent acp`
 - `copilot -> copilot --acp --stdio`
@@ -22,6 +22,7 @@ Built-in agents:
 Harness-specific docs in this directory:
 
 - [Codex](Codex.md): built-in `codex -> npx @zed-industries/codex-acp`
+- [Claude](Claude.md): built-in `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - [Copilot](Copilot.md): built-in `copilot -> copilot --acp --stdio`
 - [Droid](Droid.md): built-in `droid -> droid exec --output-format acp` with `factory-droid` and `factorydroid` aliases
 - [Cursor](Cursor.md): built-in `cursor -> cursor-agent acp`

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -74,7 +74,7 @@ Friendly agent names resolve to commands:
 - `pi` -> `npx pi-acp`
 - `openclaw` -> `openclaw acp`
 - `codex` -> `npx @zed-industries/codex-acp`
-- `claude` -> `npx -y @agentclientprotocol/claude-agent-acp`
+- `claude` -> `npx -y @agentclientprotocol/claude-agent-acp` (ACPX-owned package range)
 - `gemini` -> `gemini --acp`
 - `cursor` -> `cursor-agent acp`
 - `copilot` -> `copilot --acp --stdio`

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.22",
   codex: "^0.11.1",
-  claude: "^0.25.0",
+  claude: "^0.31.0",
 } as const;
 
 type BuiltInAgentPackageSpec = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -78,6 +78,11 @@ test("default agent is codex", () => {
   assert.equal(DEFAULT_AGENT_NAME, "codex");
 });
 
+test("claude built-in uses the current ACP adapter package range", () => {
+  assert.equal(BUILT_IN_AGENT_PACKAGES.claude.packageRange, "^0.31.0");
+  assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.31.0");
+});
+
 test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when available", (t) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "acpx-agent-registry-"));
   t.after(() => {
@@ -96,7 +101,7 @@ test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when a
     path.join(packageRoot, "package.json"),
     JSON.stringify({
       name: BUILT_IN_AGENT_PACKAGES.claude.packageName,
-      version: "0.25.0",
+      version: "0.31.0",
       bin: {
         "claude-agent-acp": "bin/claude-agent-acp.js",
       },
@@ -115,7 +120,7 @@ test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when a
     args: [path.join(packageRoot, "bin", "claude-agent-acp.js")],
     packageName: BUILT_IN_AGENT_PACKAGES.claude.packageName,
     packageRange: BUILT_IN_AGENT_PACKAGES.claude.packageRange,
-    packageVersion: "0.25.0",
+    packageVersion: "0.31.0",
     binPath: path.join(packageRoot, "bin", "claude-agent-acp.js"),
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2095,7 +2095,7 @@ async function withTempHome(run: (homeDir: string) => Promise<void>): Promise<vo
   try {
     await run(tempHome);
   } finally {
-    await fs.rm(tempHome, { recursive: true, force: true });
+    await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
   }
 }
 


### PR DESCRIPTION
## Summary
- bump the ACPX-owned Claude ACP adapter package range to `^0.31.0`
- add Claude built-in docs and fix the stale docs package name
- lock the Claude built-in range in tests and retry temp-home cleanup for the reproduced macOS `ENOTEMPTY` race

## Verification
- `npm view @agentclientprotocol/claude-agent-acp version versions dist-tags time --json --silent`
- `git -C ../oss/claude-agent-acp fetch --tags origin main --prune && git -C ../oss/claude-agent-acp log --oneline --decorate --max-count=20`
- `npm view @agentclientprotocol/claude-agent-acp@0.31.0 dependencies peerDependencies bin --json --silent`
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 exec node --test dist-test/test/agent-registry.test.js`
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 exec node --test --test-name-pattern 'prompt reconciles agentSessionId from loadSession metadata' dist-test/test/cli.test.js`
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run check`

Supersedes #253 with the same user-visible fix updated to the current upstream adapter release.
