### PR TITLE
feat(json-strict): always emit terminal prompt_result envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- CLI/output: `--json-strict` now emits a terminal `acpx/prompt_result` JSON-RPC envelope as the last line of stdout per prompt, summarizing `stopReason`, `sessionId`, accumulated `finalText` (only when `stopReason === "end_turn"`), `hadMessageChunk`, `messageChunkCount`, `thoughtChunkCount`, and `elapsedMs`. Programmatic callers should branch on this envelope's `stopReason` rather than inferring completion from chunk-stream tail shape. Cancelled and errored prompts now emit the envelope too, so consumers can distinguish "no chunks because failure" from "no chunks because parser ran off the end of the stream". Non-strict modes (`--format text`, `--format json` without `--json-strict`, `--format quiet`) are unchanged.
+
 ### Breaking
 
 ### Fixes

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -293,6 +293,7 @@ export async function handlePrompt(
       sessionId: record.acpxRecordId,
     },
     suppressReads: outputPolicy.suppressReads,
+    jsonStrict: outputPolicy.jsonStrict,
   });
 
   await printPromptSessionBanner(record, agent.cwd, outputPolicy.format, outputPolicy.jsonStrict);
@@ -378,6 +379,7 @@ export async function handleExec(
   ]);
   const outputFormatter = createOutputFormatter(outputPolicy.format, {
     suppressReads: outputPolicy.suppressReads,
+    jsonStrict: outputPolicy.jsonStrict,
   });
   const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
 

--- a/src/cli/output/json-formatter.ts
+++ b/src/cli/output/json-formatter.ts
@@ -1,10 +1,12 @@
 import { buildJsonRpcErrorResponse } from "../../acp/jsonrpc-error.js";
+import { extractSessionUpdateNotification } from "../../acp/jsonrpc.js";
 import type {
   OutputErrorAcpPayload,
   OutputErrorCode,
   OutputErrorOrigin,
   OutputFormatter,
   OutputFormatterContext,
+  PromptResultEnvelopeInput,
 } from "../../types.js";
 import { isReadLikeTool, SUPPRESSED_READ_OUTPUT } from "./read-suppression.js";
 
@@ -101,22 +103,84 @@ function sanitizeToolMessage(message: unknown): unknown {
 class JsonOutputFormatter implements OutputFormatter {
   private readonly stdout: WritableLike;
   private readonly suppressReads: boolean;
+  private readonly jsonStrict: boolean;
   private sessionId: string;
   private readonly requestMethodById = new Map<string, string>();
   private readonly toolStateById = new Map<string, { title?: string; kind?: string | null }>();
+  private chunkText = "";
+  private messageChunkCount = 0;
+  private thoughtChunkCount = 0;
+  private promptStartedAt: number | undefined;
 
-  constructor(stdout: WritableLike, suppressReads: boolean, context?: OutputFormatterContext) {
+  constructor(
+    stdout: WritableLike,
+    suppressReads: boolean,
+    context?: OutputFormatterContext,
+    jsonStrict = false,
+  ) {
     this.stdout = stdout;
     this.suppressReads = suppressReads;
     this.sessionId = context?.sessionId?.trim() || DEFAULT_JSON_SESSION_ID;
+    this.jsonStrict = jsonStrict;
   }
 
   setContext(context: OutputFormatterContext): void {
     this.sessionId = context.sessionId?.trim() || this.sessionId || DEFAULT_JSON_SESSION_ID;
   }
 
+  beginPrompt(): void {
+    this.chunkText = "";
+    this.messageChunkCount = 0;
+    this.thoughtChunkCount = 0;
+    this.promptStartedAt = Date.now();
+  }
+
   onAcpMessage(message: unknown): void {
+    if (this.jsonStrict) {
+      this.recordChunkSummary(message);
+    }
     this.stdout.write(`${JSON.stringify(this.sanitizeMessage(message))}\n`);
+  }
+
+  private recordChunkSummary(message: unknown): void {
+    const update = extractSessionUpdateNotification(message as never);
+    if (!update) {
+      return;
+    }
+    const sessionUpdate = update.update.sessionUpdate;
+    if (sessionUpdate === "agent_message_chunk") {
+      this.messageChunkCount += 1;
+      const content = update.update.content;
+      if (content?.type === "text" && typeof content.text === "string") {
+        this.chunkText += content.text;
+      }
+    } else if (sessionUpdate === "agent_thought_chunk") {
+      this.thoughtChunkCount += 1;
+    }
+  }
+
+  emitPromptResultEnvelope(result: PromptResultEnvelopeInput): void {
+    if (!this.jsonStrict) {
+      return;
+    }
+    const elapsedMs = this.promptStartedAt !== undefined ? Date.now() - this.promptStartedAt : 0;
+    const stopReason = result.stopReason ?? "unknown";
+    const finalText = stopReason === "end_turn" ? this.chunkText : null;
+    const envelope = {
+      jsonrpc: "2.0",
+      method: "acpx/prompt_result",
+      params: {
+        stopReason,
+        sessionId: result.sessionId,
+        finalText,
+        hadMessageChunk: this.messageChunkCount > 0,
+        messageChunkCount: this.messageChunkCount,
+        thoughtChunkCount: this.thoughtChunkCount,
+        elapsedMs,
+      },
+    };
+    this.stdout.write(`${JSON.stringify(envelope)}\n`);
+    this.promptStartedAt = undefined;
   }
 
   private sanitizeMessage(message: unknown): unknown {
@@ -249,6 +313,7 @@ export function createJsonOutputFormatter(
   stdout: WritableLike,
   suppressReads = false,
   context?: OutputFormatterContext,
+  jsonStrict = false,
 ): OutputFormatter {
-  return new JsonOutputFormatter(stdout, suppressReads, context);
+  return new JsonOutputFormatter(stdout, suppressReads, context, jsonStrict);
 }

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -47,6 +47,7 @@ type OutputFormatterOptions = {
   stderr?: WritableLike;
   jsonContext?: OutputFormatterContext;
   suppressReads?: boolean;
+  jsonStrict?: boolean;
 };
 
 type NormalizedToolStatus = ToolCallStatus | "unknown";
@@ -1168,7 +1169,12 @@ export function createOutputFormatter(
     case "text":
       return new TextOutputFormatter(stdout, suppressReads);
     case "json":
-      return createJsonOutputFormatter(stdout, suppressReads, options.jsonContext);
+      return createJsonOutputFormatter(
+        stdout,
+        suppressReads,
+        options.jsonContext,
+        options.jsonStrict === true,
+      );
     case "quiet":
       return new QuietOutputFormatter(stdout, stderr);
     default: {

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -601,6 +601,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
         const maxRetries = options.promptRetries ?? 0;
         let response;
         promptTurnActive = true;
+        output.beginPrompt?.();
         for (let attempt = 0; ; attempt++) {
           try {
             const promptStartedAt = Date.now();
@@ -694,6 +695,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
             (propagated as { outputAlreadyEmitted?: boolean }).outputAlreadyEmitted = sawAcpMessage;
             (propagated as { normalizedOutputError?: unknown }).normalizedOutputError =
               normalizedError;
+            output.emitPromptResultEnvelope?.({
+              stopReason: error instanceof InterruptedError ? "cancelled" : "unknown",
+              sessionId: record.acpxRecordId,
+            });
             throw propagated;
           }
         }
@@ -713,8 +718,13 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
         applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
         stopTotalTimer();
 
+        const promptResult = toPromptResult(response.stopReason, record.acpxRecordId, client);
+        output.emitPromptResultEnvelope?.({
+          stopReason: response.stopReason,
+          sessionId: record.acpxRecordId,
+        });
         return {
-          ...toPromptResult(response.stopReason, record.acpxRecordId, client),
+          ...promptResult,
           record,
           resumed,
           loadError,
@@ -728,6 +738,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
         record.acpx = acpxState;
         await flushPendingMessages(false).catch(() => {
           // best effort while process is being interrupted
+        });
+        output.emitPromptResultEnvelope?.({
+          stopReason: "cancelled",
+          sessionId: record.acpxRecordId,
         });
         if (ownClient) {
           await client.close();
@@ -831,6 +845,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
         const maxRetries = options.promptRetries ?? 0;
         let response;
         promptTurnActive = true;
+        output.beginPrompt?.();
         for (let attempt = 0; ; attempt++) {
           try {
             response = await measurePerf("runtime.exec.prompt", async () => {
@@ -857,12 +872,21 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
               }
             }
             promptTurnActive = false;
+            output.emitPromptResultEnvelope?.({
+              stopReason: error instanceof InterruptedError ? "cancelled" : "unknown",
+              sessionId,
+            });
             throw error;
           }
         }
         promptTurnActive = false;
         output.flush();
-        return toPromptResult(response.stopReason, sessionId, client);
+        const execResult = toPromptResult(response.stopReason, sessionId, client);
+        output.emitPromptResultEnvelope?.({
+          stopReason: response.stopReason,
+          sessionId,
+        });
+        return execResult;
       },
       async () => {
         await client.cancelActivePrompt(INTERRUPT_CANCEL_WAIT_MS);

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,12 @@ export type OutputErrorEmissionPolicy = {
   queueErrorAlreadyEmitted: boolean;
 };
 
+export type PromptResultEnvelopeInput = {
+  // May contain unknown stopReason values from future protocol versions; normalize before branching.
+  stopReason: string | undefined;
+  sessionId: string;
+};
+
 export interface OutputFormatter {
   setContext(context: OutputFormatterContext): void;
   onAcpMessage(message: AcpJsonRpcMessage): void;
@@ -197,6 +203,8 @@ export interface OutputFormatter {
   }): void;
   onPermissionEscalation(event: PermissionEscalationEvent): void;
   flush(): void;
+  beginPrompt?(): void;
+  emitPromptResultEnvelope?(result: PromptResultEnvelopeInput): void;
 }
 
 export type AcpClientOptions = {

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -147,6 +147,121 @@ test("json formatter passes through ACP messages", () => {
   assert.deepEqual(lines[1], second);
 });
 
+test("json-strict emits acpx/prompt_result envelope after end_turn", () => {
+  const writer = new CaptureWriter();
+  const formatter = createOutputFormatter("json", {
+    stdout: writer,
+    jsonContext: {
+      sessionId: "session-strict",
+    },
+    jsonStrict: true,
+  });
+
+  formatter.beginPrompt?.();
+  formatter.onAcpMessage(messageChunk("Hello, ") as never);
+  formatter.onAcpMessage(messageChunk("world!") as never);
+  formatter.onAcpMessage(thoughtChunk("thinking...") as never);
+  formatter.emitPromptResultEnvelope?.({
+    stopReason: "end_turn",
+    sessionId: "session-strict",
+  });
+
+  const lines = writer
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+
+  const last = lines[lines.length - 1] as {
+    jsonrpc: string;
+    method: string;
+    params: {
+      stopReason: string;
+      sessionId: string;
+      finalText: string | null;
+      hadMessageChunk: boolean;
+      messageChunkCount: number;
+      thoughtChunkCount: number;
+      elapsedMs: number;
+    };
+  };
+  assert.equal(last.jsonrpc, "2.0");
+  assert.equal(last.method, "acpx/prompt_result");
+  assert.equal(last.params.stopReason, "end_turn");
+  assert.equal(last.params.sessionId, "session-strict");
+  assert.equal(last.params.finalText, "Hello, world!");
+  assert.equal(last.params.hadMessageChunk, true);
+  assert.equal(last.params.messageChunkCount, 2);
+  assert.equal(last.params.thoughtChunkCount, 1);
+  assert.equal(typeof last.params.elapsedMs, "number");
+});
+
+test("json-strict emits acpx/prompt_result envelope with stopReason cancelled and null finalText", () => {
+  const writer = new CaptureWriter();
+  const formatter = createOutputFormatter("json", {
+    stdout: writer,
+    jsonContext: {
+      sessionId: "session-cancelled",
+    },
+    jsonStrict: true,
+  });
+
+  formatter.beginPrompt?.();
+  formatter.emitPromptResultEnvelope?.({
+    stopReason: "cancelled",
+    sessionId: "session-cancelled",
+  });
+
+  const lines = writer
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+
+  assert.equal(lines.length, 1);
+  const envelope = lines[0] as {
+    method: string;
+    params: {
+      stopReason: string;
+      finalText: string | null;
+      hadMessageChunk: boolean;
+      messageChunkCount: number;
+    };
+  };
+  assert.equal(envelope.method, "acpx/prompt_result");
+  assert.equal(envelope.params.stopReason, "cancelled");
+  assert.equal(envelope.params.finalText, null);
+  assert.equal(envelope.params.hadMessageChunk, false);
+  assert.equal(envelope.params.messageChunkCount, 0);
+});
+
+test("non-json-strict mode does not emit acpx/prompt_result envelope", () => {
+  const writer = new CaptureWriter();
+  const formatter = createOutputFormatter("json", {
+    stdout: writer,
+    jsonContext: {
+      sessionId: "session-loose",
+    },
+  });
+
+  formatter.beginPrompt?.();
+  formatter.onAcpMessage(messageChunk("hi") as never);
+  formatter.emitPromptResultEnvelope?.({
+    stopReason: "end_turn",
+    sessionId: "session-loose",
+  });
+
+  const output = writer.toString();
+  assert.doesNotMatch(output, /acpx\/prompt_result/);
+  const lines = output
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0);
+  assert.equal(lines.length, 1);
+});
+
 test("json formatter emits ACP JSON-RPC error response from onError", () => {
   const writer = new CaptureWriter();
   const formatter = createOutputFormatter("json", {


### PR DESCRIPTION
## Summary

Programmatic callers running with `--json-strict` need a single, structured signal that a prompt has finished. Today, when a prompt ends without producing any `agent_message_chunk` (e.g. `stopReason: cancelled` after a permission denial), consumers see only `[available_commands_update, usage_update]` envelopes and have to infer "no model output" from absence — which looks identical to a real envelope-shape regression.

This PR guarantees that `--json-strict` always emits exactly one terminal `acpx/prompt_result` envelope per prompt as the last line of stdout, regardless of whether message chunks were produced.

## Envelope shape

```json
{"jsonrpc":"2.0","method":"acpx/prompt_result","params":{
  "stopReason":"end_turn",
  "sessionId":"...",
  "finalText":"concatenated agent_message_chunk text, or null when stopReason!=end_turn",
  "hadMessageChunk":true,
  "messageChunkCount":7,
  "thoughtChunkCount":3,
  "elapsedMs":12345
}}
```

The existing `toPromptResult` in `src/cli/session/runtime.ts:133` already produces the shape internally; this PR just emits it as a discrete JSON-RPC notification when `jsonStrict` is set.

## Why

Built for programmatic consumers like `clawpatch` that need to distinguish:
- "model returned end_turn but malformed JSON" → real failure
- "model was cancelled / refused / hit max_tokens" → different failure class

Without a terminal envelope, the consumer has to scan the entire stream and infer state. With one, it reads the last line and branches on `stopReason`.

## Files

- `src/types.ts` — `OutputFormatter.beginPrompt?` and `emitPromptResultEnvelope?` optional methods, plus `PromptResultEnvelopeInput` type
- `src/cli/output/json-formatter.ts` — `JsonOutputFormatter` gains a `jsonStrict` flag, tracks chunks + start time, emits the envelope
- `src/cli/output/output.ts` — threads `jsonStrict` through `createOutputFormatter`
- `src/cli/command-handlers.ts` — `handlePrompt` + `handleExec` pass `outputPolicy.jsonStrict`
- `src/cli/session/runtime.ts` — `runSessionPrompt` + `runOnce` call `output.beginPrompt?.()` before the prompt loop and `output.emitPromptResultEnvelope?.()` on success / error / cancel paths
- 3 new tests in `test/output.test.ts`: end_turn envelope, cancelled envelope (null finalText), non-strict negative

## Validation

- `pnpm format:check` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm viewer:typecheck` — clean
- `pnpm viewer:build` — clean
- `pnpm test:coverage` — full suite green (output.test.js: 18/18 with 3 new)

## Notes

- Non-strict mode emits nothing new (optional-chained calls are no-ops on text/quiet/queue/discard formatters).
- Non-`OutputFormatter` consumers see byte-identical output.
- Pairs cleanly with `--require-stop-reason` (separate PR).
