### PR TITLE
feat(json-strict): default --prompt-retries to 1 when strict mode is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- CLI: when `--json-strict` is set and `--prompt-retries` is not explicitly provided, the default for `--prompt-retries` is now `1` (was `0`). Strict mode signals a programmatic caller, and surviving one transient stream cut by default is sane. Explicit `--prompt-retries 0` is still honored — operators who want to fail fast on the first transient error can. Non-strict mode is unchanged (default remains `0`).
+
 ### Breaking
 
 ### Fixes

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -289,7 +289,7 @@ export function addGlobalFlags(command: Command): Command {
     )
     .option(
       "--prompt-retries <count>",
-      "Retry failed prompt turns on transient errors (default: 0)",
+      "Retry failed prompt turns on transient errors (default: 0, or 1 with --json-strict)",
       parsePromptRetries,
     )
     .option(
@@ -381,6 +381,11 @@ export function resolveGlobalFlags(command: Command, config: ResolvedAcpxConfig)
     );
   }
 
+  // Strict mode = programmatic caller. Survive one transient stream cut by
+  // default. Explicit user value (including 0) always wins.
+  const promptRetries =
+    typeof opts.promptRetries === "number" ? opts.promptRetries : jsonStrict ? 1 : undefined;
+
   return {
     agent: opts.agent,
     cwd: opts.cwd ?? process.cwd(),
@@ -398,7 +403,7 @@ export function resolveGlobalFlags(command: Command, config: ResolvedAcpxConfig)
     allowedTools: Array.isArray(opts.allowedTools) ? opts.allowedTools : undefined,
     maxTurns: typeof opts.maxTurns === "number" ? opts.maxTurns : undefined,
     systemPrompt: resolveSystemPromptFlag(opts),
-    promptRetries: typeof opts.promptRetries === "number" ? opts.promptRetries : undefined,
+    promptRetries,
     approveAll: opts.approveAll ? true : undefined,
     approveReads: opts.approveReads ? true : undefined,
     denyAll: opts.denyAll ? true : undefined,

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -1,10 +1,43 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Command } from "commander";
+import type { ResolvedAcpxConfig } from "../src/cli/config.js";
 import {
+  addGlobalFlags,
   hasExplicitPermissionModeFlag,
+  resolveGlobalFlags,
   resolvePermissionMode,
   resolveSystemPromptFlag,
 } from "../src/cli/flags.js";
+
+function buildTestConfig(): ResolvedAcpxConfig {
+  return {
+    defaultAgent: "claude-code",
+    defaultPermissions: "approve-reads",
+    nonInteractivePermissions: "deny",
+    authPolicy: "skip",
+    ttlMs: 300_000,
+    queueMaxDepth: 16,
+    format: "text",
+    agents: {},
+    auth: {},
+    disableExec: false,
+    mcpServers: [],
+    globalPath: "/tmp/acpx-flags-test/global.json",
+    projectPath: "/tmp/acpx-flags-test/project.json",
+    hasGlobalConfig: false,
+    hasProjectConfig: false,
+  };
+}
+
+function parseFlags(argv: string[]): ReturnType<typeof resolveGlobalFlags> {
+  const command = new Command();
+  command.exitOverride();
+  addGlobalFlags(command);
+  command.action(() => {});
+  command.parse(argv, { from: "user" });
+  return resolveGlobalFlags(command, buildTestConfig());
+}
 
 test("resolvePermissionMode honors explicit approve-reads overrides", () => {
   assert.equal(resolvePermissionMode({ approveReads: true }, "approve-all"), "approve-reads");
@@ -43,4 +76,28 @@ test("resolveSystemPromptFlag rejects combining --system-prompt and --append-sys
     () => resolveSystemPromptFlag({ systemPrompt: "a", appendSystemPrompt: "b" }),
     /Use only one of --system-prompt or --append-system-prompt/,
   );
+});
+
+test("resolveGlobalFlags: --json-strict with no explicit retries defaults to 1", () => {
+  const flags = parseFlags(["--format", "json", "--json-strict"]);
+  assert.equal(flags.jsonStrict, true);
+  assert.equal(flags.promptRetries, 1);
+});
+
+test("resolveGlobalFlags: --json-strict with --prompt-retries 0 honors zero", () => {
+  const flags = parseFlags(["--format", "json", "--json-strict", "--prompt-retries", "0"]);
+  assert.equal(flags.jsonStrict, true);
+  assert.equal(flags.promptRetries, 0);
+});
+
+test("resolveGlobalFlags: --json-strict with --prompt-retries 3 honors three", () => {
+  const flags = parseFlags(["--format", "json", "--json-strict", "--prompt-retries", "3"]);
+  assert.equal(flags.jsonStrict, true);
+  assert.equal(flags.promptRetries, 3);
+});
+
+test("resolveGlobalFlags: non-strict with no explicit retries leaves promptRetries undefined", () => {
+  const flags = parseFlags([]);
+  assert.equal(flags.jsonStrict, false);
+  assert.equal(flags.promptRetries, undefined);
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2313,7 +2313,7 @@ test("integration: queued prompt honors per-request prompt retries on warm owner
   });
 });
 
-test("integration: queued prompt without retry flag ignores warm owner startup retries", async () => {
+test("integration: queued prompt with explicit zero retries ignores warm owner startup retries", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
 
@@ -2347,6 +2347,8 @@ test("integration: queued prompt without retry flag ignores warm owner startup r
           "--format",
           "json",
           "--json-strict",
+          "--prompt-retries",
+          "0",
           "prompt",
           "retryable-error-once",
         ],


### PR DESCRIPTION
## Summary

`--json-strict` signals "I'm a programmatic caller, don't be flaky on transient stream cuts." But `--prompt-retries` defaults to 0 even in strict mode, so a single transient failure crashes the caller. This PR makes the retry default depend on `jsonStrict`:

- `--json-strict` AND `--prompt-retries` not provided → default 1
- `--json-strict` AND `--prompt-retries 0` (explicit) → 0 (honored)
- `--json-strict` AND `--prompt-retries N` → N (unchanged)
- non-strict mode → unchanged (default `undefined` → downstream `?? 0`)

Detection uses `typeof opts.promptRetries === "number"` since commander has no `.default()` on this option, so `undefined` cleanly indicates "not provided."

## Files

- `src/cli/flags.ts` — one ternary in `resolveGlobalFlags`; help text updated to `(default: 0, or 1 with --json-strict)`
- `test/cli-flags.test.ts` — 4 new cases covering the matrix
- `test/integration.test.ts` — one pre-existing test renamed and updated to pass `--prompt-retries 0` explicitly (it asserted "no retry" under the old default; under the new default the same assertion holds with the explicit flag)

## Why

A previous run of `clawpatch` with acpx as the provider produced 4 distinct unparseable-output failures across 100 features, several of which would have cleared on a single retry. Strict mode is exactly where opinionated defaults make sense.

## Validation

- `pnpm format:check` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm viewer:typecheck` — clean
- `pnpm viewer:build` — clean
- `pnpm test:coverage` — 675/675 pass (was 674/675 with one regression caught and fixed)

## Notes

- Smallest acpx PR in this stack — single resolver branch.
- Companion to the `--require-stop-reason` and terminal-envelope PRs.
- Explicit user value always wins (including `0`).
