### PR TITLE
fix(runtime): stringify doctor details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Runtime/doctor: guarantee `doctor().details` contains strings even when probe failures include Error or object values. (#267)
 - CLI/prompt: honor `--model` when sending prompts to existing persistent sessions, including queued owner paths. (#211) Thanks @skywills.
 - Claude/built-in: bump the owned `@agentclientprotocol/claude-agent-acp` package range to `^0.31.0` so fresh built-in launches include the Opus 4.7 adapter update and later ACP compatibility fixes. (#253) Thanks @flowforgelab.
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -16,7 +16,7 @@ import type {
 import { AcpRuntimeError } from "./runtime/public/errors.js";
 import { createFileSessionStore } from "./runtime/public/file-session-store.js";
 import { decodeAcpxRuntimeHandleState, writeHandleState } from "./runtime/public/handle-state.js";
-import { probeRuntime } from "./runtime/public/probe.js";
+import { normalizeRuntimeDetails, probeRuntime } from "./runtime/public/probe.js";
 import { deriveAgentFromSessionKey, type AcpxHandleState } from "./runtime/public/shared.js";
 
 export { DEFAULT_AGENT_NAME, createFileSessionStore };
@@ -86,7 +86,7 @@ export class AcpxRuntime implements AcpxRuntimeLike {
       probeRunner?: (options: AcpRuntimeOptions) => Promise<{
         ok: boolean;
         message: string;
-        details?: string[];
+        details?: unknown[];
       }>;
     },
   ) {}
@@ -107,7 +107,7 @@ export class AcpxRuntime implements AcpxRuntimeLike {
       ok: report.ok,
       code: report.ok ? undefined : "ACP_BACKEND_UNAVAILABLE",
       message: report.message,
-      details: report.details,
+      details: normalizeRuntimeDetails(report.details),
     };
   }
 

--- a/src/runtime/public/probe.ts
+++ b/src/runtime/public/probe.ts
@@ -12,6 +12,52 @@ export type ProbeRuntimeDeps = {
   clientFactory?: (options: ConstructorParameters<typeof AcpClient>[0]) => AcpClient;
 };
 
+export function formatRuntimeDetail(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message || value.name;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    value == null ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return String(value);
+  }
+  if (typeof value === "function") {
+    return value.name ? `[Function ${value.name}]` : "[Function]";
+  }
+
+  const seen = new WeakSet<object>();
+  try {
+    const serialized = JSON.stringify(value, (_key, nested) => {
+      if (nested instanceof Error) {
+        return nested.message || nested.name;
+      }
+      if (nested && typeof nested === "object") {
+        if (seen.has(nested)) {
+          return "[Circular]";
+        }
+        seen.add(nested);
+      }
+      return nested;
+    });
+    return serialized ?? "undefined";
+  } catch {
+    return "unserializable object";
+  }
+}
+
+export function normalizeRuntimeDetails(
+  details: readonly unknown[] | undefined,
+): string[] | undefined {
+  return details?.map((detail) => formatRuntimeDetail(detail));
+}
+
 export async function probeRuntime(
   options: AcpRuntimeOptions,
   deps: ProbeRuntimeDeps = {},
@@ -58,7 +104,7 @@ export async function probeRuntime(
         `agent=${agentName}`,
         `command=${agentCommand}`,
         `cwd=${options.cwd}`,
-        error instanceof Error ? error.message : String(error),
+        formatRuntimeDetail(error),
       ],
     };
   } finally {

--- a/test/runtime-probe.test.ts
+++ b/test/runtime-probe.test.ts
@@ -70,3 +70,24 @@ test("probeRuntime reports failures and still closes the client", async () => {
   ]);
   assert.equal(closed, true);
 });
+
+test("probeRuntime stringifies non-Error thrown values in details", async () => {
+  const report = await probeRuntime(
+    createRuntimeOptions({
+      cwd: "/workspace",
+      sessionStore: new InMemorySessionStore(),
+    }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {
+            throw { code: "SPAWN_FAILED", reason: "missing binary" };
+          },
+          close: async () => {},
+        }) as never,
+    },
+  );
+
+  assert.equal(report.ok, false);
+  assert.equal(report.details?.[3], '{"code":"SPAWN_FAILED","reason":"missing binary"}');
+});

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -265,6 +265,35 @@ test("doctor reports backend unavailable probe failures and agent registry honor
   assert.deepEqual(report.details, ["agent=codex", "command=codex-override --acp"]);
 });
 
+test("doctor coerces probe detail values to strings", async () => {
+  const circular: Record<string, unknown> = { code: "BROKEN" };
+  circular.self = circular;
+  const runtime = new AcpxRuntime(
+    {
+      cwd: "/workspace",
+      sessionStore: createFileSessionStore({ stateDir: "/tmp/acpx-runtime-doctor-details" }),
+      agentRegistry: createAgentRegistry(),
+      permissionMode: "approve-reads",
+    },
+    {
+      probeRunner: async () => ({
+        ok: false,
+        message: "embedded ACP runtime probe failed",
+        details: ["agent=codex", new Error("spawn failed"), circular],
+      }),
+    },
+  );
+
+  const report = await runtime.doctor();
+  assert.equal(report.ok, false);
+  assert.equal(
+    report.details?.every((detail) => typeof detail === "string"),
+    true,
+  );
+  assert.match(report.details?.[1] ?? "", /spawn failed/);
+  assert.equal(report.details?.[2], '{"code":"BROKEN","self":"[Circular]"}');
+});
+
 test("AcpxRuntime validates required ensureSession inputs and runtime handles", async () => {
   const runtime = createAcpRuntime({
     cwd: "/workspace",


### PR DESCRIPTION
## Summary
- normalize runtime probe/doctor detail values to strings before returning `AcpRuntimeDoctorReport`
- stringify plain objects and circular values safely instead of leaking `[object Object]`
- add regression coverage for doctor probe details and non-Error thrown probe failures

Fixes #267.

## Validation
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run check`