### PR TITLE
feat: forward detailCode on AcpRuntimeTurnResultError

### DIFF
--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -722,6 +722,7 @@ export class AcpRuntimeManager {
             message: normalized.message,
             ...(normalized.code ? { code: normalized.code } : {}),
             ...(normalized.retryable !== undefined ? { retryable: normalized.retryable } : {}),
+            ...(normalized.detailCode ? { detailCode: normalized.detailCode } : {}),
           },
         });
       } finally {

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -123,6 +123,7 @@ export type AcpRuntimeTurnResultError = {
   message: string;
   code?: string;
   retryable?: boolean;
+  detailCode?: string;
 };
 
 export type AcpRuntimeTurnResult =

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
+import { AcpxOperationalError } from "../src/errors.js";
 import { AcpRuntimeManager } from "../src/runtime/engine/manager.js";
 import type {
   AcpRuntimeEvent,
@@ -1649,6 +1650,7 @@ test("AcpRuntimeManager fails persistent turns clearly when session/load is unav
     status: "failed",
     error: {
       code: "RUNTIME",
+      detailCode: "SESSION_RESUME_REQUIRED",
       message:
         "Persistent ACP session persistent-backend-session could not be resumed: agent does not support session/load",
       retryable: true,
@@ -1656,6 +1658,56 @@ test("AcpRuntimeManager fails persistent turns clearly when session/load is unav
   });
   assert.equal(createSessionCalls, 0);
   assert.equal(promptCalls, 0);
+});
+
+test("AcpRuntimeManager forwards normalized detailCode on turn failures", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "detail-code-session",
+    acpSessionId: "detail-code-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => true,
+          supportsLoadSession: () => true,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async () => {
+            throw new AcpxOperationalError("simulated adapter failure", {
+              detailCode: "AGENT_DISCONNECTED",
+              origin: "acp",
+            });
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("detail-code-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-detail-code",
+  });
+  const { result } = await collectTurn(turn);
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.error?.detailCode, "AGENT_DISCONNECTED");
 });
 
 test("AcpRuntimeManager still falls back to a fresh session for oneshot turns", async () => {


### PR DESCRIPTION
## Summary

Adds an optional `detailCode` field to `AcpRuntimeTurnResultError`, forwarded from the existing `NormalizedOutputError`. acpx already classifies errors internally (`AUTH_REQUIRED`, `AGENT_DISCONNECTED`, `AGENT_STARTUP_FAILED`, `SESSION_RESUME_REQUIRED`, ...), but `src/runtime/engine/manager.ts:716-726` was dropping the classification before the result reached consumers.

## Why

Embedding `acpx/runtime` in a long-running coding-agent loop. The harness needs to distinguish "permanent failure, give up immediately" from "transient error, retry with backoff" without substring-matching `error.message`. `retryable` is one bit and collapses cases that warrant different harness behavior - `AUTH_REQUIRED` is terminal, `AGENT_STARTUP_FAILED` often means "tell the user to install the adapter," both are non-retryable but the right response differs.

Reference consumer: https://github.com/kunchenguid/gnhf

## Tests

- updated the existing "fails persistent turns clearly" assertion - `SESSION_RESUME_REQUIRED` was already being computed internally and is now visible at the result boundary, which is the change in shape
- new dedicated test "forwards normalized detailCode on turn failures" using `AcpxOperationalError` with a known `detailCode`

## Open questions

**Legacy event variant.** There's a parallel `type: "error"` event in `src/runtime/public/contract.ts:115-120` emitted by `runTurn(...)` for back-compat consumers. For symmetry, `detailCode` could appear there too. Left it out of this PR to keep the surface area small. Happy to follow up if maintainers want symmetry, or to leave the legacy event frozen on purpose.

**`string` vs typed union.** `detailCode: string` matches the internal type. A typed union (`"AUTH_REQUIRED" | "AGENT_DISCONNECTED" | ...`) at the public boundary would be friendlier to consumers but locks the values in. Went with `string` (easier to evolve), happy to be talked out of it.