### PR TITLE
fix(win32): resolve Claude Code executable path for ACP spawn

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,6 +27,7 @@
     "eslint/no-self-compare": "error",
     "eslint/no-sequences": "error",
     "eslint/no-shadow": "off",
+    "eslint/no-underscore-dangle": ["error", { "allow": ["_meta"] }],
     "eslint/no-unmodified-loop-condition": "error",
     "eslint/no-useless-call": "error",
     "eslint/no-useless-computed-key": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
+- Windows/Claude: resolve the `claude.exe` executable from PATH before spawning Claude ACP sessions, so native Windows launches do not depend on shell-specific command lookup. (#289) Thanks @MikeChongCan.
 
 ## 2026.4.25 (v0.6.0)
 

--- a/src/acp/agent-command.ts
+++ b/src/acp/agent-command.ts
@@ -1,6 +1,11 @@
 import { spawn } from "node:child_process";
+import path from "node:path";
 import { CopilotAcpUnsupportedError } from "../errors.js";
-import { buildSpawnCommandOptions } from "../spawn-command-options.js";
+import {
+  buildSpawnCommandOptions,
+  readWindowsEnvValue,
+  resolveWindowsCommand,
+} from "../spawn-command-options.js";
 import { type AcpClientOptions } from "../types.js";
 import { basenameToken, splitCommandLine } from "./client-process.js";
 
@@ -320,4 +325,21 @@ export function buildClaudeCodeOptionsMeta(
   }
 
   return meta;
+}
+
+export function resolveClaudeCodeExecutable(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (platform !== "win32") {
+    return undefined;
+  }
+  if (readWindowsEnvValue(env, "CLAUDE_CODE_EXECUTABLE")) {
+    return undefined;
+  }
+  const resolved = resolveWindowsCommand("claude", env);
+  if (!resolved) {
+    return undefined;
+  }
+  return path.resolve(resolved);
 }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -64,6 +64,7 @@ import {
   isQoderAcpCommand,
   resolveAgentCloseAfterStdinEndMs,
   resolveClaudeAcpSessionCreateTimeoutMs,
+  resolveClaudeCodeExecutable,
   resolveGeminiAcpStartupTimeoutMs,
   resolveGeminiCommandArgs,
   shouldIgnoreNonJsonAgentOutputLine,
@@ -436,13 +437,23 @@ export class AcpClient {
       await ensureCopilotAcpSupport(spawnCommand);
     }
 
+    const agentSpawnOptions = buildAgentSpawnOptions(
+      this.options.cwd,
+      this.options.authCredentials,
+    );
+    const claudeAcp = isClaudeAcpCommand(spawnCommand, args);
+    if (claudeAcp) {
+      const claudeExe = resolveClaudeCodeExecutable(process.platform, agentSpawnOptions.env);
+      if (claudeExe) {
+        agentSpawnOptions.env.CLAUDE_CODE_EXECUTABLE = claudeExe;
+        this.log(`resolved system Claude Code executable: ${claudeExe}`);
+      }
+    }
+
     const spawnedChild = spawn(
       spawnCommand,
       args,
-      buildSpawnCommandOptions(
-        spawnCommand,
-        buildAgentSpawnOptions(this.options.cwd, this.options.authCredentials),
-      ),
+      buildSpawnCommandOptions(spawnCommand, agentSpawnOptions),
     ) as ChildProcessByStdio<Writable, Readable, Readable>;
 
     try {

--- a/src/spawn-command-options.ts
+++ b/src/spawn-command-options.ts
@@ -2,12 +2,12 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-function readWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+export function readWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const matchedKey = Object.keys(env).find((entry) => entry.toUpperCase() === key);
   return matchedKey ? env[matchedKey] : undefined;
 }
 
-function resolveWindowsCommand(
+export function resolveWindowsCommand(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { resolveClaudeCodeExecutable } from "../src/acp/agent-command.js";
 import { resolveAgentSessionCwd } from "../src/acp/client-process.js";
 import { buildAgentSpawnOptions, buildSpawnCommandOptions } from "../src/acp/client.js";
 import { buildTerminalSpawnOptions } from "../src/acp/terminal-manager.js";
@@ -226,4 +227,59 @@ test("buildTerminalSpawnOptions keeps shell disabled for non-batch commands", as
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test("resolveClaudeCodeExecutable finds claude.exe on PATH on Windows", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-claude-exe-"));
+  try {
+    await fs.writeFile(path.join(tempDir, "claude.exe"), "");
+    const env = { PATH: tempDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" } as NodeJS.ProcessEnv;
+    const result = resolveClaudeCodeExecutable("win32", env);
+    assert.equal(result, path.join(tempDir, "claude.exe"));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveClaudeCodeExecutable returns undefined when CLAUDE_CODE_EXECUTABLE is already set", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-claude-exe-"));
+  try {
+    await fs.writeFile(path.join(tempDir, "claude.exe"), "");
+    const env = {
+      PATH: tempDir,
+      PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      CLAUDE_CODE_EXECUTABLE: "/custom/claude",
+    } as NodeJS.ProcessEnv;
+    const result = resolveClaudeCodeExecutable("win32", env);
+    assert.equal(result, undefined);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveClaudeCodeExecutable respects case-insensitive env var on Windows", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-claude-exe-"));
+  try {
+    await fs.writeFile(path.join(tempDir, "claude.exe"), "");
+    const env = {
+      PATH: tempDir,
+      PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      claude_code_executable: "/custom/claude",
+    } as NodeJS.ProcessEnv;
+    const result = resolveClaudeCodeExecutable("win32", env);
+    assert.equal(result, undefined);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveClaudeCodeExecutable returns undefined on non-Windows platforms", () => {
+  const result = resolveClaudeCodeExecutable("linux", { PATH: "/usr/bin" } as NodeJS.ProcessEnv);
+  assert.equal(result, undefined);
+});
+
+test("resolveClaudeCodeExecutable returns undefined when claude is not on PATH", () => {
+  const env = { PATH: "/nonexistent", PATHEXT: ".COM;.EXE;.BAT;.CMD" } as NodeJS.ProcessEnv;
+  const result = resolveClaudeCodeExecutable("win32", env);
+  assert.equal(result, undefined);
 });


### PR DESCRIPTION
On Windows, when CLAUDE_CODE_EXECUTABLE is not already set, resolve claude.exe on PATH and inject it into the spawn environment before starting the ACP child process. This avoids path-resolution failures in environments where the shell's PATH lookup does not work the same way as Node's spawn.

## Changes

- Exports readWindowsEnvValue and resolveWindowsCommand from spawn-command-options.ts so they can be reused
- Adds resolveClaudeCodeExecutable in agent-command.ts that resolves the absolute path to claude.exe on Windows
- AcpClient calls resolveClaudeCodeExecutable before spawning a Claude ACP process and injects CLAUDE_CODE_EXECUTABLE when found
- Adds full test coverage for resolveClaudeCodeExecutable