### PR TITLE
fix: closeSession uses session/close not nes/close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
 - Windows/Claude: resolve the `claude.exe` executable from PATH before spawning Claude ACP sessions, so native Windows launches do not depend on shell-specific command lookup. (#289) Thanks @MikeChongCan.
+- Client/ACP: send `session/close` from `closeSession()` instead of the experimental `nes/close` method, so adapters without NES support can tear down sessions cleanly. (#291) Thanks @hexsprite.
 
 ## 2026.4.25 (v0.6.0)
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -853,7 +853,7 @@ export class AcpClient {
   async closeSession(sessionId: string): Promise<void> {
     const connection = this.getConnection();
     await this.runConnectionRequest(() =>
-      connection.unstable_closeNes({
+      connection.closeSession({
         sessionId,
       }),
     );

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -574,7 +574,7 @@ test("AcpClient closes sessions through session/close and clears the loaded sess
   };
   internals.loadedSessionId = "session-close-1";
   internals.connection = {
-    unstable_closeNes: async (params: { sessionId: string }) => {
+    closeSession: async (params: { sessionId: string }) => {
       capturedCloseSessionParams = params;
       return {};
     },


### PR DESCRIPTION
## What & why

`AcpClient.closeSession()` in `src/acp/client.ts:842` was calling `connection.unstable_closeNes(...)`, which sends the `nes/close` JSON-RPC method (Next Edit Suggestion feature) — instead of `connection.closeSession(...)`, which sends `session/close`.

Any agent that does not implement the experimental NES surface (e.g. `claude-agent-acp`) rejects with `-32601 "Method not found"`. That cascades into `ACP_BACKEND_UNSUPPORTED_CONTROL` and finally surfaces to embedders as a generic `ACP_TURN_FAILED` on session teardown. From the embedder's perspective the agent looks broken; the real failure is acpx asking the wrong method.

This PR is a one-character call-site fix plus the matching test mock fix.

## How the bug got in

| Commit | Change |
|---|---|
| `b7cc36c` ("fix: improve live session history and error hints", 2026-04-25) | `connection.closeSession` → `connection.unstable_closeSession`. The latter does not exist on the ACP SDK `Connection` type; would normally be a TS error. |
| `013f2fd` ("fix: use locked ACP SDK close API") | `unstable_closeSession` → `unstable_closeNes`. Picked the nearest existing `unstable_*` method by name — but `unstable_closeNes` is for the NES feature, not session lifecycle. |

This PR restores the original correct call (`connection.closeSession`).

## Why CI passed

`test/client.test.ts:564` is named `"AcpClient closes sessions through session/close and clears the loaded session id"`, but the mock at line 577 stubbed `unstable_closeNes`:

```ts
internals.connection = {
  unstable_closeNes: async (params: { sessionId: string }) => { … },
};
```

Production code and the mock were both wrong, in matching ways, so the test passed against the bug. This PR updates the mock to stub `closeSession`, which is what the test name has always advertised.

## ACP SDK reference (`@agentclientprotocol/sdk` ^0.21.0)

- `acp.d.ts:343` — `closeSession(...)` → wire method `session/close`
- `acp.d.ts:484` — `unstable_closeNes(...)` → wire method `nes/close`
- `schema/index.d.ts:12,20` — `nes_close: "nes/close"`, `session_close: "session/close"`

Two distinct methods on the connection. `closeSession` is the right one for `AcpClient.closeSession()`.

## Repro

1. Connect acpx to a `claude-agent-acp` backend (or any agent that does not implement `nes/close`).
2. Drive a session through to natural completion — anything that exercises `AcpClient.closeSession()` on cleanup.
3. Observe in agent stderr / acpx error path:
   - `RequestError: "Method not found": nes/close (-32601)`
   - wrapped: `Agent does not support session/close ...:oneshot:... (ACP_BACKEND_UNSUPPORTED_CONTROL)`
   - cascade: `ENOENT` on stale state, `ESRCH` on dead child, then `ACP_TURN_FAILED` returned to embedder.

After this PR: clean teardown, no spurious method-not-found.

## Diff

```diff
-      connection.unstable_closeNes({
+      connection.closeSession({
         sessionId,
       }),
```

```diff
   internals.connection = {
-    unstable_closeNes: async (params: { sessionId: string }) => {
+    closeSession: async (params: { sessionId: string }) => {
       capturedCloseSessionParams = params;
       return {};
     },
   };
```

## Follow-up worth a separate PR

`test/mock-agent.ts` does not implement `closeSession` (or `unstable_closeNes`). No integration test exercises the close path, which is why the bug slipped through CI even though there's a unit test ostensibly covering it. Adding a `closeSession` impl to the mock agent and an integration test that asserts session teardown sends `session/close` would close the gap. Happy to send that as a follow-up if useful.

## Pre-PR checklist

- [x] `pnpm build` ✅
- [x] `pnpm check` (format + typecheck + lint + build + viewer + test:coverage) ✅
- [x] One thing per PR (single bug + matching test mock fix)
- [x] Describe what & why
- [x] AI-assisted: this PR was investigated and authored with Claude Code (Anthropic) — fully tested locally, I understand what the change does and why. Forensic write-up above is the actual chain we traced (CDP capture against acpx subprocess → grep → SDK `.d.ts` → git blame).

No screenshots — the change is invisible at the wire level except that `session/close` goes out instead of `nes/close`.
