### PR TITLE
fix: translate WSL cwd for Windows agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/quiet output: emit final token usage and cost metadata to stderr when adapters include it in the ACP prompt result, while keeping quiet stdout as assistant text only. (#257)
 - Runtime/doctor: guarantee `doctor().details` contains strings even when probe failures include Error or object values. (#267)
+- Runtime/WSL: translate session cwd with `wslpath` when running under WSL and spawning Windows `.exe` ACP agents, so `session/new` and `session/load` receive paths the agent can access. (#232)
 - CLI/prompt: honor `--model` when sending prompts to existing persistent sessions, including queued owner paths. (#211) Thanks @skywills.
 - Claude/built-in: bump the owned `@agentclientprotocol/claude-agent-acp` package range to `^0.31.0` so fresh built-in launches include the Opus 4.7 adapter update and later ACP compatibility fixes. (#253) Thanks @flowforgelab.
 

--- a/src/acp/client-process.ts
+++ b/src/acp/client-process.ts
@@ -1,10 +1,20 @@
-import type { ChildProcess, ChildProcessByStdio } from "node:child_process";
+import { execFile, type ChildProcess, type ChildProcessByStdio } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 export type CommandParts = {
   command: string;
   args: string[];
+};
+
+type ResolveSessionCwdOptions = {
+  platform?: NodeJS.Platform;
+  existsSync?: (filePath: string) => boolean;
+  runWslpath?: (cwd: string) => Promise<string>;
 };
 
 export function isoNow(): string {
@@ -144,6 +154,61 @@ export function splitCommandLine(value: string): CommandParts {
 
 export function asAbsoluteCwd(cwd: string): string {
   return path.resolve(cwd);
+}
+
+export async function resolveAgentSessionCwd(
+  cwd: string,
+  agentCommand: string,
+  options: ResolveSessionCwdOptions = {},
+): Promise<string> {
+  const resolved = asAbsoluteCwd(cwd);
+  if (!shouldTranslateWslWindowsCwd(agentCommand, options)) {
+    return resolved;
+  }
+
+  const translated = (await (options.runWslpath ?? runWslpath)(resolved)).trim();
+  if (!translated) {
+    throw new Error(`wslpath returned an empty Windows path for cwd: ${resolved}`);
+  }
+  return translated;
+}
+
+function shouldTranslateWslWindowsCwd(
+  agentCommand: string,
+  options: ResolveSessionCwdOptions,
+): boolean {
+  if (!isWsl(options)) {
+    return false;
+  }
+
+  try {
+    const { command } = splitCommandLine(agentCommand);
+    return isWindowsExecutableCommand(command);
+  } catch {
+    return false;
+  }
+}
+
+function isWsl(options: ResolveSessionCwdOptions): boolean {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") {
+    return false;
+  }
+
+  const existsSync = options.existsSync ?? fs.existsSync;
+  return existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");
+}
+
+function isWindowsExecutableCommand(command: string): boolean {
+  const normalized = command.replace(/\\/g, "/").toLowerCase();
+  return normalized.endsWith(".exe") || normalized.startsWith("/mnt/c/");
+}
+
+async function runWslpath(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("wslpath", ["-w", cwd], {
+    encoding: "utf8",
+  });
+  return stdout;
 }
 
 export function basenameToken(value: string): string {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -78,6 +78,7 @@ import {
   isoNow,
   isChildProcessRunning,
   requireAgentStdio,
+  resolveAgentSessionCwd,
   splitCommandLine,
   waitForChildExit,
   waitForSpawn,
@@ -630,12 +631,13 @@ export class AcpClient {
     const connection = this.getConnection();
     const { command, args } = splitCommandLine(this.options.agentCommand);
     const claudeAcp = isClaudeAcpCommand(command, args);
+    const sessionCwd = await resolveAgentSessionCwd(cwd, this.options.agentCommand);
 
     let result: Awaited<ReturnType<typeof connection.newSession>>;
     try {
       const createPromise = this.runConnectionRequest(() =>
         connection.newSession({
-          cwd: asAbsoluteCwd(cwd),
+          cwd: sessionCwd,
           mcpServers: this.options.mcpServers ?? [],
           _meta: buildClaudeCodeOptionsMeta(this.options.sessionOptions),
         }),
@@ -673,6 +675,7 @@ export class AcpClient {
     options: LoadSessionOptions = {},
   ): Promise<SessionLoadResult> {
     const connection = this.getConnection();
+    const sessionCwd = await resolveAgentSessionCwd(cwd, this.options.agentCommand);
     const previousSuppression = this.suppressSessionUpdates;
     const previousReplaySuppression = this.suppressReplaySessionUpdateMessages;
     this.suppressSessionUpdates = previousSuppression || Boolean(options.suppressReplayUpdates);
@@ -685,7 +688,7 @@ export class AcpClient {
       response = await this.runConnectionRequest(() =>
         connection.loadSession({
           sessionId,
-          cwd: asAbsoluteCwd(cwd),
+          cwd: sessionCwd,
           mcpServers: this.options.mcpServers ?? [],
         }),
       );

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { resolveAgentSessionCwd } from "../src/acp/client-process.js";
 import { buildAgentSpawnOptions, buildSpawnCommandOptions } from "../src/acp/client.js";
 import { buildTerminalSpawnOptions } from "../src/acp/terminal-manager.js";
 import { buildQueueOwnerSpawnOptions } from "../src/cli/session/queue-owner-process.js";
@@ -126,6 +127,57 @@ test("buildSpawnCommandOptions keeps shell disabled for non-batch commands", asy
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test("resolveAgentSessionCwd translates WSL cwd for Windows exe agents", async () => {
+  let capturedCwd: string | undefined;
+
+  const cwd = await resolveAgentSessionCwd(
+    "/home/user/project",
+    '"/mnt/c/Users/User/AppData/Local/GitHub CLI/copilot/copilot.exe" --acp --stdio',
+    {
+      platform: "linux",
+      existsSync: (filePath) => filePath === "/proc/sys/fs/binfmt_misc/WSLInterop",
+      runWslpath: async (value) => {
+        capturedCwd = value;
+        return "\\\\wsl.localhost\\Ubuntu\\home\\user\\project\n";
+      },
+    },
+  );
+
+  assert.equal(capturedCwd, "/home/user/project");
+  assert.equal(cwd, "\\\\wsl.localhost\\Ubuntu\\home\\user\\project");
+});
+
+test("resolveAgentSessionCwd leaves non-WSL and non-Windows agents on resolved cwd", async () => {
+  const nonWsl = await resolveAgentSessionCwd("relative/project", "/mnt/c/tools/copilot.exe", {
+    platform: "linux",
+    existsSync: () => false,
+    runWslpath: async () => {
+      throw new Error("wslpath should not run");
+    },
+  });
+  const wslNodeAgent = await resolveAgentSessionCwd("/home/user/project", "node ./agent.js", {
+    platform: "linux",
+    existsSync: (filePath) => filePath === "/proc/sys/fs/binfmt_misc/WSLInterop",
+    runWslpath: async () => {
+      throw new Error("wslpath should not run");
+    },
+  });
+
+  assert.equal(nonWsl, path.resolve("relative/project"));
+  assert.equal(wslNodeAgent, "/home/user/project");
+});
+
+test("resolveAgentSessionCwd rejects empty wslpath output", async () => {
+  await assert.rejects(
+    resolveAgentSessionCwd("/home/user/project", "/mnt/c/tools/copilot.exe --acp", {
+      platform: "linux",
+      existsSync: (filePath) => filePath === "/proc/sys/fs/binfmt_misc/WSLInterop",
+      runWslpath: async () => "\n",
+    }),
+    /wslpath returned an empty Windows path/,
+  );
 });
 
 test("buildTerminalSpawnOptions enables shell for PATH-resolved .cmd wrappers on Windows", async () => {


### PR DESCRIPTION
## Summary
- translate ACP session cwd via `wslpath -w` when acpx is running under WSL and the configured agent command targets a Windows executable
- apply the translated cwd to both `session/new` and `session/load`
- add regression coverage for WSL Windows exe detection, no-op paths, and empty `wslpath` output

Fixes #232

## Verification
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run check`
