### PR TITLE
fix: send session/close before agent termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
-- Client/ACP: migrate from `nes/close` to `session/close`, add `sendSessionClose` option to `AcpClient.close()` so teardown paths send `session/close` before the agent is killed, and handle SIGTERM in the queue owner so it runs through the teardown path on `sessions close`.
+- Client/ACP: migrate from `nes/close` to `session/close`, have `AcpClient.close()` send `session/close` before the agent is killed, and handle SIGTERM in the queue owner so it runs through the teardown path on `sessions close`.
 
 ## 2026.4.25 (v0.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
+- Client/ACP: migrate from `nes/close` to `session/close`, add `sendSessionClose` option to `AcpClient.close()` so teardown paths send `session/close` before the agent is killed, and handle SIGTERM in the queue owner so it runs through the teardown path on `sessions close`.
 
 ## 2026.4.25 (v0.6.0)
 

--- a/docs/2026-04-29-session-close-teardown.md
+++ b/docs/2026-04-29-session-close-teardown.md
@@ -1,0 +1,76 @@
+---
+title: Guaranteed Session Closure
+description: How acpx ensures ACP session/close is sent to agents before process termination.
+author: Adrian Cole <adrian@tetrate.io>
+date: 2026-04-29
+---
+
+## Context
+
+ACP defines [`session/close`][session-close] for cancelling ongoing work and
+freeing server-side session resources. Agents advertise support via
+`sessionCapabilities.close`. When supported, `acpx` must send this call before
+terminating the agent process.
+
+[session-close]: https://agentclientprotocol.com/rfds/session-close
+
+## Session close behavior
+
+`AcpClient.close({ sendSessionClose: true })` sends `session/close` for the
+loaded session before terminating the agent process. The call is gated by
+`sessionCapabilities.close`, bounded by `sessionCloseGraceMs` (default 1500 ms),
+and best-effort. Plain `close()` without the option releases the client
+connection and kills the agent without sending `session/close`.
+
+Callers that end the session pass the option:
+
+- `runOnce` (exec/oneshot)
+- `runSessionPrompt` (prompt with own client)
+- `runSessionQueueOwner` (queue owner via `sharedClient`)
+
+Callers that detach without ending the session (e.g. `sessions new`,
+`createSessionWithClient`) call plain `close()`.
+
+`session-control.ts` does not send `session/close`. It terminates the process
+that owns the client.
+
+## Queue owner graceful shutdown
+
+The queue owner runs detached. `sessions close` terminates it via SIGTERM.
+Node.js default SIGTERM exits immediately without running finally blocks, so
+`runSessionQueueOwner` registers a handler:
+
+```js
+const onSigterm = () => {
+  void owner?.close();
+};
+process.on("SIGTERM", onSigterm);
+```
+
+This breaks the `nextTask()` loop so the finally block runs and
+`sharedClient.close()` sends `session/close`. The handler is removed in the
+finally block.
+
+`process.on` is used instead of `once` because the perf-metrics handler
+re-raises SIGTERM after removing itself. During an active prompt,
+`withInterrupt` also fires and cancels the prompt. Both coexist without
+conflict.
+
+## Teardown sequence
+
+```mermaid
+stateDiagram-v2
+    [*] --> SIGTERM_sent: sessions close
+    SIGTERM_sent --> handler_fires: onSigterm
+    handler_fires --> loop_breaks: owner.close()
+    loop_breaks --> finally_block: nextTask() returns undefined
+    finally_block --> session_close_sent: sharedClient.close()
+    session_close_sent --> agent_terminated: terminateAgentProcess
+    agent_terminated --> owner_exits: write record, release lease
+    owner_exits --> pid_check: session-control.ts
+    pid_check --> record_closed: agent already dead, skip kill
+    record_closed --> [*]
+```
+
+`session-control.ts` also attempts to kill the agent PID directly as a
+fallback when the queue owner was already dead.

--- a/docs/2026-04-29-session-close-teardown.md
+++ b/docs/2026-04-29-session-close-teardown.md
@@ -1,6 +1,6 @@
 ---
 title: Guaranteed Session Closure
-description: How acpx ensures ACP session/close is sent to agents before process termination.
+description: How acpx sends ACP session/close before process termination.
 author: Adrian Cole <adrian@tetrate.io>
 date: 2026-04-29
 ---
@@ -16,29 +16,34 @@ terminating the agent process.
 
 ## Session close behavior
 
-`AcpClient.close({ sendSessionClose: true })` sends `session/close` for the
-loaded session before terminating the agent process. The call is gated by
-`sessionCapabilities.close`, bounded by `sessionCloseGraceMs` (default 1500 ms),
-and best-effort. Plain `close()` without the option releases the client
-connection and kills the agent without sending `session/close`.
+`AcpClient.close()` sends `session/close` for the loaded session before
+terminating the agent process. The call is gated by `sessionCapabilities.close`,
+bounded by `sessionCloseGraceMs` (default 1500 ms), and best-effort.
+If no session is loaded, or the agent does not advertise close, `close()`
+just releases the client connection and kills the agent.
 
-Callers that end the session pass the option:
+Callers that end the session call `close()`:
 
 - `runOnce` (exec/oneshot)
 - `runSessionPrompt` (prompt with own client)
+- `FlowRunner.runPersistentPrompt` after the first flow step detaches
+  and later resumes with `session/load`
+- `FlowRunner.closePendingPersistentSessionClients` when a flow run
+  finishes or fails
 - `runSessionQueueOwner` (queue owner via `sharedClient`)
 
-Callers that detach without ending the session (e.g. `sessions new`,
-`createSessionWithClient`) call plain `close()`.
+Callers that detach after creating a session (e.g. `sessions new`,
+`createSessionWithClient`) also call `close()`. Later reconnects can still use
+`session/load`.
 
-`session-control.ts` does not send `session/close`. It terminates the process
-that owns the client.
+`session-control.ts` does not send `session/close`. It terminates
+the process that owns the client.
 
 ## Queue owner graceful shutdown
 
 The queue owner runs detached. `sessions close` terminates it via SIGTERM.
-Node.js default SIGTERM exits immediately without running finally blocks, so
-`runSessionQueueOwner` registers a handler:
+Node.js default SIGTERM exits immediately without running finally
+blocks, so `runSessionQueueOwner` registers a handler:
 
 ```js
 const onSigterm = () => {
@@ -48,13 +53,12 @@ process.on("SIGTERM", onSigterm);
 ```
 
 This breaks the `nextTask()` loop so the finally block runs and
-`sharedClient.close()` sends `session/close`. The handler is removed in the
-finally block.
+`sharedClient.close()` sends `session/close`. The handler is
+removed in the finally block.
 
 `process.on` is used instead of `once` because the perf-metrics handler
-re-raises SIGTERM after removing itself. During an active prompt,
-`withInterrupt` also fires and cancels the prompt. Both coexist without
-conflict.
+re-raises SIGTERM after removing itself. During an active prompt, `withInterrupt`
+also fires and cancels the prompt. Both coexist without conflict.
 
 ## Teardown sequence
 
@@ -72,5 +76,5 @@ stateDiagram-v2
     record_closed --> [*]
 ```
 
-`session-control.ts` also attempts to kill the agent PID directly as a
-fallback when the queue owner was already dead.
+`session-control.ts` also attempts to kill the agent PID directly as a fallback
+when the queue owner was already dead.

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -301,9 +301,14 @@ export class AcpClient {
         this.eventHandlers.onClientOperation?.(operation);
       },
     });
+    const envSessionCloseGraceMs = Number(process.env.ACPX_SESSION_CLOSE_GRACE_MS);
+    const defaultSessionCloseGraceMs =
+      Number.isFinite(envSessionCloseGraceMs) && envSessionCloseGraceMs > 0
+        ? envSessionCloseGraceMs
+        : SESSION_CLOSE_GRACE_MS;
     this.sessionCloseGraceMs = Math.max(
       0,
-      Math.round(this.options.sessionCloseGraceMs ?? SESSION_CLOSE_GRACE_MS),
+      Math.round(this.options.sessionCloseGraceMs ?? defaultSessionCloseGraceMs),
     );
   }
 
@@ -914,12 +919,10 @@ export class AcpClient {
     }
   }
 
-  async close(options?: { sendSessionClose?: boolean }): Promise<void> {
+  async close(): Promise<void> {
     this.closing = true;
 
-    if (options?.sendSessionClose) {
-      await this.tryCloseSession(this.loadedSessionId);
-    }
+    await this.tryCloseSession(this.loadedSessionId);
     await this.terminalManager.shutdown();
 
     const agent = this.agent;

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -104,6 +104,7 @@ const REPLAY_DRAIN_TIMEOUT_MS = 5_000;
 const DRAIN_POLL_INTERVAL_MS = 20;
 const AGENT_CLOSE_TERM_GRACE_MS = 1_500;
 const AGENT_CLOSE_KILL_GRACE_MS = 1_000;
+const SESSION_CLOSE_GRACE_MS = 1_500;
 const STARTUP_STDERR_MAX_CHARS = 8_192;
 
 type LoadSessionOptions = {
@@ -253,6 +254,7 @@ export class AcpClient {
   };
   private readonly filesystem: FileSystemHandlers;
   private readonly terminalManager: TerminalManager;
+  private readonly sessionCloseGraceMs: number;
   private sessionUpdateChain: Promise<void> = Promise.resolve();
   private observedSessionUpdates = 0;
   private processedSessionUpdates = 0;
@@ -299,10 +301,18 @@ export class AcpClient {
         this.eventHandlers.onClientOperation?.(operation);
       },
     });
+    this.sessionCloseGraceMs = Math.max(
+      0,
+      Math.round(this.options.sessionCloseGraceMs ?? SESSION_CLOSE_GRACE_MS),
+    );
   }
 
   get initializeResult(): InitializeResponse | undefined {
     return this.initResult;
+  }
+
+  get closeGraceMs(): number {
+    return this.sessionCloseGraceMs;
   }
 
   getAgentPid(): number | undefined {
@@ -842,13 +852,20 @@ export class AcpClient {
   async closeSession(sessionId: string): Promise<void> {
     const connection = this.getConnection();
     await this.runConnectionRequest(() =>
-      connection.unstable_closeNes({
+      connection.closeSession({
         sessionId,
       }),
     );
     if (this.loadedSessionId === sessionId) {
       this.loadedSessionId = undefined;
     }
+  }
+
+  private async tryCloseSession(sessionId: string | undefined): Promise<void> {
+    if (!sessionId || !this.supportsCloseSession()) {
+      return;
+    }
+    await withTimeout(this.closeSession(sessionId), this.sessionCloseGraceMs).catch(() => {});
   }
 
   async requestCancelActivePrompt(): Promise<boolean> {
@@ -897,9 +914,12 @@ export class AcpClient {
     }
   }
 
-  async close(): Promise<void> {
+  async close(options?: { sendSessionClose?: boolean }): Promise<void> {
     this.closing = true;
 
+    if (options?.sendSessionClose) {
+      await this.tryCloseSession(this.loadedSessionId);
+    }
     await this.terminalManager.shutdown();
 
     const agent = this.agent;

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -266,7 +266,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     if (owner) {
       await owner.close();
     }
-    await sharedClient.close({ sendSessionClose: true }).catch(() => {
+    await sharedClient.close().catch(() => {
       // best effort while queue owner is shutting down
     });
     try {

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -170,6 +170,13 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     }
   };
 
+  // Handle SIGTERM so the finally block runs and sharedClient.close()
+  // sends session/close before the agent process is terminated.
+  const onSigterm = () => {
+    void owner?.close();
+  };
+  process.on("SIGTERM", onSigterm);
+
   try {
     owner = await SessionQueueOwner.start(
       lease,
@@ -251,6 +258,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
       });
     }
   } finally {
+    process.off("SIGTERM", onSigterm);
     if (heartbeatTimer) {
       clearInterval(heartbeatTimer);
     }
@@ -258,7 +266,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     if (owner) {
       await owner.close();
     }
-    await sharedClient.close().catch(() => {
+    await sharedClient.close({ sendSessionClose: true }).catch(() => {
       // best effort while queue owner is shutting down
     });
     try {

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -687,7 +687,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     }
     client.clearEventHandlers();
     if (ownClient) {
-      await client.close({ sendSessionClose: true });
+      await client.close();
     }
     applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
     applyConversation(record, conversation);
@@ -800,7 +800,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
       },
     );
   } finally {
-    await client.close({ sendSessionClose: true });
+    await client.close();
   }
 }
 

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -674,9 +674,6 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
         await flushPendingMessages(false).catch(() => {
           // best effort while process is being interrupted
         });
-        if (ownClient) {
-          await client.close();
-        }
       },
     );
   } finally {
@@ -690,7 +687,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     }
     client.clearEventHandlers();
     if (ownClient) {
-      await client.close();
+      await client.close({ sendSessionClose: true });
     }
     applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
     applyConversation(record, conversation);
@@ -800,11 +797,10 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
       },
       async () => {
         await client.cancelActivePrompt(INTERRUPT_CANCEL_WAIT_MS);
-        await client.close();
       },
     );
   } finally {
-    await client.close();
+    await client.close({ sendSessionClose: true });
   }
 }
 

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -178,7 +178,6 @@ export async function createSessionWithClient(
     verbose: options.verbose,
     sessionOptions: options.sessionOptions,
   });
-
   try {
     const record = await withInterrupt(
       async () => await createSessionRecordWithClient(client, options),

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -44,6 +44,7 @@ export type WithConnectedSessionOptions<T> = {
   terminal?: boolean;
   resumePolicy?: SessionResumePolicy;
   timeoutMs?: number;
+  sessionCloseGraceMs?: number;
   verbose?: boolean;
   onClientAvailable?: (controller: FullConnectedSessionController) => void;
   onClientClosed?: () => void;
@@ -94,6 +95,7 @@ export async function withConnectedSession<T>(
       authPolicy: options.authPolicy,
       terminal: options.terminal,
       verbose: options.verbose,
+      sessionCloseGraceMs: options.sessionCloseGraceMs,
       sessionOptions: sessionOptionsFromRecord(record),
     }) ??
     new AcpClient({
@@ -106,6 +108,7 @@ export async function withConnectedSession<T>(
       authPolicy: options.authPolicy,
       terminal: options.terminal,
       verbose: options.verbose,
+      sessionCloseGraceMs: options.sessionCloseGraceMs,
       sessionOptions: sessionOptionsFromRecord(record),
     });
   let activeSessionIdForControl = record.acpSessionId;
@@ -171,7 +174,6 @@ export async function withConnectedSession<T>(
         await options.saveRecord(record).catch(() => {
           // best effort while process is being interrupted
         });
-        await client.close();
       },
     );
   } finally {

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { AcpClient } from "../../acp/client.js";
 import { normalizeOutputError } from "../../acp/error-normalization.js";
-import { extractAcpError, isAcpResourceNotFoundError } from "../../acp/error-shapes.js";
+import { isAcpResourceNotFoundError } from "../../acp/error-shapes.js";
 import { withTimeout } from "../../async-control.js";
 import { textPrompt, type PromptInput } from "../../prompt-content.js";
 import {
@@ -139,21 +139,6 @@ class AsyncEventQueue {
 
 function isoNow(): string {
   return new Date().toISOString();
-}
-
-function isUnsupportedSessionCloseError(error: unknown): boolean {
-  const acp = extractAcpError(error);
-  if (!acp) {
-    return false;
-  }
-  if (acp.code === -32601 || acp.code === -32602) {
-    return true;
-  }
-  if (acp.code !== -32603 || !acp.data || typeof acp.data !== "object") {
-    return false;
-  }
-  const details = (acp.data as { details?: unknown }).details;
-  return typeof details === "string" && details.toLowerCase().includes("invalid params");
 }
 
 function toPromptInput(
@@ -356,6 +341,7 @@ export class AcpRuntimeManager {
       nonInteractivePermissions: this.options.nonInteractivePermissions,
       verbose: this.options.verbose,
       timeoutMs: this.options.timeoutMs,
+      sessionCloseGraceMs: this.options.sessionCloseGraceMs,
       resumePolicy: resumePolicyForSessionMode(sessionMode),
       run,
     });
@@ -397,6 +383,7 @@ export class AcpRuntimeManager {
       permissionMode: this.options.permissionMode,
       nonInteractivePermissions: this.options.nonInteractivePermissions,
       verbose: this.options.verbose,
+      sessionCloseGraceMs: this.options.sessionCloseGraceMs,
     });
     let keepClientOpen = false;
 
@@ -538,6 +525,7 @@ export class AcpRuntimeManager {
             permissionMode: this.options.permissionMode,
             nonInteractivePermissions: this.options.nonInteractivePermissions,
             verbose: this.options.verbose,
+            sessionCloseGraceMs: this.options.sessionCloseGraceMs,
           });
         const runtimeClient = client;
         const runtimeConversation = conversation;
@@ -745,8 +733,8 @@ export class AcpRuntimeManager {
             pooled = await this.retainPersistentClientAfterTurn({ record, client });
           }
         }
-        if (!pooled) {
-          await client?.close().catch(() => {});
+        if (!pooled && client) {
+          await client.close().catch(() => {});
         }
         if (record) {
           this.activeControllers.delete(record.acpxRecordId);
@@ -902,6 +890,7 @@ export class AcpRuntimeManager {
         permissionMode: this.options.permissionMode,
         nonInteractivePermissions: this.options.nonInteractivePermissions,
         verbose: this.options.verbose,
+        sessionCloseGraceMs: this.options.sessionCloseGraceMs,
       });
 
     try {
@@ -914,15 +903,8 @@ export class AcpRuntimeManager {
           `Agent does not support session/close for ${record.acpxRecordId}.`,
         );
       }
-      await withTimeout(client.closeSession(record.acpSessionId), this.options.timeoutMs);
+      await withTimeout(client.closeSession(record.acpSessionId), client.closeGraceMs);
     } catch (error) {
-      if (isUnsupportedSessionCloseError(error)) {
-        throw new AcpRuntimeError(
-          "ACP_BACKEND_UNSUPPORTED_CONTROL",
-          `Agent does not support session/close for ${record.acpxRecordId}.`,
-          { cause: error },
-        );
-      }
       if (isAcpResourceNotFoundError(error)) {
         return;
       }

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -191,6 +191,7 @@ export type AcpRuntimeOptions = {
   permissionMode: PermissionMode;
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   timeoutMs?: number;
+  sessionCloseGraceMs?: number;
   probeAgent?: string;
   verbose?: boolean;
 };

--- a/src/runtime/public/probe.ts
+++ b/src/runtime/public/probe.ts
@@ -72,6 +72,7 @@ export async function probeRuntime(
       permissionMode: options.permissionMode,
       nonInteractivePermissions: options.nonInteractivePermissions,
       verbose: options.verbose,
+      sessionCloseGraceMs: options.sessionCloseGraceMs,
     }) ??
     new AcpClient({
       agentCommand,
@@ -80,6 +81,7 @@ export async function probeRuntime(
       permissionMode: options.permissionMode,
       nonInteractivePermissions: options.nonInteractivePermissions,
       verbose: options.verbose,
+      sessionCloseGraceMs: options.sessionCloseGraceMs,
     });
 
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,7 @@ export type AcpClientOptions = {
   terminal?: boolean;
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
+  sessionCloseGraceMs?: number;
   sessionOptions?: {
     model?: string;
     allowedTools?: string[];

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -574,7 +574,7 @@ test("AcpClient closes sessions through session/close and clears the loaded sess
   };
   internals.loadedSessionId = "session-close-1";
   internals.connection = {
-    unstable_closeNes: async (params: { sessionId: string }) => {
+    closeSession: async (params: { sessionId: string }) => {
       capturedCloseSessionParams = params;
       return {};
     },
@@ -587,6 +587,72 @@ test("AcpClient closes sessions through session/close and clears the loaded sess
     sessionId: "session-close-1",
   });
   assert.equal(internals.loadedSessionId, undefined);
+});
+
+test("close skips session/close when sendSessionClose is not set", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let calls = 0;
+  internals.connection = {
+    closeSession: async () => {
+      calls += 1;
+      return {};
+    },
+  };
+  internals.loadedSessionId = "some-session";
+  internals.initResult = { agentCapabilities: { sessionCapabilities: { close: {} } } };
+
+  await client.close();
+
+  assert.equal(calls, 0);
+});
+
+test("close skips session/close when capability is missing", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let calls = 0;
+  internals.connection = {
+    closeSession: async () => {
+      calls += 1;
+      return {};
+    },
+  };
+  internals.loadedSessionId = "some-session";
+  internals.initResult = { agentCapabilities: {} };
+
+  await client.close({ sendSessionClose: true });
+
+  assert.equal(calls, 0);
+});
+
+test("close sends session/close for the loaded session when sendSessionClose is set", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let closedSessionId: string | undefined;
+  internals.initResult = { agentCapabilities: { sessionCapabilities: { close: {} } } };
+  internals.loadedSessionId = "close-on-shutdown";
+  internals.connection = {
+    closeSession: async (params: { sessionId: string }) => {
+      closedSessionId = params.sessionId;
+      return {};
+    },
+  };
+
+  await client.close({ sendSessionClose: true });
+
+  assert.equal(closedSessionId, "close-on-shutdown");
+});
+
+test("close respects grace timeout when session/close hangs", async () => {
+  const client = makeClient({ sessionCloseGraceMs: 10 });
+  const internals = asInternals(client);
+  internals.initResult = { agentCapabilities: { sessionCapabilities: { close: {} } } };
+  internals.loadedSessionId = "hung-session";
+  internals.connection = { closeSession: () => new Promise<void>(() => {}) };
+
+  const start = Date.now();
+  await client.close({ sendSessionClose: true });
+  assert.ok(Date.now() - start < 200);
 });
 
 test("AcpClient session update handling drains queued callbacks and swallows handler failures", async () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -589,24 +589,6 @@ test("AcpClient closes sessions through session/close and clears the loaded sess
   assert.equal(internals.loadedSessionId, undefined);
 });
 
-test("close skips session/close when sendSessionClose is not set", async () => {
-  const client = makeClient();
-  const internals = asInternals(client);
-  let calls = 0;
-  internals.connection = {
-    closeSession: async () => {
-      calls += 1;
-      return {};
-    },
-  };
-  internals.loadedSessionId = "some-session";
-  internals.initResult = { agentCapabilities: { sessionCapabilities: { close: {} } } };
-
-  await client.close();
-
-  assert.equal(calls, 0);
-});
-
 test("close skips session/close when capability is missing", async () => {
   const client = makeClient();
   const internals = asInternals(client);
@@ -620,12 +602,12 @@ test("close skips session/close when capability is missing", async () => {
   internals.loadedSessionId = "some-session";
   internals.initResult = { agentCapabilities: {} };
 
-  await client.close({ sendSessionClose: true });
+  await client.close();
 
   assert.equal(calls, 0);
 });
 
-test("close sends session/close for the loaded session when sendSessionClose is set", async () => {
+test("close sends session/close for the loaded session", async () => {
   const client = makeClient();
   const internals = asInternals(client);
   let closedSessionId: string | undefined;
@@ -638,7 +620,7 @@ test("close sends session/close for the loaded session when sendSessionClose is 
     },
   };
 
-  await client.close({ sendSessionClose: true });
+  await client.close();
 
   assert.equal(closedSessionId, "close-on-shutdown");
 });
@@ -651,8 +633,23 @@ test("close respects grace timeout when session/close hangs", async () => {
   internals.connection = { closeSession: () => new Promise<void>(() => {}) };
 
   const start = Date.now();
-  await client.close({ sendSessionClose: true });
+  await client.close();
   assert.ok(Date.now() - start < 200);
+});
+
+test("close reads grace timeout from ACPX_SESSION_CLOSE_GRACE_MS", async () => {
+  await withEnv({ ACPX_SESSION_CLOSE_GRACE_MS: "10" }, async () => {
+    const client = makeClient();
+    const internals = asInternals(client);
+    internals.initResult = { agentCapabilities: { sessionCapabilities: { close: {} } } };
+    internals.loadedSessionId = "env-hung-session";
+    internals.connection = { closeSession: () => new Promise<void>(() => {}) };
+
+    assert.equal(client.closeGraceMs, 10);
+    const start = Date.now();
+    await client.close();
+    assert.ok(Date.now() - start < 200);
+  });
 });
 
 test("AcpClient session update handling drains queued callbacks and swallows handler failures", async () => {

--- a/test/fixtures/flow-single-acp.flow.ts
+++ b/test/fixtures/flow-single-acp.flow.ts
@@ -1,0 +1,15 @@
+import { acp, defineFlow, extractJsonObject } from "acpx/flows";
+
+export default defineFlow({
+  name: "fixture-single-acp",
+  startAt: "only",
+  nodes: {
+    only: acp({
+      async prompt() {
+        return 'echo {"ok":true}';
+      },
+      parse: (text) => extractJsonObject(text),
+    }),
+  },
+  edges: [],
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -31,6 +31,9 @@ const FLOW_INTERRUPT_FIXTURE_PATH = fileURLToPath(
 const FLOW_ACP_DISCONNECT_FIXTURE_PATH = fileURLToPath(
   new URL("./fixtures/flow-acp-disconnect.flow.js", import.meta.url),
 );
+const FLOW_SINGLE_ACP_FIXTURE_PATH = fileURLToPath(
+  new URL("./fixtures/flow-single-acp.flow.js", import.meta.url),
+);
 const FLOW_WAIT_FIXTURE_PATH = fileURLToPath(
   new URL("./fixtures/flow-wait.flow.js", import.meta.url),
 );
@@ -108,8 +111,18 @@ test("integration: exec sends session/close before teardown when supported", asy
       );
 
       const closeRequest = payloads[closeIndex] as { params?: { sessionId?: string } };
+      const closeRequestId = extractJsonRpcId(closeRequest);
       assert.equal(typeof closeRequest.params?.sessionId, "string");
       assert.notEqual(closeRequest.params?.sessionId?.length, 0);
+      assert.notEqual(closeRequestId, undefined);
+      assert.equal(
+        payloads.some(
+          (message) =>
+            extractJsonRpcId(message) === closeRequestId && Object.hasOwn(message, "result"),
+        ),
+        true,
+        result.stdout,
+      );
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
@@ -181,6 +194,46 @@ test("integration: flow run executes multiple ACP steps in one session and branc
         1,
         JSON.stringify(payload, null, 2),
       );
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: flow run sends session/close when detaching the initial persistent ACP client", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const markerPath = path.join(cwd, "flow-close-session-marker.txt");
+    const closeCapableAgentCommand =
+      `${MOCK_AGENT_COMMAND} --supports-load-session ` +
+      `--close-session-marker ${JSON.stringify(markerPath)}`;
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          closeCapableAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "flow",
+          "run",
+          FLOW_SINGLE_ACP_FIXTURE_PATH,
+        ],
+        homeDir,
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      const payload = JSON.parse(result.stdout.trim()) as {
+        sessionBindings?: Record<string, { acpSessionId: string }>;
+        outputs?: Record<string, unknown>;
+      };
+      const [binding] = Object.values(payload.sessionBindings ?? {});
+
+      assert.deepEqual(payload.outputs?.only, { ok: true });
+      assert.equal(await fs.readFile(markerPath, "utf8"), binding?.acpSessionId);
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -68,6 +68,54 @@ test("integration: exec echo baseline", async () => {
   });
 });
 
+test("integration: exec sends session/close before teardown when supported", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const closeCapableAgentCommand = `${MOCK_AGENT_COMMAND} --supports-close-session`;
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          closeCapableAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "exec",
+          "echo hello",
+        ],
+        homeDir,
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+
+      // session/close must appear after the prompt result
+      const promptResultIndex = payloads.findIndex(
+        (p) => "result" in p && (p.result as { stopReason?: string })?.stopReason === "end_turn",
+      );
+      const closeIndex = payloads.findIndex(
+        (p) => p.method === "session/close" && extractJsonRpcId(p) !== undefined,
+      );
+      assert.notEqual(promptResultIndex, -1, "expected prompt result in output");
+      assert.notEqual(closeIndex, -1, `expected session/close in output:\n${result.stdout}`);
+      assert.ok(
+        closeIndex > promptResultIndex,
+        `session/close (index ${closeIndex}) must come after prompt result (index ${promptResultIndex})`,
+      );
+
+      const closeRequest = payloads[closeIndex] as { params?: { sessionId?: string } };
+      assert.equal(typeof closeRequest.params?.sessionId, "string");
+      assert.notEqual(closeRequest.params?.sessionId?.length, 0);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: built-in cursor agent resolves to cursor-agent acp", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -1117,7 +1165,7 @@ test("integration: exec --model fails when session/set_model fails", async () =>
 test("integration: sessions new --model fails when session/set_model fails", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
-    const failModelAgentCommand = `${MOCK_AGENT_COMMAND} --set-session-model-fails`;
+    const failModelAgentCommand = `${MOCK_AGENT_COMMAND} --set-session-model-fails --supports-close-session`;
 
     try {
       const result = await runCli(
@@ -2311,6 +2359,107 @@ test("integration: prompt reuses warm queue owner and agent pid across turns", a
         throw new Error("queue owner lock missing pid");
       }
       assert.equal(await waitForPidExit(lockTwo.pid, 5_000), true);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// Proves the SIGTERM teardown path: sessions close -> SIGTERM -> queue owner
+// finally block -> sharedClient.close() -> session/close sent to agent.
+// The mock agent writes a marker file when it receives closeSession, so the
+// file only exists if the full chain succeeded.
+test("integration: sessions close sends session/close to agent via queue owner SIGTERM teardown", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    // mock-agent writes the ACP session id here when it receives session/close
+    const markerPath = path.join(cwd, "close-session-marker.txt");
+
+    try {
+      const closeCapableAgentCommand = `${MOCK_AGENT_COMMAND} --close-session-marker ${JSON.stringify(markerPath)}`;
+
+      // Create a persistent session with a close-capable agent
+      const created = await runCli(
+        [
+          "--agent",
+          closeCapableAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "sessions",
+          "new",
+        ],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+      const createdEvent = JSON.parse(created.stdout.trim()) as {
+        acpxRecordId?: string;
+      };
+      const sessionId = createdEvent.acpxRecordId;
+      assert.equal(typeof sessionId, "string");
+
+      // Send a prompt to spawn the detached queue owner
+      const prompt = await runCli(
+        [
+          "--agent",
+          closeCapableAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "quiet",
+          "prompt",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.equal(prompt.code, 0, prompt.stderr);
+
+      // Record the queue owner PID so we can wait for it
+      const { lockPath } = queuePaths(homeDir, sessionId as string);
+      const lock = JSON.parse(await fs.readFile(lockPath, "utf8")) as {
+        pid?: number;
+      };
+      assert.equal(typeof lock.pid, "number");
+
+      // sessions close SIGTERMs the queue owner
+      const closed = await runCli(
+        [
+          "--agent",
+          closeCapableAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "sessions",
+          "close",
+        ],
+        homeDir,
+      );
+      assert.equal(closed.code, 0, closed.stderr);
+      assert.equal(await waitForPidExit(lock.pid as number, 5_000), true);
+
+      // The marker file proves session/close reached the agent
+      const markerContent = await fs.readFile(markerPath, "utf8");
+      assert.ok(markerContent.length > 0, "marker file should contain session id");
+
+      const sessionRecordPath = path.join(
+        homeDir,
+        ".acpx",
+        "sessions",
+        `${encodeURIComponent(sessionId as string)}.json`,
+      );
+      const record = JSON.parse(await fs.readFile(sessionRecordPath, "utf8")) as {
+        acp_session_id?: string;
+      };
+      assert.equal(
+        markerContent,
+        record.acp_session_id,
+        "marker should contain the ACP session id from the session record",
+      );
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
 import { randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
 import { Readable, Writable } from "node:stream";
 import {
   AgentSideConnection,
+  type CloseSessionRequest,
+  type CloseSessionResponse,
   PROTOCOL_VERSION,
   RequestError,
   ndJsonStream,
@@ -36,6 +39,8 @@ type MockAgentOptions = {
   newSessionMeta?: Record<string, string>;
   loadSessionMeta?: Record<string, string>;
   supportsLoadSession: boolean;
+  supportsCloseSession: boolean;
+  closeSessionMarker?: string;
   loadSessionNotFound: boolean;
   loadSessionFailsOnEmpty: boolean;
   setSessionModeFails: boolean;
@@ -300,6 +305,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   const newSessionMeta: Record<string, string> = {};
   const loadSessionMeta: Record<string, string> = {};
   let supportsLoadSession = false;
+  let supportsCloseSession = false;
+  let closeSessionMarker: string | undefined;
   let loadSessionNotFound = false;
   let loadSessionFailsOnEmpty = false;
   let setSessionModeFails = false;
@@ -318,6 +325,18 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
 
     if (token === "--supports-load-session") {
       supportsLoadSession = true;
+      continue;
+    }
+
+    if (token === "--supports-close-session") {
+      supportsCloseSession = true;
+      continue;
+    }
+
+    if (token === "--close-session-marker") {
+      supportsCloseSession = true;
+      closeSessionMarker = parseOptionValue(argv, index + 1, token);
+      index += 1;
       continue;
     }
 
@@ -416,6 +435,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     newSessionMeta: Object.keys(newSessionMeta).length > 0 ? { ...newSessionMeta } : undefined,
     loadSessionMeta: Object.keys(loadSessionMeta).length > 0 ? { ...loadSessionMeta } : undefined,
     supportsLoadSession,
+    supportsCloseSession,
+    closeSessionMarker,
     loadSessionNotFound,
     loadSessionFailsOnEmpty,
     setSessionModeFails,
@@ -512,10 +533,20 @@ class MockAgent implements Agent {
   }
 
   async initialize(): Promise<InitializeResponse> {
+    const agentCapabilities: NonNullable<InitializeResponse["agentCapabilities"]> = {};
+    if (this.options.supportsLoadSession) {
+      agentCapabilities.loadSession = true;
+    }
+    if (this.options.supportsCloseSession) {
+      agentCapabilities.sessionCapabilities = {
+        close: {},
+      };
+    }
+
     return {
       protocolVersion: PROTOCOL_VERSION,
       authMethods: [],
-      agentCapabilities: this.options.supportsLoadSession ? { loadSession: true } : {},
+      agentCapabilities,
     };
   }
 
@@ -668,6 +699,25 @@ class MockAgent implements Agent {
 
   async cancel(params: { sessionId: SessionId }): Promise<void> {
     this.sessions.get(params.sessionId)?.pendingPrompt?.abort();
+  }
+
+  async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
+    if (!this.options.supportsCloseSession) {
+      throw new Error("closeSession is not supported");
+    }
+
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw RequestError.resourceNotFound(params.sessionId);
+    }
+
+    if (this.options.closeSessionMarker) {
+      writeFileSync(this.options.closeSessionMarker, params.sessionId, "utf8");
+    }
+
+    session.pendingPrompt?.abort();
+    this.sessions.delete(params.sessionId);
+    return {};
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -246,6 +246,50 @@ test("AcpRuntimeManager creates a fresh record for each oneshot session", async 
   assert.equal(store.records.size, 2);
 });
 
+test("AcpRuntimeManager closes the client when record save fails during ensureSession", async () => {
+  const store = new InMemorySessionStore();
+  store.save = async () => {
+    throw new Error("save failed");
+  };
+
+  let closeCalls = 0;
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          initializeResult: {
+            protocolVersion: 1,
+            agentCapabilities: {},
+          },
+          start: async () => {},
+          close: async () => {
+            closeCalls += 1;
+          },
+          createSession: async () => ({
+            sessionId: "fresh-session",
+            agentSessionId: "fresh-agent-session",
+          }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+        }) as never,
+    },
+  );
+
+  await assert.rejects(
+    async () =>
+      await manager.ensureSession({
+        sessionKey: "failing-save-session",
+        agent: "codex",
+        mode: "persistent",
+        cwd: "/workspace",
+      }),
+    /save failed/,
+  );
+
+  assert.equal(closeCalls, 1);
+  assert.equal(store.records.size, 0);
+});
+
 test("AcpRuntimeManager streams runtime events and saves updated status", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "turn-session",
@@ -1261,6 +1305,7 @@ test("AcpRuntimeManager closes the backend session when discarding persistent st
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
           supportsCloseSession: () => true,
+          closeGraceMs: 1_500,
           closeSession: async (sessionId: string) => {
             closedSessionIds.push(sessionId);
           },
@@ -1305,6 +1350,7 @@ test("AcpRuntimeManager closes the backend session when discarding persistent st
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
           supportsCloseSession: () => true,
+          closeGraceMs: 1_500,
           closeSession: async () => {},
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
@@ -1359,6 +1405,7 @@ test("AcpRuntimeManager treats missing backend sessions as a successful discard 
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
           supportsCloseSession: () => true,
+          closeGraceMs: 1_500,
           closeSession: async () => {
             throw { error: { code: -32002, message: "session not found" } };
           },
@@ -1387,7 +1434,7 @@ test("AcpRuntimeManager treats missing backend sessions as a successful discard 
   assert.equal(closed?.acpx?.reset_on_next_ensure, true);
 });
 
-test("AcpRuntimeManager applies timeoutMs to backend session shutdown during discard reset", async () => {
+test("AcpRuntimeManager applies sessionCloseGraceMs to backend session shutdown during discard reset", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "discard-timeout-session",
     acpSessionId: "slow-backend-session",
@@ -1400,7 +1447,11 @@ test("AcpRuntimeManager applies timeoutMs to backend session shutdown during dis
   let closeSessionCalls = 0;
   const never = new Promise<void>(() => {});
   const manager = new AcpRuntimeManager(
-    createRuntimeOptions({ cwd: "/workspace", sessionStore: store, timeoutMs: 5 }),
+    createRuntimeOptions({
+      cwd: "/workspace",
+      sessionStore: store,
+      sessionCloseGraceMs: 5,
+    }),
     {
       clientFactory: () =>
         ({
@@ -1415,6 +1466,7 @@ test("AcpRuntimeManager applies timeoutMs to backend session shutdown during dis
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
           supportsCloseSession: () => true,
+          closeGraceMs: 5,
           closeSession: async () => {
             closeSessionCalls += 1;
             await never;

--- a/test/runtime-test-helpers.ts
+++ b/test/runtime-test-helpers.ts
@@ -144,11 +144,13 @@ export function createRuntimeOptions(params: {
   sessionStore: AcpSessionStore;
   agentRegistry?: AcpAgentRegistry;
   timeoutMs?: number;
+  sessionCloseGraceMs?: number;
 }): AcpRuntimeOptions {
   return {
     cwd: params.cwd,
     sessionStore: params.sessionStore,
     timeoutMs: params.timeoutMs,
+    sessionCloseGraceMs: params.sessionCloseGraceMs,
     agentRegistry: params.agentRegistry ?? {
       resolve(agentName: string) {
         return `${agentName} --acp`;


### PR DESCRIPTION
Migrate from nes/close to session/close. Add sendSessionClose option to AcpClient.close() so callers that end a session can request session/close before the agent is killed, while callers that detach (e.g. sessions new) skip it. Add a SIGTERM handler to the queue owner so its finally block runs when sessions close sends the signal.