### PR TITLE
fix: mark resumable sessions idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Repo: https://github.com/openclaw/acpx
 - CLI/quiet output: emit final token usage and cost metadata to stderr when adapters include it in the ACP prompt result, while keeping quiet stdout as assistant text only. (#257)
 - Runtime/doctor: guarantee `doctor().details` contains strings even when probe failures include Error or object values. (#267)
 - Runtime/WSL: translate session cwd with `wslpath` when running under WSL and spawning Windows `.exe` ACP agents, so `session/new` and `session/load` receive paths the agent can access. (#232)
+- CLI/status: report resumable persistent sessions as `idle` when no queue owner is running, instead of marking pre-prompt or TTL-expired sessions as dead. (#185)
 - CLI/prompt: honor `--model` when sending prompts to existing persistent sessions, including queued owner paths. (#211) Thanks @skywills.
 - Claude/built-in: bump the owned `@agentclientprotocol/claude-agent-acp` package range to `^0.31.0` so fresh built-in launches include the Opus 4.7 adapter update and later ACP compatibility fixes. (#253) Thanks @flowforgelab.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ One command surface for Pi, OpenClaw ACP, Codex, Claude, and other ACP-compatibl
 - **Prompt from file/stdin**: `--file <path>` or piped stdin for prompt content
 - **Config files**: global + project JSON config with `acpx config show|init`
 - **Session inspect/history**: `sessions show` and `sessions history --limit <n>`
-- **Local status checks**: `status` reports running/dead/no-session, pid, uptime, last prompt
+- **Local status checks**: `status` reports running/idle/dead/no-session, pid, uptime, last prompt
 - **Client methods**: stable `fs/*` and `terminal/*` handlers with permission controls and cwd sandboxing
 - **Auth handshake**: stable `authenticate` support via env/config credentials
 - **Structured output**: typed ACP messages (thinking, tool calls, diffs) instead of ANSI scraping

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -341,11 +341,15 @@ acpx [global_options] status -s <name>
 
 Shows local process status for the cwd-scoped session:
 
-- `running`, `dead`, or `no-session`
+- `running`, `idle`, `dead`, or `no-session`
 - session id, agent command, pid
 - uptime when running
 - last prompt timestamp
 - last known exit code/signal when dead
+
+`idle` means the persistent session is saved and resumable, but no queue owner is
+currently running. The next prompt starts a queue owner and reconnects the
+session.
 
 Status checks are local and PID-based (`kill(pid, 0)` semantics).
 

--- a/src/cli/status-command.ts
+++ b/src/cli/status-command.ts
@@ -12,6 +12,8 @@ import { emitJsonResult } from "./output/json-output.js";
 import { agentSessionIdPayload } from "./output/render.js";
 import { probeQueueOwnerHealth } from "./queue/ipc.js";
 
+type SessionStatusState = "running" | "idle" | "dead";
+
 function formatUptime(startedAt: string | undefined): string | undefined {
   if (!startedAt) {
     return undefined;
@@ -30,6 +32,37 @@ function formatUptime(startedAt: string | undefined): string | undefined {
   return `${hours.toString().padStart(2, "0")}:${minutes
     .toString()
     .padStart(2, "0")}:${remSeconds.toString().padStart(2, "0")}`;
+}
+
+function resolveStatusState(
+  record: { lastAgentExitCode?: number | null; lastAgentExitSignal?: NodeJS.Signals | null },
+  health: Awaited<ReturnType<typeof probeQueueOwnerHealth>>,
+): SessionStatusState {
+  if (health.healthy) {
+    return "running";
+  }
+
+  if (health.hasLease) {
+    return "dead";
+  }
+
+  if (record.lastAgentExitSignal || (record.lastAgentExitCode ?? 0) !== 0) {
+    return "dead";
+  }
+
+  return "idle";
+}
+
+function statusSummary(state: SessionStatusState): string {
+  switch (state) {
+    case "running":
+      return "queue owner healthy";
+    case "idle":
+      return "session idle; queue owner will start on next prompt";
+    case "dead":
+      return "queue owner unavailable";
+  }
+  return "queue owner unavailable";
 }
 
 export async function handleStatus(
@@ -74,12 +107,14 @@ export async function handleStatus(
   }
 
   const health = await probeQueueOwnerHealth(record.acpxRecordId);
-  const running = health.healthy;
+  const statusState = resolveStatusState(record, health);
+  const running = statusState === "running";
+  const dead = statusState === "dead";
   const payload = {
     sessionId: record.acpxRecordId,
     agentCommand: record.agentCommand,
     pid: health.pid ?? record.pid ?? null,
-    status: running ? "running" : "dead",
+    status: statusState,
     model: record.acpx?.current_model_id ?? null,
     mode: record.acpx?.current_mode_id ?? null,
     availableModels: record.acpx?.available_models ?? null,
@@ -93,16 +128,16 @@ export async function handleStatus(
   if (
     emitJsonResult(globalFlags.format, {
       action: "status_snapshot",
-      status: running ? "alive" : "dead",
+      status: running ? "alive" : statusState,
       pid: payload.pid ?? undefined,
-      summary: running ? "queue owner healthy" : "queue owner unavailable",
+      summary: statusSummary(statusState),
       model: payload.model ?? undefined,
       mode: payload.mode ?? undefined,
       availableModels: payload.availableModels ?? undefined,
       uptime: payload.uptime ?? undefined,
       lastPromptTime: payload.lastPromptTime ?? undefined,
-      exitCode: payload.exitCode ?? undefined,
-      signal: payload.signal ?? undefined,
+      exitCode: dead ? (payload.exitCode ?? undefined) : undefined,
+      signal: dead ? (payload.signal ?? undefined) : undefined,
       acpxRecordId: record.acpxRecordId,
       acpxSessionId: record.acpSessionId,
       agentSessionId: record.agentSessionId,
@@ -127,7 +162,7 @@ export async function handleStatus(
   process.stdout.write(`mode: ${payload.mode ?? "-"}\n`);
   process.stdout.write(`uptime: ${payload.uptime ?? "-"}\n`);
   process.stdout.write(`lastPromptTime: ${payload.lastPromptTime ?? "-"}\n`);
-  if (payload.status === "dead") {
+  if (dead) {
     process.stdout.write(`exitCode: ${payload.exitCode ?? "-"}\n`);
     process.stdout.write(`signal: ${payload.signal ?? "-"}\n`);
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1548,9 +1548,45 @@ test("status resolves named session when -s is before subcommand", async () => {
     const payload = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
     assert.equal(payload.action, "status_snapshot");
     assert.equal(payload.acpxRecordId, "named-status-session");
-    assert.equal(payload.status, "dead");
+    assert.equal(payload.status, "idle");
+    assert.equal(payload.summary, "session idle; queue owner will start on next prompt");
     assert.notEqual(payload.status, "no-session");
     assert.equal(payload.agentSessionId, undefined);
+  });
+});
+
+test("status reports idle for resumable sessions without a live queue owner", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "idle-status-session",
+      acpSessionId: "idle-status-session",
+      agentCommand: AGENT_REGISTRY.codex,
+      cwd,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: "2026-01-01T00:01:00.000Z",
+      lastPromptAt: "2026-01-01T00:01:00.000Z",
+      closed: false,
+      pid: 12345,
+      agentStartedAt: "2026-01-01T00:00:00.000Z",
+      lastAgentExitCode: 0,
+      lastAgentExitAt: "2026-01-01T00:02:00.000Z",
+    });
+
+    const json = await runCli(["--cwd", cwd, "--format", "json", "codex", "status"], homeDir);
+    assert.equal(json.code, 0, json.stderr);
+    const payload = JSON.parse(json.stdout.trim()) as Record<string, unknown>;
+    assert.equal(payload.action, "status_snapshot");
+    assert.equal(payload.status, "idle");
+    assert.equal(payload.summary, "session idle; queue owner will start on next prompt");
+    assert.equal(payload.exitCode, undefined);
+
+    const text = await runCli(["--cwd", cwd, "codex", "status"], homeDir);
+    assert.equal(text.code, 0, text.stderr);
+    assert.match(text.stdout, /status: idle/);
+    assert.doesNotMatch(text.stdout, /exitCode:/);
   });
 });
 
@@ -2024,6 +2060,48 @@ test("status reports running queue owner when owner socket is reachable", async 
       assert.match(result.stdout, /status: running/);
     } finally {
       await closeServer(server);
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});
+
+test("status reports dead when queue owner lease is present but unreachable", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const sessionId = "status-unreachable-owner";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+
+    try {
+      await writeSessionRecord(homeDir, {
+        acpxRecordId: sessionId,
+        acpSessionId: sessionId,
+        agentCommand: AGENT_REGISTRY.codex,
+        cwd,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastUsedAt: "2026-01-01T00:00:00.000Z",
+        lastPromptAt: "2026-01-01T00:00:00.000Z",
+        closed: false,
+        pid: keeper.pid,
+        agentStartedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      await writeQueueOwnerLock({
+        lockPath,
+        pid: keeper.pid,
+        sessionId,
+        socketPath,
+      });
+
+      const result = await runCli(["--cwd", cwd, "--format", "json", "codex", "status"], homeDir);
+      assert.equal(result.code, 0, result.stderr);
+      const payload = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+      assert.equal(payload.status, "dead");
+      assert.equal(payload.summary, "queue owner unavailable");
+    } finally {
       await cleanupOwnerArtifacts({ socketPath, lockPath });
       stopProcess(keeper);
     }


### PR DESCRIPTION
## Summary
- report saved/resumable persistent sessions as `idle` when no queue owner is currently running
- keep `dead` for broken queue-owner leases/crash states
- document the new status value and add regression coverage for idle/running/dead status paths

Fixes #185

## Verification
- `fnm exec --using=24.15.0 corepack pnpm@10.33.2 run check`
- live CLI sequence: `sessions ensure` -> `status: idle`; prompt with short TTL -> `status: alive`; after TTL -> `status: idle`
