### PR TITLE
chore(agents): bump built-in adapter ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Agents/built-ins: bump the default `@zed-industries/codex-acp` package range to `^0.12.0` and `pi-acp` to `^0.0.26` so fresh built-in launches pick up the latest adapter releases.
 - CLI/claude: add `--system-prompt <text>` and `--append-system-prompt <text>` global flags that forward through ACP `_meta.systemPrompt` on `session/new`, letting callers replace or append to the Claude Code system prompt without dropping out of persistent acpx sessions. The value is persisted in `session_options.system_prompt` so ensure/reuse flows keep the override. Codex and other agents ignore the field. (#229) Thanks @Vercantez.
 - CLI/sessions: add `sessions prune` with `--dry-run`, age filters, and `--include-history` so closed session records and optional event streams can be cleaned up explicitly. (#227) Thanks @coder999999999.
 - CLI/ACP: add `--no-terminal` to disable advertised ACP terminal capability for new agent clients. (#155) Thanks @DMQ.

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ACP_ADAPTER_PACKAGE_RANGES = {
-  pi: "^0.0.22",
-  codex: "^0.11.1",
+  pi: "^0.0.26",
+  codex: "^0.12.0",
   claude: "^0.31.0",
 } as const;
 

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -83,6 +83,12 @@ test("claude built-in uses the current ACP adapter package range", () => {
   assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.31.0");
 });
 
+test("npm-backed built-ins use current adapter package ranges", () => {
+  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^0.12.0");
+  assert.equal(AGENT_REGISTRY.codex, "npx @zed-industries/codex-acp@^0.12.0");
+  assert.equal(AGENT_REGISTRY.pi, "npx pi-acp@^0.0.26");
+});
+
 test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when available", (t) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "acpx-agent-registry-"));
   t.after(() => {


### PR DESCRIPTION
Bumps built-in npm adapter ranges missed by the package dependency update:

- `@zed-industries/codex-acp` from `^0.11.1` to `^0.12.0` (latest published 2026-04-24)
- `pi-acp` from `^0.0.22` to `^0.0.26`

`@agentclientprotocol/claude-agent-acp` and `@agentclientprotocol/sdk` were already current at `0.31.0` / `0.20.0`.

Local proof:
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run build:test`
- `fnm exec --using=24.15.0 node --test dist-test/test/agent-registry.test.js`
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run check` (573 tests)