### PR TITLE
fix(prompt): honor model option on persistent prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- CLI/prompt: honor `--model` when sending prompts to existing persistent sessions, including queued owner paths. (#211) Thanks @skywills.
 - Claude/built-in: bump the owned `@agentclientprotocol/claude-agent-acp` package range to `^0.31.0` so fresh built-in launches include the Opus 4.7 adapter update and later ACP compatibility fixes. (#253) Thanks @flowforgelab.
 
 ## 2026.4.25 (v0.6.0)

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -233,6 +233,12 @@ export async function handlePrompt(
     promptRetries: globalFlags.promptRetries,
     verbose: globalFlags.verbose,
     waitForCompletion: flags.wait !== false,
+    sessionOptions: {
+      model: globalFlags.model,
+      allowedTools: globalFlags.allowedTools,
+      maxTurns: globalFlags.maxTurns,
+      systemPrompt: globalFlags.systemPrompt,
+    },
   });
 
   if ("queued" in result) {

--- a/src/cli/queue/ipc-server.ts
+++ b/src/cli/queue/ipc-server.ts
@@ -4,6 +4,7 @@ import { normalizeOutputError } from "../../acp/error-normalization.js";
 import { recordPerfDuration } from "../../perf-metrics.js";
 import { textPrompt } from "../../prompt-content.js";
 import type {
+  AcpClientOptions,
   NonInteractivePermissionPolicy,
   PermissionMode,
   PromptInput,
@@ -83,6 +84,7 @@ export type QueueTask = {
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   timeoutMs?: number;
   suppressSdkConsoleErrors?: boolean;
+  sessionOptions?: NonNullable<AcpClientOptions["sessionOptions"]>;
   waitForCompletion: boolean;
   enqueuedAt: number;
   send: (message: QueueOwnerMessage) => void;
@@ -451,6 +453,7 @@ export class SessionQueueOwner {
         nonInteractivePermissions: request.nonInteractivePermissions,
         timeoutMs: request.timeoutMs,
         suppressSdkConsoleErrors: request.suppressSdkConsoleErrors,
+        sessionOptions: request.sessionOptions,
         waitForCompletion: request.waitForCompletion,
         enqueuedAt: Date.now(),
         send: (message) => {

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -3,6 +3,7 @@ import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { QueueConnectionError, QueueProtocolError } from "../../errors.js";
 import { incrementPerfCounter } from "../../perf-metrics.js";
 import type {
+  AcpClientOptions,
   NonInteractivePermissionPolicy,
   OutputErrorEmissionPolicy,
   OutputFormatter,
@@ -269,6 +270,7 @@ export type SubmitToQueueOwnerOptions = {
   suppressSdkConsoleErrors?: boolean;
   waitForCompletion: boolean;
   verbose?: boolean;
+  sessionOptions?: NonNullable<AcpClientOptions["sessionOptions"]>;
 };
 
 async function submitToQueueOwner(
@@ -288,6 +290,7 @@ async function submitToQueueOwner(
     timeoutMs: options.timeoutMs,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     waitForCompletion: options.waitForCompletion,
+    sessionOptions: options.sessionOptions,
   };
 
   options.outputFormatter.setContext({

--- a/src/cli/queue/messages.ts
+++ b/src/cli/queue/messages.ts
@@ -4,6 +4,7 @@ import { isPromptInput, textPrompt } from "../../prompt-content.js";
 import {
   OUTPUT_ERROR_CODES,
   OUTPUT_ERROR_ORIGINS,
+  type AcpClientOptions,
   type OutputErrorAcpPayload,
   type OutputErrorCode,
   type OutputErrorOrigin,
@@ -17,6 +18,8 @@ import type {
   SessionSendResult,
 } from "../../types.js";
 
+type QueueSessionOptions = NonNullable<AcpClientOptions["sessionOptions"]>;
+
 export type QueueSubmitRequest = {
   type: "submit_prompt";
   requestId: string;
@@ -29,6 +32,7 @@ export type QueueSubmitRequest = {
   timeoutMs?: number;
   suppressSdkConsoleErrors?: boolean;
   waitForCompletion: boolean;
+  sessionOptions?: QueueSessionOptions;
 };
 
 export type QueueCancelRequest = {
@@ -186,6 +190,55 @@ function parseAcpError(value: unknown): OutputErrorAcpPayload | undefined {
   };
 }
 
+function parseSessionOptions(value: unknown): QueueSessionOptions | null | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const sessionOptions: QueueSessionOptions = {};
+  if (record.model != null) {
+    if (typeof record.model !== "string" || record.model.trim().length === 0) {
+      return null;
+    }
+    sessionOptions.model = record.model;
+  }
+  if (record.allowedTools != null) {
+    if (!Array.isArray(record.allowedTools)) {
+      return null;
+    }
+    const allowedTools = record.allowedTools.filter(
+      (tool): tool is string => typeof tool === "string",
+    );
+    if (allowedTools.length !== record.allowedTools.length) {
+      return null;
+    }
+    sessionOptions.allowedTools = allowedTools;
+  }
+  if (record.maxTurns != null) {
+    if (typeof record.maxTurns !== "number" || !Number.isFinite(record.maxTurns)) {
+      return null;
+    }
+    sessionOptions.maxTurns = Math.max(1, Math.round(record.maxTurns));
+  }
+  if (record.systemPrompt != null) {
+    if (typeof record.systemPrompt === "string") {
+      sessionOptions.systemPrompt = record.systemPrompt;
+    } else {
+      const systemPrompt = asRecord(record.systemPrompt);
+      if (!systemPrompt || typeof systemPrompt.append !== "string") {
+        return null;
+      }
+      sessionOptions.systemPrompt = { append: systemPrompt.append };
+    }
+  }
+
+  return sessionOptions;
+}
+
 function parseOwnerGeneration(value: unknown): number | undefined | null {
   if (value == null) {
     return undefined;
@@ -235,6 +288,7 @@ export function parseQueueRequest(raw: unknown): QueueRequest | null {
         : typeof request.suppressSdkConsoleErrors === "boolean"
           ? request.suppressSdkConsoleErrors
           : null;
+    const sessionOptions = parseSessionOptions(request.sessionOptions);
 
     const prompt =
       request.prompt == null ? undefined : isPromptInput(request.prompt) ? request.prompt : null;
@@ -245,6 +299,7 @@ export function parseQueueRequest(raw: unknown): QueueRequest | null {
       prompt === null ||
       nonInteractivePermissions === null ||
       suppressSdkConsoleErrors === null ||
+      sessionOptions === null ||
       typeof request.waitForCompletion !== "boolean"
     ) {
       return null;
@@ -262,6 +317,7 @@ export function parseQueueRequest(raw: unknown): QueueRequest | null {
       timeoutMs,
       ...(suppressSdkConsoleErrors !== undefined ? { suppressSdkConsoleErrors } : {}),
       waitForCompletion: request.waitForCompletion,
+      ...(sessionOptions !== undefined ? { sessionOptions } : {}),
     };
   }
 

--- a/src/cli/queue/owner-env.ts
+++ b/src/cli/queue/owner-env.ts
@@ -79,6 +79,30 @@ export function parseQueueOwnerPayload(raw: string): QueueOwnerRuntimeOptions {
     options.promptRetries = Math.max(0, Math.round(record.promptRetries));
   }
 
+  const sessionOpts = asRecord(record.sessionOptions);
+  if (sessionOpts) {
+    options.sessionOptions = {};
+    if (typeof sessionOpts.model === "string" && sessionOpts.model.trim().length > 0) {
+      options.sessionOptions.model = sessionOpts.model;
+    }
+    if (Array.isArray(sessionOpts.allowedTools)) {
+      options.sessionOptions.allowedTools = sessionOpts.allowedTools.filter(
+        (tool): tool is string => typeof tool === "string",
+      );
+    }
+    if (typeof sessionOpts.maxTurns === "number" && Number.isFinite(sessionOpts.maxTurns)) {
+      options.sessionOptions.maxTurns = Math.max(1, Math.round(sessionOpts.maxTurns));
+    }
+    if (typeof sessionOpts.systemPrompt === "string") {
+      options.sessionOptions.systemPrompt = sessionOpts.systemPrompt;
+    } else {
+      const systemPrompt = asRecord(sessionOpts.systemPrompt);
+      if (typeof systemPrompt?.append === "string") {
+        options.sessionOptions.systemPrompt = { append: systemPrompt.append };
+      }
+    }
+  }
+
   return options;
 }
 

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -89,6 +89,7 @@ export type SessionSendOptions = {
   maxQueueDepth?: number;
   client?: AcpClient;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
 } & TimedRunOptions;
 
 export type SessionEnsureOptions = {

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
+import type { SessionAgentOptions } from "../../runtime/engine/session-options.js";
 import type {
   AuthPolicy,
   McpServer,
@@ -19,6 +20,7 @@ export type QueueOwnerRuntimeOptions = {
   ttlMs?: number;
   maxQueueDepth?: number;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
 };
 
 type SessionSendLike = {
@@ -33,6 +35,7 @@ type SessionSendLike = {
   ttlMs?: number;
   maxQueueDepth?: number;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
 };
 
 export function sanitizeQueueOwnerExecArgv(
@@ -131,6 +134,7 @@ export function queueOwnerRuntimeOptionsFromSend(
     ttlMs: options.ttlMs,
     maxQueueDepth: options.maxQueueDepth,
     promptRetries: options.promptRetries,
+    sessionOptions: options.sessionOptions,
   };
 }
 

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -5,7 +5,10 @@ import { checkpointPerfMetricsCapture } from "../../perf-metrics-capture.js";
 import { setPerfGauge } from "../../perf-metrics.js";
 import { promptToDisplayText } from "../../prompt-content.js";
 import { applyLifecycleSnapshotToRecord } from "../../runtime/engine/lifecycle.js";
-import { sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
+import {
+  mergeSessionOptions,
+  sessionOptionsFromRecord,
+} from "../../runtime/engine/session-options.js";
 import {
   absolutePath,
   resolveSessionRecord,
@@ -56,6 +59,7 @@ async function submitToRunningOwner(
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     waitForCompletion,
     verbose: options.verbose,
+    sessionOptions: options.sessionOptions,
   });
 }
 
@@ -78,7 +82,10 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     authPolicy: options.authPolicy,
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
-    sessionOptions: sessionOptionsFromRecord(sessionRecord),
+    sessionOptions: mergeSessionOptions(
+      options.sessionOptions,
+      sessionOptionsFromRecord(sessionRecord),
+    ),
   });
   const ttlMs = normalizeQueueOwnerTtlMs(options.ttlMs);
   const maxQueueDepth = Math.max(1, Math.round(options.maxQueueDepth ?? 16));
@@ -226,6 +233,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
             authPolicy: options.authPolicy,
             suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
             promptRetries: options.promptRetries,
+            sessionOptions: options.sessionOptions,
             onClientAvailable: setActiveController,
             onClientClosed: clearActiveController,
             onPromptActive: async () => {

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -14,7 +14,11 @@ import {
 } from "../../runtime/engine/lifecycle.js";
 import { runPromptTurn } from "../../runtime/engine/prompt-turn.js";
 import { connectAndLoadSession } from "../../runtime/engine/reconnect.js";
-import { sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
+import {
+  mergeSessionOptions,
+  sessionOptionsFromRecord,
+  type SessionAgentOptions,
+} from "../../runtime/engine/session-options.js";
 import {
   cloneSessionAcpxState,
   cloneSessionConversation,
@@ -24,6 +28,7 @@ import {
   trimConversationForRuntime,
 } from "../../session/conversation-model.js";
 import { SessionEventWriter } from "../../session/events.js";
+import { setCurrentModelId, setDesiredModelId } from "../../session/mode-preference.js";
 import { absolutePath, isoNow, resolveSessionRecord } from "../../session/persistence.js";
 import type {
   AcpJsonRpcMessage,
@@ -40,6 +45,7 @@ import type {
   PromptInput,
   RunPromptResult,
   SessionNotification,
+  SessionRecord,
   SessionResumePolicy,
   SessionSendResult,
 } from "../../types.js";
@@ -66,6 +72,7 @@ type RunSessionPromptOptions = {
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   promptRetries?: number;
+  sessionOptions?: SessionAgentOptions;
   onClientAvailable?: (controller: ActiveSessionController) => void;
   onClientClosed?: () => void;
   onPromptActive?: () => Promise<void> | void;
@@ -157,6 +164,31 @@ async function applyRequestedModelIfAdvertised(params: {
     params.timeoutMs,
   );
   return true;
+}
+
+async function applyPromptModelIfAdvertised(params: {
+  client: AcpClient;
+  sessionId: string;
+  requestedModel: string | undefined;
+  record: SessionRecord;
+  timeoutMs?: number;
+}): Promise<void> {
+  const requestedModel =
+    typeof params.requestedModel === "string" ? params.requestedModel.trim() : "";
+  if (!requestedModel || !Array.isArray(params.record.acpx?.available_models)) {
+    return;
+  }
+  if (params.record.acpx.current_model_id === requestedModel) {
+    setDesiredModelId(params.record, requestedModel);
+    return;
+  }
+
+  await withTimeout(
+    params.client.setSessionModel(params.sessionId, requestedModel),
+    params.timeoutMs,
+  );
+  setDesiredModelId(params.record, requestedModel);
+  setCurrentModelId(params.record, requestedModel);
 }
 
 function jsonRpcIdKey(value: unknown): string | undefined {
@@ -274,6 +306,7 @@ export async function runQueuedTask(
     authPolicy?: AuthPolicy;
     suppressSdkConsoleErrors?: boolean;
     promptRetries?: number;
+    sessionOptions?: SessionAgentOptions;
     onClientAvailable?: (controller: ActiveSessionController) => void;
     onClientClosed?: () => void;
     onPromptActive?: () => Promise<void> | void;
@@ -299,6 +332,7 @@ export async function runQueuedTask(
       suppressSdkConsoleErrors: task.suppressSdkConsoleErrors ?? options.suppressSdkConsoleErrors,
       verbose: options.verbose,
       promptRetries: options.promptRetries,
+      sessionOptions: mergeSessionOptions(task.sessionOptions, options.sessionOptions),
       onClientAvailable: options.onClientAvailable,
       onClientClosed: options.onClientClosed,
       onPromptActive: options.onPromptActive,
@@ -360,6 +394,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
   });
   const pendingMessages: AcpJsonRpcMessage[] = [];
   const pendingConnectOutputMessages: AcpJsonRpcMessage[] = [];
+  const sessionOptions = mergeSessionOptions(
+    options.sessionOptions,
+    sessionOptionsFromRecord(record),
+  );
   let bufferingConnectOutput = true;
   let promptTurnActive = false;
   let promptTurnHadSideEffects = false;
@@ -398,7 +436,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       authPolicy: options.authPolicy,
       suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
       verbose: options.verbose,
-      sessionOptions: sessionOptionsFromRecord(record),
+      sessionOptions,
     });
   client.updateRuntimeOptions({
     permissionMode: options.permissionMode,
@@ -503,6 +541,14 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
             `[acpx] ${formatPerfMetric("prompt.connect_and_load", Date.now() - connectStartedAt)}\n`,
           );
         }
+
+        await applyPromptModelIfAdvertised({
+          client,
+          sessionId: activeSessionId,
+          requestedModel: sessionOptions?.model,
+          record,
+          timeoutMs: options.timeoutMs,
+        });
 
         output.setContext({
           sessionId: record.acpxRecordId,

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -9,6 +9,28 @@ export type SessionAgentOptions = {
   systemPrompt?: SystemPromptOption;
 };
 
+export function mergeSessionOptions(
+  preferred: SessionAgentOptions | undefined,
+  fallback: SessionAgentOptions | undefined,
+): SessionAgentOptions | undefined {
+  const merged: SessionAgentOptions = { ...fallback };
+
+  if (preferred?.model !== undefined) {
+    merged.model = preferred.model;
+  }
+  if (preferred?.allowedTools !== undefined) {
+    merged.allowedTools = preferred.allowedTools;
+  }
+  if (preferred?.maxTurns !== undefined) {
+    merged.maxTurns = preferred.maxTurns;
+  }
+  if (preferred?.systemPrompt !== undefined) {
+    merged.systemPrompt = preferred.systemPrompt;
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 export function sessionOptionsFromRecord(record: SessionRecord): SessionAgentOptions | undefined {
   const stored = record.acpx?.session_options;
   if (!stored) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -978,6 +978,48 @@ test("integration: exec --model skips session/set_model when agent does not adve
   });
 });
 
+test("integration: prompt --model updates existing session model before prompt", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const modelAgentCommand = `${LOAD_CAPABLE_MOCK_AGENT_COMMAND} --advertise-models`;
+
+    try {
+      const created = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      const result = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "--model",
+          "fast-model",
+          "prompt",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const setModelRequest = payloads.find((payload) => payload.method === "session/set_model") as
+        | { params?: { modelId?: string } }
+        | undefined;
+      assert(setModelRequest, "expected session/set_model before the persistent prompt");
+      assert.equal(setModelRequest.params?.modelId, "fast-model");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec --model fails when session/set_model fails", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/queue-messages.test.ts
+++ b/test/queue-messages.test.ts
@@ -40,6 +40,69 @@ test("parseQueueRequest rejects invalid nonInteractivePermissions value", () => 
   assert.equal(parsed, null);
 });
 
+test("parseQueueRequest accepts prompt session options", () => {
+  const parsed = parseQueueRequest({
+    type: "submit_prompt",
+    requestId: "req-session-options",
+    message: "hello",
+    permissionMode: "approve-reads",
+    sessionOptions: {
+      model: "fast-model",
+      allowedTools: ["Read", "Grep"],
+      maxTurns: 4,
+      systemPrompt: { append: "keep it brief" },
+    },
+    waitForCompletion: true,
+  });
+
+  assert.deepEqual(parsed, {
+    type: "submit_prompt",
+    requestId: "req-session-options",
+    ownerGeneration: undefined,
+    message: "hello",
+    prompt: [{ type: "text", text: "hello" }],
+    permissionMode: "approve-reads",
+    nonInteractivePermissions: undefined,
+    timeoutMs: undefined,
+    waitForCompletion: true,
+    sessionOptions: {
+      model: "fast-model",
+      allowedTools: ["Read", "Grep"],
+      maxTurns: 4,
+      systemPrompt: { append: "keep it brief" },
+    },
+  });
+});
+
+test("parseQueueRequest rejects invalid prompt session options", () => {
+  assert.equal(
+    parseQueueRequest({
+      type: "submit_prompt",
+      requestId: "req-session-options-invalid-model",
+      message: "hello",
+      permissionMode: "approve-reads",
+      sessionOptions: {
+        model: "   ",
+      },
+      waitForCompletion: true,
+    }),
+    null,
+  );
+  assert.equal(
+    parseQueueRequest({
+      type: "submit_prompt",
+      requestId: "req-session-options-invalid-tools",
+      message: "hello",
+      permissionMode: "approve-reads",
+      sessionOptions: {
+        allowedTools: ["Read", 123],
+      },
+      waitForCompletion: true,
+    }),
+    null,
+  );
+});
+
 test("parseQueueOwnerMessage accepts typed queue error payload", () => {
   const parsed = parseQueueOwnerMessage({
     type: "error",

--- a/test/queue-owner-env.test.ts
+++ b/test/queue-owner-env.test.ts
@@ -23,6 +23,12 @@ describe("parseQueueOwnerPayload", () => {
         ],
         ttlMs: 1234,
         maxQueueDepth: 7,
+        sessionOptions: {
+          model: "fast-model",
+          allowedTools: ["Read"],
+          maxTurns: 3,
+          systemPrompt: "stay concise",
+        },
       }),
     );
     assert.equal(parsed.sessionId, "session-1");
@@ -46,6 +52,12 @@ describe("parseQueueOwnerPayload", () => {
       },
     ]);
     assert.equal(parsed.maxQueueDepth, 7);
+    assert.deepEqual(parsed.sessionOptions, {
+      model: "fast-model",
+      allowedTools: ["Read"],
+      maxTurns: 3,
+      systemPrompt: "stay concise",
+    });
   });
 
   it("rejects invalid payloads", () => {


### PR DESCRIPTION
## Summary
- fixes persistent `prompt --model` so the requested model is applied before the next prompt turn
- carries prompt session options through queue-owner request/task boundaries so warm owners receive the requested model
- adds regression coverage for the persistent prompt path plus queue payload parsing

## Review notes
This is a narrower replacement for #211. Latest `@agentclientprotocol/claude-agent-acp` already resolves model aliases in `session/set_model`, and OpenCode's ACP server also resolves model selections through its ACP model handlers, so ACPX does not need to special-case `session/set_config_option` for prompt model switches here.

## Validation
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run check`
