### PR TITLE
fix(terminal): run unsplit command lines through the system shell [AI-assisted]

### DIFF
--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -15,7 +15,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import { PermissionDeniedError, PermissionPromptUnavailableError } from "../errors.js";
 import { promptForPermission } from "../permission-prompt.js";
-import { buildSpawnCommandOptions } from "../spawn-command-options.js";
+import { buildShellExec, buildSpawnCommandOptions } from "../spawn-command-options.js";
 import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } from "../types.js";
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
@@ -190,10 +190,11 @@ export class TerminalManager {
         0,
         Math.round(params.outputByteLimit ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES),
       );
+      const exec = buildShellExec(params.command, params.args);
       const proc = spawn(
-        params.command,
-        params.args ?? [],
-        buildTerminalSpawnOptions(params.command, params.cwd ?? this.cwd, params.env),
+        exec.command,
+        exec.args,
+        buildTerminalSpawnOptions(exec.command, params.cwd ?? this.cwd, params.env),
       );
       await waitForSpawn(proc);
 

--- a/src/spawn-command-options.ts
+++ b/src/spawn-command-options.ts
@@ -74,3 +74,41 @@ export function buildSpawnCommandOptions(
     shell: true,
   };
 }
+
+export type ShellExec = {
+  command: string;
+  args: string[];
+};
+
+/**
+ * Resolve a `terminal/create` request into an actual `spawn()` argv pair.
+ *
+ * The ACP `CreateTerminalRequest` schema models `command` as the executable
+ * and `args` as its argument vector, mirroring `child_process.spawn(cmd, args)`.
+ * In practice, several agents (Claude Code, Codex-style wrappers, and others)
+ * place a full shell command line in the `command` field and leave `args`
+ * empty. Other ACP clients — notably Zed via its `ShellBuilder` — handle this
+ * by always running the request through the system shell, so those agents work
+ * out of the box. Spawning the unsplit string directly fails with `ENOENT`
+ * because the shell line is treated as an executable name.
+ *
+ * To match the de facto behavior of other ACP clients, when `args` is empty we
+ * route the command through `/bin/sh -c <command>` on Unix or `cmd.exe /C
+ * <command>` on Windows. When `args` is non-empty we honor the literal ACP
+ * contract and spawn `command` with the provided argv unchanged. This keeps
+ * well-behaved agents on the original direct-spawn fast path while letting
+ * "raw shell line" agents work transparently.
+ */
+export function buildShellExec(
+  command: string,
+  args: string[] | undefined,
+  platform: NodeJS.Platform = process.platform,
+): ShellExec {
+  if (args && args.length > 0) {
+    return { command, args };
+  }
+  if (platform === "win32") {
+    return { command: "cmd.exe", args: ["/d", "/s", "/c", command] };
+  }
+  return { command: "/bin/sh", args: ["-c", command] };
+}

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -8,6 +8,7 @@ import { resolveAgentSessionCwd } from "../src/acp/client-process.js";
 import { buildAgentSpawnOptions, buildSpawnCommandOptions } from "../src/acp/client.js";
 import { buildTerminalSpawnOptions } from "../src/acp/terminal-manager.js";
 import { buildQueueOwnerSpawnOptions } from "../src/cli/session/queue-owner-process.js";
+import { buildShellExec } from "../src/spawn-command-options.js";
 
 test("buildAgentSpawnOptions hides Windows console windows and preserves auth env", () => {
   const options = buildAgentSpawnOptions("/tmp/acpx-agent", {
@@ -128,6 +129,38 @@ test("buildSpawnCommandOptions keeps shell disabled for non-batch commands", asy
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test("buildShellExec passes through command and args verbatim when args are non-empty", () => {
+  const linuxExec = buildShellExec("node", ["-e", "console.log('ok')"], "linux");
+  assert.deepEqual(linuxExec, { command: "node", args: ["-e", "console.log('ok')"] });
+
+  const windowsExec = buildShellExec("npx", ["create-foo"], "win32");
+  assert.deepEqual(windowsExec, { command: "npx", args: ["create-foo"] });
+});
+
+test("buildShellExec wraps command in /bin/sh -c on Unix when args are missing or empty", () => {
+  const fromUndefined = buildShellExec("ls -la /Users/foo/", undefined, "linux");
+  assert.deepEqual(fromUndefined, { command: "/bin/sh", args: ["-c", "ls -la /Users/foo/"] });
+
+  const fromEmpty = buildShellExec("echo hello | tr a-z A-Z", [], "darwin");
+  assert.deepEqual(fromEmpty, {
+    command: "/bin/sh",
+    args: ["-c", "echo hello | tr a-z A-Z"],
+  });
+});
+
+test("buildShellExec wraps command in cmd.exe /d /s /c on Windows when args are empty", () => {
+  const exec = buildShellExec("dir C:\\Users", undefined, "win32");
+  assert.deepEqual(exec, { command: "cmd.exe", args: ["/d", "/s", "/c", "dir C:\\Users"] });
+});
+
+test("buildShellExec preserves bare commands without args by routing through the shell", () => {
+  // A bare token like "ls" still goes through the shell so PATH lookup,
+  // aliases, and shell builtins behave consistently regardless of whether
+  // an agent splits args or not.
+  const exec = buildShellExec("ls", undefined, "linux");
+  assert.deepEqual(exec, { command: "/bin/sh", args: ["-c", "ls"] });
 });
 
 test("resolveAgentSessionCwd translates WSL cwd for Windows exe agents", async () => {

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -133,3 +133,83 @@ test("terminal manager fails when prompt is unavailable and policy is fail", asy
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });
+
+test("terminal manager runs an unsplit shell command line passed in the command field", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX-shell behavior; Windows path covered elsewhere");
+    return;
+  }
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  try {
+    const manager = new TerminalManager({
+      cwd: tmp,
+      permissionMode: "approve-all",
+    });
+
+    // The whole shell line lives in `command`; `args` is omitted on purpose,
+    // mirroring the request shape used by Claude Code, codebuddy, and other
+    // agents that don't pre-split their Bash tool input.
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: "echo hello-from-shell",
+    });
+
+    const waitResult = await manager.waitForTerminalExit({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    assert.equal(waitResult.exitCode, 0);
+
+    const outputResult = await manager.terminalOutput({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    assert.match(outputResult.output, /hello-from-shell/);
+
+    await manager.releaseTerminal({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager honors shell metacharacters in an unsplit command", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX-shell behavior; Windows path covered elsewhere");
+    return;
+  }
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  try {
+    const manager = new TerminalManager({
+      cwd: tmp,
+      permissionMode: "approve-all",
+    });
+
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: "printf 'one\\ntwo\\nthree\\n' | wc -l",
+    });
+
+    const waitResult = await manager.waitForTerminalExit({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    assert.equal(waitResult.exitCode, 0);
+
+    const outputResult = await manager.terminalOutput({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    // wc -l prints the count; tolerate leading whitespace from BSD/GNU wc.
+    assert.match(outputResult.output, /^\s*3\b/);
+
+    await manager.releaseTerminal({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

When an ACP agent sends `terminal/create` with the entire shell command line in the `command` field and no `args`, acpx fails with:

```
spawn ls -la /Users/foo/ ENOENT
```

This is because `terminal-manager.ts` does:

```ts
spawn(params.command, params.args ?? [], options);
```

so the whole string `\"ls -la /Users/foo/\"` is treated as an executable name.

This affects multiple real-world agents that don't pre-split their Bash tool input, including:

- **claude-code-acp** (and the previous `mcp-server.ts`-based path before commit `be618f5d`):
  https://github.com/agentclientprotocol/claude-agent-acp/blob/main/src/tools.ts
- **codebuddy** (Tencent's `@tencent-ai/codebuddy-code` ACP integration)
- (likely others — anything that proxies a generic \"Bash\" tool through ACP)

## Why other ACP clients aren't affected

Zed always wraps the request through its `ShellBuilder` regardless of `args` shape:

https://github.com/zed-industries/zed/blob/main/crates/acp_thread/src/acp_thread.rs (search for `ShellBuilder::new(&Shell::Program(shell), is_windows)` near `create_terminal_entity`)

So those agents \"just work\" against Zed and never hit this code path. acpx's stricter literal interpretation of the schema is the outlier in practice.

## Fix

Introduce `buildShellExec(command, args, platform)` in `src/spawn-command-options.ts`:

- **`args` non-empty** → return `{command, args}` unchanged. Honor the literal ACP contract; well-behaved agents stay on the existing direct-spawn fast path with zero behavior change.
- **`args` empty/missing** → return `{command: \"/bin/sh\", args: [\"-c\", command]}` on Unix, or `{command: \"cmd.exe\", args: [\"/d\", \"/s\", \"/c\", command]}` on Windows.

`terminal-manager.ts` calls `buildShellExec` before `spawn()`. The existing Windows `.bat/.cmd` auto-shell path in `buildSpawnCommandOptions` is unaffected — it still triggers for the legitimate \"command is a batch file, args is the argv\" case.

### Why `/bin/sh` not `bash -lc`

- ACP doesn't ask for login-shell semantics (`~/.zshrc`, `~/.bash_profile`); environment should come from `params.env`, not the operator's dotfiles.
- `/bin/sh` is universally available; `bash` may not be in containers.
- Matches Zed's `Shell::System` choice in spirit.

### Why \"always wrap when args empty\" rather than \"detect metacharacters\"

A heuristic like \"only wrap if `command` contains `|` `&&` `;` `>` `*` …\" would misfire on the most common case in the wild — `\"ls -la /path\"`, which is plain whitespace with no metacharacters and would still ENOENT. Routing all empty-args requests through the shell is simpler, has no false negatives, and at most adds one shell fork for bare commands like `\"ls\"`.

## Permission prompt

Unaffected. `toCommandLine(params.command, params.args)` still computes the user-facing display string from the original request, so the prompt shows `\"ls -la /Users/foo/\"` not `\"/bin/sh -c ls -la /Users/foo/\"`.

## Tests

- `test/spawn-options.test.ts`: 4 new cases for `buildShellExec` (non-empty args passthrough, Unix wrapping, Windows wrapping, bare command).
- `test/terminal.test.ts`: 2 new end-to-end cases — one for `\"echo hello-from-shell\"` (whitespace only), one for a pipeline (`printf … | wc -l`). Both skip on Windows where the POSIX-shell path doesn't apply.
- All 608 existing tests still pass: `pnpm test` → `# pass 608 # fail 0`.
- `pnpm typecheck`, `pnpm lint`, and `pnpm format:check` (on the changed files) all clean.

## Compatibility

- **Well-behaved agents** (`command: \"ls\", args: [\"-la\"]`): unchanged. `args.length > 0` short-circuits to direct spawn.
- **Raw-shell-line agents** (`command: \"ls -la /path\"`, no args): now work via `/bin/sh -c`.
- **Windows batch wrappers** (`command: \"npx\", args: [\"create-foo\"]`): unchanged. `buildSpawnCommandOptions` still detects the resolved `.cmd`/`.bat` and adds `shell: true`.

The only theoretical break is an agent that intentionally sends `command: \"/path/with spaces/exe\"` with empty args expecting direct spawn. That's already an awkward request shape under the schema (`args` exists for exactly this kind of thing) and I haven't found such a caller in the wild.

## AI-assisted disclosure

- [x] AI-assisted (CodeBuddy / Claude). Marked in title.
- [x] Lightly tested: full `pnpm test` suite passes locally on macOS arm64. Have not exercised the Windows `cmd.exe /d /s /c` path on a real Windows machine, but the unit test covers the argv shape.
- [x] I understand what the code does and reviewed every line.
- [x] Will resolve any bot review conversations after addressing them.

The session that produced this PR was a back-and-forth investigation: dumping ACP history JSONL to see the actual failing requests, comparing claude-code-acp's `command: input.command` pattern with Zed's `ShellBuilder` wrap, then reading the acpx terminal-manager + spawn-command-options to design the fix.