### PR TITLE
fix: recognize .cmd/.bat as Windows-side commands for WSL cwd translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Repo: https://github.com/openclaw/acpx
 - CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
 - Windows/Claude: resolve the `claude.exe` executable from PATH before spawning Claude ACP sessions, so native Windows launches do not depend on shell-specific command lookup. (#289) Thanks @MikeChongCan.
 - Client/ACP: send `session/close` from `closeSession()` instead of the experimental `nes/close` method, so adapters without NES support can tear down sessions cleanly. (#291) Thanks @hexsprite.
+- Runtime/WSL: recognize Windows `.cmd` and `.bat` ACP agent wrappers for cwd translation, including wrappers installed on non-C drives. (#280) Thanks @solomonneas.
 
 ## 2026.4.25 (v0.6.0)
 

--- a/src/acp/client-process.ts
+++ b/src/acp/client-process.ts
@@ -199,9 +199,11 @@ function isWsl(options: ResolveSessionCwdOptions): boolean {
   return existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");
 }
 
+const WINDOWS_EXECUTABLE_EXTENSION_RE = /\.(?:exe|cmd|bat)$/u;
+
 function isWindowsExecutableCommand(command: string): boolean {
-  const normalized = command.replace(/\\/g, "/").toLowerCase();
-  return normalized.endsWith(".exe") || normalized.startsWith("/mnt/c/");
+  const normalized = command.toLowerCase();
+  return WINDOWS_EXECUTABLE_EXTENSION_RE.test(normalized);
 }
 
 async function runWslpath(cwd: string): Promise<string> {

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -170,6 +170,54 @@ test("resolveAgentSessionCwd leaves non-WSL and non-Windows agents on resolved c
   assert.equal(wslNodeAgent, "/home/user/project");
 });
 
+test("resolveAgentSessionCwd translates WSL cwd for Windows .cmd wrappers", async () => {
+  let capturedCwd: string | undefined;
+
+  const cwd = await resolveAgentSessionCwd(
+    "/home/user/project",
+    '"/mnt/c/Program Files/nodejs/npx.cmd" some-acp-agent --stdio',
+    {
+      platform: "linux",
+      existsSync: (filePath) => filePath === "/proc/sys/fs/binfmt_misc/WSLInterop",
+      runWslpath: async (value) => {
+        capturedCwd = value;
+        return "\\\\wsl.localhost\\Ubuntu\\home\\user\\project\n";
+      },
+    },
+  );
+
+  assert.equal(capturedCwd, "/home/user/project");
+  assert.equal(cwd, "\\\\wsl.localhost\\Ubuntu\\home\\user\\project");
+});
+
+test("resolveAgentSessionCwd translates WSL cwd for Windows agents on non-C drives", async () => {
+  let capturedCwd: string | undefined;
+
+  const cwd = await resolveAgentSessionCwd("/home/user/project", "/mnt/d/tools/agent.bat --acp", {
+    platform: "linux",
+    existsSync: (filePath) => filePath === "/proc/sys/fs/binfmt_misc/WSLInterop",
+    runWslpath: async (value) => {
+      capturedCwd = value;
+      return "\\\\wsl.localhost\\Ubuntu\\home\\user\\project\n";
+    },
+  });
+
+  assert.equal(capturedCwd, "/home/user/project");
+  assert.equal(cwd, "\\\\wsl.localhost\\Ubuntu\\home\\user\\project");
+});
+
+test("resolveAgentSessionCwd does not translate WSL cwd for extension-less commands under /mnt/<drive>/", async () => {
+  const cwd = await resolveAgentSessionCwd("/home/user/project", "/mnt/c/tools/linux-agent --acp", {
+    platform: "linux",
+    existsSync: (filePath) => filePath === "/proc/sys/fs/binfmt_misc/WSLInterop",
+    runWslpath: async () => {
+      throw new Error("wslpath should not run for extension-less /mnt/<drive>/ commands");
+    },
+  });
+
+  assert.equal(cwd, "/home/user/project");
+});
+
 test("resolveAgentSessionCwd rejects empty wslpath output", async () => {
   await assert.rejects(
     resolveAgentSessionCwd("/home/user/project", "/mnt/c/tools/copilot.exe --acp", {


### PR DESCRIPTION
## Summary

`isWindowsExecutableCommand` (`src/acp/client-process.ts`), used by `resolveAgentSessionCwd` to decide whether to translate cwd via `wslpath -w` before spawning a Windows-side ACP agent from WSL, previously matched only `.exe` extensions or any path starting with `/mnt/c/`. This missed Windows wrappers like `npx.cmd` / `codex.cmd` and Windows agents installed on non-C drives. Match `.exe`, `.cmd`, and `.bat` instead, aligning with `basenameToken`'s existing extension scope a few lines down in the same file.

The original `/mnt/c/` prefix branch is **dropped entirely**, not widened to `/mnt/<drive>/`. Drvfs paths are just mounts, so a path-only check cannot distinguish a Windows binary from a Linux script that happens to live on a mounted Windows drive (e.g. `/mnt/d/tools/acp-adapter` could be either). Translating cwd to a UNC path in the Linux-script case would corrupt its working directory. Extension-based detection is the structurally correct discriminator.

## Why

The inconsistency was self-evident in the same file: `basenameToken` (`src/acp/client-process.ts:219-224`) already strips `.cmd|.exe|.bat`, and `spawn-options.test.ts:70-77` already tests `.cmd/.bat` shell handling on Windows. Only `isWindowsExecutableCommand` was treating `.exe` as the sole Windows-side extension.

The C-drive prefix limitation also showed up as a real-world inconvenience: any Windows agent installed on a non-C drive (common on dev boxes that put apps on D:/E: for space) was silently skipping cwd translation.

## Behavior change to call out

This narrows behavior in one direction: extension-less commands directly under `/mnt/c/` (e.g. `/mnt/c/tools/linux-agent`) **no longer** trigger cwd translation. The original `startsWith("/mnt/c/")` accepted them; the new predicate does not. I judged this a latent bug rather than load-bearing behavior, since translating cwd to a UNC path for a Linux binary running under WSL would corrupt its working directory. The new negative test (`does not translate WSL cwd for extension-less commands under /mnt/<drive>/`) locks this in. Happy to revisit if there is a documented use case I missed.

## Files

- `src/acp/client-process.ts` - predicate now keys off the executable extension only; module-level `WINDOWS_EXECUTABLE_EXTENSION_RE` constant.
- `test/spawn-options.test.ts` - three additions: `.cmd` wrapper translation, `.bat` on non-C drive translation, negative test for extension-less `/mnt/<drive>/` commands.

## Out of scope

`.com` (PATHEXT default) and `.ps1` are not added. Both `basenameToken` and `isWindowsExecutableCommand` keep the same `cmd|exe|bat` set; widening at one site without the other would re-introduce inconsistency. Happy to add as a follow-up if maintainers want broader coverage.

## Test plan

- [x] `pnpm run check` clean (format:check + typecheck + lint + build + viewer:typecheck + viewer:build + test:coverage)
- [x] `pnpm test` - 588/588 pass (was 585 baseline + 3 new)
- [x] Net diff: +52 / -2 across 2 files

## AI assistance

AI-assisted PR. Drafted with **Claude Code (Opus 4.7)** and reviewed twice with **Codex (GPT 5.5)**. The first Codex pass pushed back on an earlier version that widened the path-prefix rule to `/mnt/<drive>/` instead of dropping it; the diff was tightened in response. Final Codex pass returned no findings. Independent code review by a separate reviewer agent before push. **Fully tested** locally - full `pnpm check` suite green.