### PR TITLE
feat(runtime): expose advertised configOptions per-session via handle-aware getCapabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Runtime/embedding: capture per-session advertised `configOptions` from `session/new` and `session/load` and surface them via handle-aware `getCapabilities`, so embedders can reconcile advertised keys before issuing `session/set_config_option` against adapters with narrow advertised configOption sets (e.g. `claude-agent-acp` v0.31+ which only advertises `mode | model | effort`). `getCapabilities()` and `getCapabilities({})` keep their synchronous return; only `getCapabilities({ handle })` becomes async. Thanks @samithaj.
+
 ### Breaking
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acpx",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Headless CLI client for the Agent Client Protocol (ACP) — talk to coding agents from the command line",
   "keywords": [
     "acp",

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -18,6 +18,7 @@ import {
   type ReleaseTerminalResponse,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
+  type SessionConfigOption,
   type SessionNotification,
   type SetSessionConfigOptionResponse,
   type TerminalOutputRequest,
@@ -116,11 +117,13 @@ export type SessionCreateResult = {
   sessionId: string;
   agentSessionId?: string;
   models?: SessionModelState;
+  configOptions?: SessionConfigOption[];
 };
 
 export type SessionLoadResult = {
   agentSessionId?: string;
   models?: SessionModelState;
+  configOptions?: SessionConfigOption[];
 };
 
 type AgentDisconnectReason = "process_exit" | "process_close" | "pipe_close" | "connection_close";
@@ -661,6 +664,7 @@ export class AcpClient {
       sessionId: result.sessionId,
       agentSessionId: extractRuntimeSessionId(result._meta),
       models: result.models ?? undefined,
+      configOptions: result.configOptions ?? undefined,
     };
   }
 
@@ -707,6 +711,7 @@ export class AcpClient {
     return {
       agentSessionId: extractRuntimeSessionId(response?._meta),
       models: response?.models ?? undefined,
+      configOptions: response?.configOptions ?? undefined,
     };
   }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -201,8 +201,25 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     });
   }
 
-  getCapabilities(_input?: { handle?: AcpRuntimeHandle }): AcpRuntimeCapabilities {
-    return ACPX_CAPABILITIES;
+  getCapabilities(input?: {
+    handle?: AcpRuntimeHandle;
+  }): AcpRuntimeCapabilities | Promise<AcpRuntimeCapabilities> {
+    if (!input?.handle) {
+      return ACPX_CAPABILITIES;
+    }
+    const recordId = input.handle.acpxRecordId ?? input.handle.sessionKey;
+    return this.options.sessionStore.load(recordId).then((record) => {
+      const ids = record?.acpx?.config_options
+        ?.map((option) => option.id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (!ids || ids.length === 0) {
+        return ACPX_CAPABILITIES;
+      }
+      return {
+        ...ACPX_CAPABILITIES,
+        configOptionKeys: Array.from(new Set(ids)),
+      };
+    });
   }
 
   async getStatus(input: {

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { AcpClient } from "../../acp/client.js";
 import { normalizeOutputError } from "../../acp/error-normalization.js";
 import { extractAcpError, isAcpResourceNotFoundError } from "../../acp/error-shapes.js";
@@ -39,6 +39,7 @@ import {
 import { runPromptTurn } from "./prompt-turn.js";
 import { connectAndLoadSession } from "./reconnect.js";
 import { shouldReuseExistingRecord } from "./reuse-policy.js";
+import { applyConfigOptionsToRecord } from "./session-config-options.js";
 
 export type AcpRuntimeManagerDeps = {
   clientFactory?: (options: ConstructorParameters<typeof AcpClient>[0]) => AcpClient;
@@ -69,18 +70,6 @@ function createDeferred<T>(): Deferred<T> {
     reject = rej;
   });
   return { promise, resolve, reject };
-}
-
-function applyConfigOptionsToRecord(
-  record: SessionRecord,
-  configOptions: SetSessionConfigOptionResponse["configOptions"] | undefined,
-): void {
-  if (!configOptions) {
-    return;
-  }
-  const acpxState = cloneSessionAcpxState(record.acpx) ?? {};
-  acpxState.config_options = structuredClone(configOptions);
-  record.acpx = acpxState;
 }
 
 class AsyncEventQueue {
@@ -404,14 +393,17 @@ export class AcpRuntimeManager {
       await client.start();
       let sessionId: string;
       let agentSessionId: string | undefined;
+      let advertisedConfigOptions: SessionConfigOption[] | undefined;
       if (input.resumeSessionId) {
         const loaded = await client.loadSession(input.resumeSessionId, cwd);
         sessionId = input.resumeSessionId;
         agentSessionId = loaded.agentSessionId;
+        advertisedConfigOptions = loaded.configOptions;
       } else {
         const created = await client.createSession(cwd);
         sessionId = created.sessionId;
         agentSessionId = created.agentSessionId;
+        advertisedConfigOptions = created.configOptions;
       }
       const record = createInitialRecord({
         recordId: createRecordId(input.sessionKey, input.mode),
@@ -425,6 +417,7 @@ export class AcpRuntimeManager {
       record.protocolVersion = client.initializeResult?.protocolVersion;
       record.agentCapabilities = client.initializeResult?.agentCapabilities;
       applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
+      applyConfigOptionsToRecord(record, advertisedConfigOptions);
       await this.options.sessionStore.save(record);
       if (input.mode === "persistent") {
         const previousClient = this.pendingPersistentClients.get(record.acpxRecordId);

--- a/src/runtime/engine/reconnect.ts
+++ b/src/runtime/engine/reconnect.ts
@@ -27,6 +27,7 @@ import {
   reconcileAgentSessionId,
   sessionHasAgentMessages,
 } from "./lifecycle.js";
+import { applyConfigOptionsToRecord } from "./session-config-options.js";
 
 export type ConnectedSessionController = {
   hasActivePrompt: () => boolean;
@@ -291,6 +292,7 @@ export async function connectAndLoadSession(
       );
       reconcileAgentSessionId(record, loadResult.agentSessionId);
       sessionModels = loadResult.models;
+      applyConfigOptionsToRecord(record, loadResult.configOptions);
       resumed = true;
     } catch (error) {
       loadError = formatErrorMessage(error);
@@ -309,6 +311,7 @@ export async function connectAndLoadSession(
       createdFreshSession = true;
       pendingAgentSessionId = createdSession.agentSessionId;
       sessionModels = createdSession.models;
+      applyConfigOptionsToRecord(record, createdSession.configOptions);
     }
   } else {
     if (sameSessionOnly) {
@@ -322,6 +325,7 @@ export async function connectAndLoadSession(
     createdFreshSession = true;
     pendingAgentSessionId = createdSession.agentSessionId;
     sessionModels = createdSession.models;
+    applyConfigOptionsToRecord(record, createdSession.configOptions);
   }
 
   if (createdFreshSession) {

--- a/src/runtime/engine/session-config-options.ts
+++ b/src/runtime/engine/session-config-options.ts
@@ -1,0 +1,15 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { cloneSessionAcpxState } from "../../session/conversation-model.js";
+import type { SessionRecord } from "../../types.js";
+
+export function applyConfigOptionsToRecord(
+  record: SessionRecord,
+  configOptions: SessionConfigOption[] | null | undefined,
+): void {
+  if (!configOptions) {
+    return;
+  }
+  const acpxState = cloneSessionAcpxState(record.acpx) ?? {};
+  acpxState.config_options = structuredClone(configOptions);
+  record.acpx = acpxState;
+}

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
+import type { SessionConfigOption, SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { AcpRuntimeManager } from "../src/runtime/engine/manager.js";
 import type {
   AcpRuntimeEvent,
@@ -26,8 +26,15 @@ type FakeClient = {
   };
   start: () => Promise<void>;
   close: () => Promise<void>;
-  createSession: (cwd: string) => Promise<{ sessionId: string; agentSessionId?: string }>;
-  loadSession: (sessionId: string, cwd: string) => Promise<{ agentSessionId?: string }>;
+  createSession: (cwd: string) => Promise<{
+    sessionId: string;
+    agentSessionId?: string;
+    configOptions?: SessionConfigOption[];
+  }>;
+  loadSession: (
+    sessionId: string,
+    cwd: string,
+  ) => Promise<{ agentSessionId?: string; configOptions?: SessionConfigOption[] }>;
   hasReusableSession: (sessionId: string) => boolean;
   supportsLoadSession: () => boolean;
   supportsCloseSession?: () => boolean;
@@ -35,7 +42,7 @@ type FakeClient = {
     sessionId: string,
     cwd: string,
     options: { suppressReplayUpdates: boolean },
-  ) => Promise<{ agentSessionId?: string }>;
+  ) => Promise<{ agentSessionId?: string; configOptions?: SessionConfigOption[] }>;
   getAgentLifecycleSnapshot: () => {
     pid?: number;
     startedAt?: string;
@@ -1923,4 +1930,120 @@ test("AcpRuntimeManager reuses a kept-open persistent client for controls before
   await manager.close(handle);
 
   assert.equal(closeCalls, 1);
+});
+
+test("AcpRuntimeManager captures advertised configOptions from session/new", async () => {
+  const store = new InMemorySessionStore();
+  const advertised: SessionConfigOption[] = [
+    {
+      id: "mode",
+      name: "Mode",
+      description: "Permission mode",
+      type: "select",
+      currentValue: "default",
+      options: [{ value: "default", name: "Default" }],
+    } as SessionConfigOption,
+    {
+      id: "effort",
+      name: "Effort",
+      description: "Reasoning effort",
+      type: "select",
+      currentValue: "medium",
+      options: [{ value: "medium", name: "Medium" }],
+    } as SessionConfigOption,
+  ];
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          initializeResult: { protocolVersion: 1, agentCapabilities: { loadSession: true } },
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({
+            sessionId: "claude-session",
+            agentSessionId: "claude-agent",
+            configOptions: advertised,
+          }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => false,
+          supportsLoadSession: () => true,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async () => ({ stopReason: "end_turn" }),
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const created = await manager.ensureSession({
+    sessionKey: "claude-session-key",
+    agent: "claude",
+    mode: "persistent",
+  });
+
+  const persisted = store.records.get(created.acpxRecordId);
+  assert.deepEqual(
+    persisted?.acpx?.config_options?.map((option) => option.id),
+    ["mode", "effort"],
+  );
+});
+
+test("AcpRuntimeManager captures advertised configOptions from session/load on resume", async () => {
+  const store = new InMemorySessionStore();
+  const advertised: SessionConfigOption[] = [
+    {
+      id: "model",
+      name: "Model",
+      description: "Model id",
+      type: "select",
+      currentValue: "claude-3.7",
+      options: [{ value: "claude-3.7", name: "Claude 3.7" }],
+    } as SessionConfigOption,
+  ];
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          initializeResult: { protocolVersion: 1, agentCapabilities: { loadSession: true } },
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({
+            agentSessionId: "resumed-agent",
+            configOptions: advertised,
+          }),
+          hasReusableSession: () => false,
+          supportsLoadSession: () => true,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async () => ({ stopReason: "end_turn" }),
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const resumed = await manager.ensureSession({
+    sessionKey: "resumed-session",
+    agent: "claude",
+    mode: "persistent",
+    resumeSessionId: "prior-acp-session",
+  });
+
+  const persisted = store.records.get(resumed.acpxRecordId);
+  assert.deepEqual(
+    persisted?.acpx?.config_options?.map((option) => option.id),
+    ["model"],
+  );
 });

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -425,6 +425,98 @@ test("AcpxRuntime falls back to plain runtimeSessionName handles and reuses a si
   assert.equal(managerFactoryCalls, 1);
 });
 
+test("AcpxRuntime.getCapabilities is synchronous and returns base capabilities when no handle is supplied", () => {
+  const runtime = new AcpxRuntime({
+    cwd: "/workspace",
+    sessionStore: createFileSessionStore({ stateDir: "/tmp/acpx-runtime-caps-no-handle" }),
+    agentRegistry: createAgentRegistry(),
+    permissionMode: "approve-reads",
+  });
+
+  const capsNoArg = runtime.getCapabilities();
+  assert.deepEqual(capsNoArg, {
+    controls: ["session/set_mode", "session/set_config_option", "session/status"],
+  });
+
+  const capsEmpty = runtime.getCapabilities({});
+  assert.deepEqual(capsEmpty, {
+    controls: ["session/set_mode", "session/set_config_option", "session/status"],
+  });
+});
+
+test("AcpxRuntime.getCapabilities({ handle }) returns advertised configOptionKeys from the session record", async (t) => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-runtime-caps-handle-"));
+  t.after(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  const store = createFileSessionStore({ stateDir });
+  const record = createSessionRecord({
+    acpxRecordId: "agent:claude:acp:caps",
+    acpSessionId: "claude-sid",
+    acpx: {
+      config_options: [
+        { id: "mode", name: "Mode", type: "select", currentValue: "default", options: [] },
+        { id: "model", name: "Model", type: "select", currentValue: "x", options: [] },
+        { id: "effort", name: "Effort", type: "select", currentValue: "high", options: [] },
+      ] as never,
+    },
+  });
+  await store.save(record);
+
+  const runtime = new AcpxRuntime({
+    cwd: "/workspace",
+    sessionStore: store,
+    agentRegistry: createAgentRegistry(),
+    permissionMode: "approve-reads",
+  });
+
+  const handle = {
+    sessionKey: record.acpxRecordId,
+    backend: "acpx",
+    runtimeSessionName: record.acpxRecordId,
+    acpxRecordId: record.acpxRecordId,
+  };
+  const caps = await runtime.getCapabilities({ handle });
+  assert.deepEqual(caps, {
+    controls: ["session/set_mode", "session/set_config_option", "session/status"],
+    configOptionKeys: ["mode", "model", "effort"],
+  });
+});
+
+test("AcpxRuntime.getCapabilities({ handle }) returns base capabilities when the record has no config_options", async (t) => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-runtime-caps-empty-"));
+  t.after(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  const store = createFileSessionStore({ stateDir });
+  const record = createSessionRecord({
+    acpxRecordId: "agent:codex:acp:caps-empty",
+    acpSessionId: "codex-sid",
+    acpx: {},
+  });
+  await store.save(record);
+
+  const runtime = new AcpxRuntime({
+    cwd: "/workspace",
+    sessionStore: store,
+    agentRegistry: createAgentRegistry(),
+    permissionMode: "approve-reads",
+  });
+
+  const handle = {
+    sessionKey: record.acpxRecordId,
+    backend: "acpx",
+    runtimeSessionName: record.acpxRecordId,
+    acpxRecordId: record.acpxRecordId,
+  };
+  const caps = await runtime.getCapabilities({ handle });
+  assert.deepEqual(caps, {
+    controls: ["session/set_mode", "session/set_config_option", "session/status"],
+  });
+});
+
 test("createRuntimeStore is an alias for the file-backed session store", async (t) => {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-runtime-store-alias-"));
   t.after(async () => {


### PR DESCRIPTION
## Summary

Capture the `configOptions` array adapters return on `session/new` and `session/load` and surface those advertised ids through `getCapabilities({ handle })`. This lets embedders intersect their intended `session/set_config_option` pairs against the advertised set before issuing the RPC, rather than discovering unsupported keys via `-32603 Unknown config option` rejections.

The motivating case is `@agentclientprotocol/claude-agent-acp@0.31+`, which only advertises `mode | model | effort`. Embedders such as OpenClaw that minted `timeout`/`thinking`/`approval_policy` against a generic vocabulary were getting opaque `ACP_TURN_FAILED` turns because there was no per-session capability surface to filter against.

## What changes

- `SessionCreateResult` and `SessionLoadResult` now carry an optional `configOptions?: SessionConfigOption[]`, populated from the SDK's `NewSessionResponse.configOptions` and `LoadSessionResponse.configOptions`.
- `manager.ensureSession()` and `reconnect.connectAndLoadSession()` (both load and fallback-create branches) call `applyConfigOptionsToRecord(record, ...)` so the advertised list is persisted to `record.acpx.config_options`.
- `applyConfigOptionsToRecord` is promoted from a private function inside `manager.ts` to a small shared helper at `src/runtime/engine/session-config-options.ts` so both call sites use the same clone-and-write contract.
- `AcpxRuntime.getCapabilities()` becomes handle-aware:
  - `getCapabilities()` and `getCapabilities({})` (no handle) are still **synchronous** and return the same static `ACPX_CAPABILITIES`.
  - `getCapabilities({ handle })` returns a `Promise<AcpRuntimeCapabilities>` whose `configOptionKeys` is populated from `record.acpx.config_options.map(opt => opt.id)` (deduped). When the record has no `config_options` it falls back to base capabilities.

The public `AcpRuntime.getCapabilities` contract already declared the return as `Promise<AcpRuntimeCapabilities> | AcpRuntimeCapabilities` and `AcpRuntimeCapabilities.configOptionKeys?: string[]` was already part of the type — so this is fully additive. Patch bump (`0.6.1 → 0.6.2`).

## Why pair with `loadSessionWithOptions(..., { suppressReplayUpdates: true })`

`reconnect.connectAndLoadSession` deliberately suppresses replayed `config_option_update` notifications during load, so the `setConfigOption` response handler (which already calls `applyConfigOptionsToRecord`) cannot be relied on to seed the advertised list on resume. Capturing from `LoadSessionResponse.configOptions` directly is the only reliable seed.

## Repro that motivated this

Verified end-to-end against `npx -y @agentclientprotocol/claude-agent-acp@0.31` over stdio:

```
[repro] step 2: session/new
[repro] session/new result keys: [ 'sessionId', 'models', 'modes', 'configOptions' ]
[repro] step 3: set_config_option { configId: "timeout", value: "120" }
{ code: -32603, message: "Internal error", data: { details: "Unknown config option: timeout" } }
[repro] step 4 (sanity): set_config_option { configId: "mode", value: "default" }
  → succeeds
```

The harness exposes `configOptions` on `session/new` (here advertising `mode`, `model`, `effort`); without this PR the runtime drops that information on the floor.

## Test plan

- [x] `pnpm run lint && pnpm run typecheck && pnpm test` (590 tests, all passing)
- [x] New tests in `test/runtime.test.ts`:
  - `getCapabilities()` and `getCapabilities({})` stay synchronous and return base capabilities.
  - `getCapabilities({ handle })` returns advertised `configOptionKeys` from the record.
  - `getCapabilities({ handle })` returns base capabilities when the record has no `config_options`.
- [x] New tests in `test/runtime-manager.test.ts`:
  - `manager.ensureSession` populates `record.acpx.config_options` from `session/new`.
  - `manager.ensureSession` populates `record.acpx.config_options` from `session/load` on resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
