### PR TITLE
fix: surface actionable auth hint when no credentials match advertised ACP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
+- ACP/auth: surface an actionable hint on stderr when an agent advertises auth methods (e.g. droid's `factory-api-key`) but no matching credentials are configured, listing the `ACPX_AUTH_<METHOD_ID>` env var, the `~/.acpx/config.json` entry, and the agent-native env var to set. Document `FACTORY_API_KEY` requirements in [`agents/Droid.md`](agents/Droid.md).
 
 ## 2026.4.25 (v0.6.0)
 

--- a/agents/Droid.md
+++ b/agents/Droid.md
@@ -4,3 +4,30 @@
 - Aliases: `factory-droid`, `factorydroid`
 - Default command: `droid exec --output-format acp`
 - Upstream: https://www.factory.ai
+
+## Authentication
+
+Droid is a cloud gateway and requires a Factory API key for every session.
+Provide the credential in any one of these forms before running `acpx droid ...`:
+
+- `export FACTORY_API_KEY=<credential>` — the agent-native variable; works
+  because `acpx` propagates the parent environment to the child agent.
+- `export ACPX_AUTH_FACTORY_API_KEY=<credential>` — triggers ACP `authenticate`
+  via acpx and is also forwarded to the child as `FACTORY_API_KEY`.
+- Add an entry under `auth.factory-api-key` in `~/.acpx/config.json`.
+
+Obtain a key from the Factory dashboard at https://www.factory.ai.
+
+### Why device-pairing is not used
+
+Droid advertises a `device-pairing` ACP auth method that opens a browser and
+waits for completion. acpx runs droid in headless ACP mode where there is no
+TTY to display the pairing code, and the call blocks indefinitely. Use a
+`FACTORY_API_KEY` instead.
+
+### Interactive `droid` cached credentials do not carry over
+
+Running `droid` interactively caches credentials locally, but
+`droid exec --output-format acp` (the command acpx invokes) does not currently
+reuse them. Always set `FACTORY_API_KEY` for acpx-driven sessions, even if you
+have already logged in via the Droid TUI.

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -79,6 +79,7 @@ Friendly agent names resolve to commands:
 - `cursor` -> `cursor-agent acp`
 - `copilot` -> `copilot --acp --stdio`
 - `droid` -> `droid exec --output-format acp` (`factory-droid` and `factorydroid` also resolve to `droid`)
+  Requires `FACTORY_API_KEY` (or `ACPX_AUTH_FACTORY_API_KEY`); see [`agents/Droid.md`](../../agents/Droid.md).
 - `iflow` -> `iflow --experimental-acp`
 - `kilocode` -> `npx -y @kilocode/cli acp`
 - `kimi` -> `kimi acp`

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -98,6 +98,17 @@ export function resolveConfiguredAuthCredential(
   return configCredentials[methodId] ?? configCredentials[toEnvToken(methodId)];
 }
 
+export function describeAuthCredentialEnvNames(methodId: string): {
+  prefixed: string | undefined;
+  bare: string | undefined;
+} {
+  const bare = toEnvToken(methodId);
+  if (bare.length === 0) {
+    return { prefixed: undefined, bare: undefined };
+  }
+  return { prefixed: `${AUTH_ENV_PREFIX}${bare}`, bare };
+}
+
 export function buildAgentSpawnOptions(
   cwd: string,
   authCredentials: Record<string, string> | undefined,

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -70,6 +70,7 @@ import {
 } from "./agent-command.js";
 import {
   buildAgentSpawnOptions,
+  describeAuthCredentialEnvNames,
   readEnvCredential,
   resolveConfiguredAuthCredential,
 } from "./auth-env.js";
@@ -1164,9 +1165,7 @@ export class AcpClient {
         );
       }
 
-      this.log(
-        `agent advertised auth methods [${methods.map((m) => m.id).join(", ")}] but no matching credentials found — skipping (agent may handle auth internally)`,
-      );
+      this.warnNoMatchingAuthCredentials(methods);
       return;
     }
 
@@ -1175,6 +1174,32 @@ export class AcpClient {
     });
 
     this.log(`authenticated with method ${selected.methodId} (${selected.source})`);
+  }
+
+  private warnNoMatchingAuthCredentials(methods: AuthMethod[]): void {
+    const ids = methods.map((m) => m.id).join(", ");
+    const lines: string[] = [
+      `[acpx] agent advertised auth methods [${ids}] but no matching credentials were configured.`,
+      `[acpx] To authenticate via acpx, set ONE of:`,
+    ];
+    for (const method of methods) {
+      const names = describeAuthCredentialEnvNames(method.id);
+      if (names.prefixed) {
+        lines.push(`[acpx]   export ${names.prefixed}=<credential>`);
+      }
+      lines.push(`[acpx]   ~/.acpx/config.json  →  auth.${method.id}: <credential>`);
+    }
+    const bareHints = methods
+      .map((m) => describeAuthCredentialEnvNames(m.id).bare)
+      .filter((bare): bare is string => Boolean(bare));
+    if (bareHints.length > 0) {
+      lines.push(
+        `[acpx] Continuing — agents that read native env vars (e.g. ${bareHints.join(", ")}) directly may still authenticate.`,
+      );
+    } else {
+      lines.push(`[acpx] Continuing — the agent may still authenticate internally.`);
+    }
+    process.stderr.write(`${lines.join("\n")}\n`);
   }
 
   private async handlePermissionRequest(

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -274,6 +274,37 @@ test("AcpClient ignores ambient normalized provider env vars for auth selection"
   );
 });
 
+test("AcpClient authenticateIfRequired warns with actionable env/config hints when skipping", async () => {
+  await withEnv(
+    {
+      ACPX_AUTH_FACTORY_API_KEY: undefined,
+      FACTORY_API_KEY: undefined,
+    },
+    async () => {
+      const client = makeClient();
+      const internals = asInternals(client);
+
+      const writes: string[] = [];
+      await withStderrCapture(writes, async () => {
+        await internals.authenticateIfRequired?.(
+          {
+            authenticate: async () => {
+              throw new Error("authenticate should not be called");
+            },
+          },
+          [{ id: "factory-api-key" }],
+        );
+      });
+
+      const output = writes.join("");
+      assert.match(output, /agent advertised auth methods \[factory-api-key\]/);
+      assert.match(output, /export ACPX_AUTH_FACTORY_API_KEY=/);
+      assert.match(output, /auth\.factory-api-key/);
+      assert.match(output, /native env vars \(e\.g\. FACTORY_API_KEY\)/);
+    },
+  );
+});
+
 test("AcpClient authenticateIfRequired throws when auth policy is fail and credentials are missing", async () => {
   const client = makeClient({ authPolicy: "fail" });
   const internals = asInternals(client);
@@ -834,6 +865,19 @@ async function withEnv(
         process.env[key] = value;
       }
     }
+  }
+}
+
+async function withStderrCapture(writes: string[], run: () => Promise<void> | void): Promise<void> {
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await run();
+  } finally {
+    process.stderr.write = original;
   }
 }
 


### PR DESCRIPTION
## Summary

When an ACP agent advertises auth methods but no matching credentials are configured, `acpx` now writes an actionable hint to stderr instead of silently logging behind `--verbose`. The hint lists all three ways to provide the credential — the `ACPX_AUTH_<METHOD_ID>` env var, the `~/.acpx/config.json` `auth.<method-id>` entry, and the agent-native env var the agent reads directly (e.g. `FACTORY_API_KEY` for droid).

Also adds an `Auth` section to [`agents/Droid.md`](agents/Droid.md) documenting `FACTORY_API_KEY` as the only viable path, why droid's `device-pairing` ACP method is unusable in headless mode, and that `droid`'s interactive cached credentials do not carry over to `droid exec --output-format acp`.

Closes NAI-186.

## Why

Reproduced via `acpx droid 'prompt'` with `FACTORY_API_KEY` unset. acpx's existing `authPolicy: skip` is correct (keeps users on agent-native env vars working), but it routes the skip-with-no-credentials event through `--verbose` only. The first user-visible message therefore comes from droid's device-pairing flow, which prints _"Click the Login button"_ copy with no analog in a non-TTY CLI context. The new hint closes the gap: users see the `acpx`-side action items before the agent's own auth flow takes over.

The change is fully generic — it derives env var names from the existing `toEnvToken` / `AUTH_ENV_PREFIX` logic in `src/acp/auth-env.ts`, so it works for any future credential-gated ACP agent without per-agent code.

### Before

\`\`\`
$ FACTORY_API_KEY= acpx droid sessions new
Authentication required:

Your code: QKGL-NPMF

Click the "Login" button to authenticate, or set a FACTORY_API_KEY environment variable.
\`\`\`

(Source: droid's TTY-oriented copy, with no acpx-side context.)

### After (additional acpx hint preceding any agent output)

\`\`\`
[acpx] agent advertised auth methods [factory-api-key] but no matching credentials were configured.
[acpx] To authenticate via acpx, set ONE of:
[acpx]   export ACPX_AUTH_FACTORY_API_KEY=<credential>
[acpx]   ~/.acpx/config.json  →  auth.factory-api-key: <credential>
[acpx] Continuing — agents that read native env vars (e.g. FACTORY_API_KEY) directly may still authenticate.
\`\`\`

## Investigation context

Originating brainstorm: [`docs/brainstorms/2026-03-11-droid-auth-investigation-brainstorm.md`](docs/brainstorms/2026-03-11-droid-auth-investigation-brainstorm.md). Confirms acpx auth logic is correct (no behavior change), only the surfacing of the skip path needed an upgrade.

## Files

- \`src/acp/auth-env.ts\` — new \`describeAuthCredentialEnvNames(methodId)\` helper exposing the prefixed/bare env names already implied by the existing token logic.
- \`src/acp/client.ts\` — replace the verbose-only \`this.log(...)\` skip path with \`warnNoMatchingAuthCredentials(methods)\`, which writes the multi-line hint to \`process.stderr\`.
- \`agents/Droid.md\` — new Auth section.
- \`skills/acpx/SKILL.md\` — one-line auth note under \`droid\` (per AGENTS.md harness sync rule).
- \`test/client.test.ts\` — new \`withStderrCapture\` helper + a unit test asserting the hint contains the env var, config path, and bare env hints.
- \`CHANGELOG.md\` — entry under \`## Unreleased\` → \`### Fixes\`.

## Test plan

- [x] \`pnpm run check\` — 586/586 tests pass; build, typecheck, lint, format, coverage all clean. (One pre-existing flaky \`replay viewer streams live sidebar...\` test failed once on the parallel test run; passes 3/3 in isolation; passed on the second full run. Unrelated to this change.)
- [x] \`pnpm run check:docs\` — 0 errors.
- [x] Manual verification of the new test case asserting hint content.

## AI assistance

Drafted with Claude Code, working from the existing investigation brainstorm and verified end-to-end with the test suite. Fully tested.