### PR TITLE
fix: expose tool call update details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Runtime/embedding: preserve structured ACP `tool_call_update` details on public runtime events, including content, output, locations, kind, and raw payload fields, so embedders can display live tool progress. (#306) Thanks @joeia26.
+
 ## 2026.5.5 (v0.7.0)
 
 ### Changes

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -1,3 +1,4 @@
+import type { ToolCallContent, ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
 import type {
   McpServer,
   NonInteractivePermissionPolicy,
@@ -99,6 +100,11 @@ export type AcpRuntimeEvent =
       toolCallId?: string;
       status?: string;
       title?: string;
+      kind?: ToolKind;
+      locations?: ToolCallLocation[];
+      rawInput?: unknown;
+      rawOutput?: unknown;
+      content?: ToolCallContent[];
     }
   /**
    * Compatibility terminal event emitted by runTurn(...). startTurn(...).events

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -326,7 +326,10 @@ function createToolCallEvent(params: {
   const toolCallId = asOptionalString(params.payload.toolCallId);
   const kind = readToolKind(params.payload.kind);
   const summaryText = status ? `${title} (${status})` : title;
-  const detailSummary = inputSummary ?? outputSummary;
+  const detailSummary =
+    params.tag === "tool_call_update"
+      ? (outputSummary ?? inputSummary)
+      : (inputSummary ?? outputSummary);
   return {
     type: "tool_call",
     text: detailSummary ? `${summaryText}: ${detailSummary}` : summaryText,

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -1,5 +1,8 @@
+import type { ToolCallContent, ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
 import type { AcpRuntimeEvent, AcpSessionUpdateTag } from "./contract.js";
 import { asOptionalString, asString, asTrimmedString, isRecord } from "./shared.js";
+
+const TOOL_OUTPUT_SUMMARY_MAX_CHARS = 500;
 
 function safeParseJsonObject(line: string): Record<string, unknown> | null {
   try {
@@ -214,6 +217,103 @@ function summarizeToolInput(rawInput: unknown): string | undefined {
   ]);
 }
 
+function truncateToolSummary(value: string): string {
+  if (value.length <= TOOL_OUTPUT_SUMMARY_MAX_CHARS) {
+    return value;
+  }
+  return `${value.slice(0, TOOL_OUTPUT_SUMMARY_MAX_CHARS - 1)}…`;
+}
+
+function readToolContentText(value: unknown): string | undefined {
+  const record = isRecord(value) ? value : undefined;
+  if (!record) {
+    return undefined;
+  }
+  if (record.type === "content") {
+    return readToolContentText(record.content);
+  }
+  if (record.type === "text") {
+    return asString(record.text);
+  }
+  if (record.type === "resource_link") {
+    return (
+      asOptionalString(record.title) ||
+      asOptionalString(record.name) ||
+      asOptionalString(record.uri)
+    );
+  }
+  if (record.type === "resource") {
+    const resource = isRecord(record.resource) ? record.resource : undefined;
+    return asString(resource?.text) || asOptionalString(resource?.uri);
+  }
+  if (record.type === "diff") {
+    const path = asOptionalString(record.path) || "file";
+    return `diff ${path}`;
+  }
+  if (record.type === "terminal") {
+    const terminalId = asOptionalString(record.terminalId) || asOptionalString(record.id);
+    return terminalId ? `[terminal] ${terminalId}` : "[terminal]";
+  }
+  return undefined;
+}
+
+function summarizeToolContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const fragments = content
+    .map((entry) => readToolContentText(entry)?.trim())
+    .filter((entry): entry is string => Boolean(entry));
+  if (fragments.length === 0) {
+    return undefined;
+  }
+  return truncateToolSummary([...new Set(fragments)].join("\n"));
+}
+
+function summarizeToolOutput(rawOutput: unknown): string | undefined {
+  if (rawOutput == null) {
+    return undefined;
+  }
+  if (
+    typeof rawOutput === "string" ||
+    typeof rawOutput === "number" ||
+    typeof rawOutput === "boolean"
+  ) {
+    return truncateToolSummary(String(rawOutput));
+  }
+  const record = isRecord(rawOutput) ? rawOutput : undefined;
+  if (!record) {
+    return undefined;
+  }
+  return (
+    truncateToolSummary(
+      readFirstString(record, ["text", "message", "error", "stdout", "stderr", "content"]) ?? "",
+    ) || undefined
+  );
+}
+
+function shouldForwardArray(value: unknown): boolean {
+  return Array.isArray(value);
+}
+
+function readToolKind(value: unknown): ToolKind | undefined {
+  const kind = asOptionalString(value);
+  if (
+    kind === "read" ||
+    kind === "edit" ||
+    kind === "delete" ||
+    kind === "move" ||
+    kind === "search" ||
+    kind === "execute" ||
+    kind === "fetch" ||
+    kind === "think" ||
+    kind === "other"
+  ) {
+    return kind;
+  }
+  return undefined;
+}
+
 function createToolCallEvent(params: {
   payload: Record<string, unknown>;
   tag: AcpSessionUpdateTag;
@@ -221,14 +321,31 @@ function createToolCallEvent(params: {
   const title = asTrimmedString(params.payload.title) || "tool call";
   const status = asTrimmedString(params.payload.status);
   const inputSummary = summarizeToolInput(params.payload.rawInput);
+  const outputSummary =
+    summarizeToolContent(params.payload.content) ?? summarizeToolOutput(params.payload.rawOutput);
   const toolCallId = asOptionalString(params.payload.toolCallId);
+  const kind = readToolKind(params.payload.kind);
   const summaryText = status ? `${title} (${status})` : title;
+  const detailSummary = inputSummary ?? outputSummary;
   return {
     type: "tool_call",
-    text: inputSummary ? `${summaryText}: ${inputSummary}` : summaryText,
+    text: detailSummary ? `${summaryText}: ${detailSummary}` : summaryText,
     tag: params.tag,
     ...(toolCallId ? { toolCallId } : {}),
     ...(status ? { status } : {}),
+    ...(kind ? { kind } : {}),
+    ...(shouldForwardArray(params.payload.locations)
+      ? { locations: params.payload.locations as ToolCallLocation[] }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(params.payload, "rawInput")
+      ? { rawInput: params.payload.rawInput }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(params.payload, "rawOutput")
+      ? { rawOutput: params.payload.rawOutput }
+      : {}),
+    ...(shouldForwardArray(params.payload.content)
+      ? { content: params.payload.content as ToolCallContent[] }
+      : {}),
     title,
   };
 }

--- a/test/runtime-events.test.ts
+++ b/test/runtime-events.test.ts
@@ -33,6 +33,65 @@ test("parsePromptEventLine handles text chunks, usage updates, tool updates, and
         params: {
           sessionId: "s1",
           update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "call_READ",
+            status: "in_progress",
+            rawOutput: {
+              content: [{ type: "text", text: "partial output" }],
+              details: { path: "src/app.ts" },
+            },
+            content: [
+              {
+                type: "content",
+                content: { type: "text", text: "partial output" },
+              },
+            ],
+            locations: [{ path: "src/app.ts", line: 12 }],
+          },
+        },
+      }),
+    ),
+    {
+      type: "tool_call",
+      text: "tool call (in_progress): partial output",
+      tag: "tool_call_update",
+      toolCallId: "call_READ",
+      status: "in_progress",
+      title: "tool call",
+      rawOutput: {
+        content: [{ type: "text", text: "partial output" }],
+        details: { path: "src/app.ts" },
+      },
+      content: [
+        {
+          type: "content",
+          content: { type: "text", text: "partial output" },
+        },
+      ],
+      locations: [{ path: "src/app.ts", line: 12 }],
+    },
+  );
+
+  const longOutput = "x".repeat(600);
+  const parsedLongUpdate = parsePromptEventLine(
+    JSON.stringify({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call_LONG",
+      rawOutput: { stdout: longOutput },
+    }),
+  );
+  assert.equal(parsedLongUpdate?.type, "tool_call");
+  assert.equal(parsedLongUpdate?.text.length, 511);
+  assert.match(parsedLongUpdate?.text ?? "", /^tool call: x+…$/);
+
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s1",
+          update: {
             sessionUpdate: "agent_thought_chunk",
             text: "thinking",
           },
@@ -122,6 +181,10 @@ test("parsePromptEventLine handles text chunks, usage updates, tool updates, and
       tag: "tool_call",
       toolCallId: "call_SEARCH",
       status: "in_progress",
+      rawInput: {
+        command: "rg",
+        args: ["-n", "needle"],
+      },
       title: "Search",
     },
   );

--- a/test/runtime-events.test.ts
+++ b/test/runtime-events.test.ts
@@ -28,6 +28,27 @@ test("parsePromptEventLine handles text chunks, usage updates, tool updates, and
   assert.deepEqual(
     parsePromptEventLine(
       JSON.stringify({
+        sessionUpdate: "tool_call_update",
+        title: "Read",
+        toolCallId: "call_READ_WITH_INPUT",
+        rawInput: { path: "src/app.ts" },
+        rawOutput: { stdout: "fresh output" },
+      }),
+    ),
+    {
+      type: "tool_call",
+      text: "Read: fresh output",
+      tag: "tool_call_update",
+      toolCallId: "call_READ_WITH_INPUT",
+      title: "Read",
+      rawInput: { path: "src/app.ts" },
+      rawOutput: { stdout: "fresh output" },
+    },
+  );
+
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
         jsonrpc: "2.0",
         method: "session/update",
         params: {


### PR DESCRIPTION
## Summary

- Preserve structured ACP `tool_call_update` details on public runtime `tool_call` events.
- Forward `kind`, `locations`, `rawInput`, `rawOutput`, and `content` when present.
- Render useful summaries from `content` / `rawOutput`, with long output truncated.
- Add regression coverage for update projection and long output truncation.

## Problem

`tool_call_update` events can carry incremental output, structured content, and file locations. Before this change, the public runtime projection collapsed those updates into a minimal event, so downstream consumers could see the tool title/status but could not inspect the actual update payload.

For example, an ACP update containing:

```json
{
  "sessionUpdate": "tool_call_update",
  "toolCallId": "call_READ",
  "status": "in_progress",
  "rawOutput": {
    "content": [{ "type": "text", "text": "partial output" }]
  },
  "locations": [{ "path": "src/app.ts", "line": 12 }]
}
```

previously produced only a generic `tool call (in_progress)` summary. After this change, the runtime event preserves the structured fields and can render:

```text
tool call (in_progress): partial output
```

## Testing

- `pnpm run build:test && node --test dist-test/test/runtime-events.test.js dist-test/test/output.test.js dist-test/test/read-output-suppression.test.js`
  - `22 pass / 0 fail`
- `pnpm run test`
  - `602 pass / 0 fail`
