### PR TITLE
fix: use session/resume for ACP reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Repo: https://github.com/openclaw/acpx
 - CLI/sessions: use agent-side ACP `session/list` when available, including
   cursor pagination, cwd filtering, and agent-native session metadata. Thanks
   @amknight.
+- Sessions/reconnect: use ACP `session/resume` when adapters advertise it, so resume-only agents can reuse saved sessions without requiring `session/load`. Thanks @amknight.
 
 ## 2026.5.15 (v0.8.0)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ One command surface for Pi, OpenClaw ACP, Codex, Claude, and other ACP-compatibl
 - **Fire-and-forget**: `--no-wait` queues a prompt and returns immediately
 - **Graceful cancel**: `Ctrl+C` sends ACP `session/cancel` before force-kill fallback
 - **Session controls**: `set-mode` and `set <key> <value>` for `session/set_mode` and `session/set_config_option`
-- **Crash reconnect**: dead agent processes are detected and sessions are reloaded automatically
+- **Crash reconnect**: dead agent processes are detected and sessions are resumed or reloaded automatically
 - **Prompt from file/stdin**: `--file <path>` or piped stdin for prompt content
 - **Config files**: global + project JSON config with `acpx config show|init`
 - **Session inspect/history**: `sessions show` and `sessions history --limit <n>`
@@ -405,7 +405,7 @@ spawns the ACP bridge directly without `pnpm` wrapper noise:
 - Session metadata is stored under `~/.acpx/sessions/`.
 - Each successful prompt appends lightweight turn history previews (`role`, `timestamp`, `textPreview`) to session metadata.
 - `Ctrl+C` during a running turn sends ACP `session/cancel` and waits briefly for `stopReason=cancelled` before force-killing if needed.
-- If a saved session pid is dead on the next prompt, `acpx` respawns the agent, attempts `session/load`, and transparently falls back to `session/new` if loading fails.
+- If a saved session pid is dead on the next prompt, `acpx` respawns the agent, attempts `session/resume` when advertised or `session/load` otherwise, and transparently falls back to `session/new` if reconnecting fails.
 
 ## Full CLI reference
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -449,7 +449,7 @@ For prompt commands:
 Use `sessions new [--name <name>]` when you explicitly want a fresh scoped session.
 Use `sessions ensure [--name <name>]` when you want idempotent "get-or-create" behavior.
 
-If a saved session PID is dead, `acpx` respawns the agent, tries `session/load`, and transparently falls back to `session/new` when loading fails.
+If a saved session PID is dead, `acpx` respawns the agent, tries `session/resume` when advertised or `session/load` otherwise, and transparently falls back to `session/new` when reconnecting fails.
 
 ### Prompt queueing
 

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -73,7 +73,7 @@ Practical implication: switching from `acpx --agent ./bin/v1` to `acpx --agent .
 A custom agent must:
 
 - Speak ACP over stdio (or whatever transport the adapter supports — most are stdio).
-- Implement the standard ACP methods (`initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/load`, `session/close`).
+- Implement the standard ACP methods (`initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/resume` or `session/load`, `session/close`).
 - Advertise `agentCapabilities` and `availableModels` honestly. `--model <id>` requires `availableModels` to include the requested id, and `set model <id>` calls `session/set_model`.
 
 `fs/*` and `terminal/*` client methods are stable on the `acpx` side and respect cwd sandboxing — your adapter can request file reads, writes, and terminal calls and they will be routed through `acpx`'s permission policy.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -168,8 +168,8 @@ See [Session control](session-control.md) for `set-mode`, `set <key> <value>`, a
 Saved sessions track adapter PIDs. If a saved PID is dead on the next prompt:
 
 1. `acpx` respawns the agent.
-2. Attempts ACP `session/load` with the saved provider session id.
-3. Falls back to `session/new` if loading fails, transparently updating the saved record.
+2. Attempts ACP `session/resume` with the saved provider session id when the agent advertises it, otherwise ACP `session/load`.
+3. Falls back to `session/new` if reconnecting fails, transparently updating the saved record.
 
 This makes long-running scripted sessions resilient to crashes, OS restarts, and adapter upgrades.
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -18,6 +18,7 @@ import {
   type ReadTextFileResponse,
   type ReleaseTerminalRequest,
   type ReleaseTerminalResponse,
+  type ResumeSessionResponse,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
@@ -134,7 +135,13 @@ export type SessionLoadResult = {
   models?: SessionModelState;
 };
 
-function toSessionLoadResult(response: LoadSessionResponse | undefined): SessionLoadResult {
+export type SessionResumeResult = SessionLoadResult;
+
+type ReconnectedSessionResponse = LoadSessionResponse | ResumeSessionResponse;
+
+function toReconnectedSessionResult(
+  response: ReconnectedSessionResponse | undefined,
+): SessionLoadResult {
   return {
     agentSessionId: extractRuntimeSessionId(response?._meta),
     configOptions: response?.configOptions ?? undefined,
@@ -404,6 +411,10 @@ export class AcpClient {
 
   supportsLoadSession(): boolean {
     return Boolean(this.initResult?.agentCapabilities?.loadSession);
+  }
+
+  supportsResumeSession(): boolean {
+    return Boolean(this.initResult?.agentCapabilities?.sessionCapabilities?.resume);
   }
 
   supportsCloseSession(): boolean {
@@ -867,7 +878,23 @@ export class AcpClient {
 
     this.loadedSessionId = sessionId;
 
-    return toSessionLoadResult(response);
+    return toReconnectedSessionResult(response);
+  }
+
+  async resumeSession(sessionId: string, cwd = this.options.cwd): Promise<SessionResumeResult> {
+    const connection = this.getConnection();
+    const sessionCwd = await resolveAgentSessionCwd(cwd, this.options.agentCommand);
+    const response = await this.runConnectionRequest(() =>
+      connection.resumeSession({
+        sessionId,
+        cwd: sessionCwd,
+        mcpServers: this.options.mcpServers ?? [],
+      }),
+    );
+
+    this.loadedSessionId = sessionId;
+
+    return toReconnectedSessionResult(response);
   }
 
   private applySessionUpdateSuppression(enabled: boolean): SessionUpdateSuppressionState {

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -363,7 +363,9 @@ export async function handlePrompt(
   applyPermissionExitCode(result);
 
   if (globalFlags.verbose && result.loadError) {
-    process.stderr.write(`[acpx] loadSession failed, started fresh session: ${result.loadError}\n`);
+    process.stderr.write(
+      `[acpx] session reconnect failed, started fresh session: ${result.loadError}\n`,
+    );
   }
 }
 
@@ -585,7 +587,9 @@ export async function handleSetMode(
   });
 
   if (globalFlags.verbose && result.loadError) {
-    process.stderr.write(`[acpx] loadSession failed, started fresh session: ${result.loadError}\n`);
+    process.stderr.write(
+      `[acpx] session reconnect failed, started fresh session: ${result.loadError}\n`,
+    );
   }
 
   printSetModeResultByFormat(modeId, result, globalFlags.format);
@@ -620,7 +624,9 @@ export async function handleSetModel(
   });
 
   if (globalFlags.verbose && result.loadError) {
-    process.stderr.write(`[acpx] loadSession failed, started fresh session: ${result.loadError}\n`);
+    process.stderr.write(
+      `[acpx] session reconnect failed, started fresh session: ${result.loadError}\n`,
+    );
   }
 
   printSetModelResultByFormat(modelId, result, globalFlags.format);
@@ -662,7 +668,9 @@ export async function handleSetConfigOption(
   });
 
   if (globalFlags.verbose && result.loadError) {
-    process.stderr.write(`[acpx] loadSession failed, started fresh session: ${result.loadError}\n`);
+    process.stderr.write(
+      `[acpx] session reconnect failed, started fresh session: ${result.loadError}\n`,
+    );
   }
 
   printSetConfigOptionResultByFormat(configId, value, result, globalFlags.format);

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Command, InvalidArgumentError } from "commander";
 import { isCodexInvocation } from "../acp/codex-compat.js";
+import { AgentSpawnError } from "../errors.js";
 import { loadPermissionPolicySpec } from "../permission-policy.js";
 import {
   mergePromptSourceWithText,
@@ -41,6 +42,7 @@ import {
   type StatusFlags,
 } from "./flags.js";
 import { emitJsonResult } from "./output/json-output.js";
+import type { SessionListResult } from "./session/contracts.js";
 
 class NoSessionError extends Error {
   constructor(message: string) {
@@ -676,6 +678,39 @@ export async function handleSetConfigOption(
   printSetConfigOptionResultByFormat(configId, value, result, globalFlags.format);
 }
 
+async function tryListAgentSessions(
+  agent: ResolvedAgentInvocation,
+  flags: SessionsListFlags,
+  globalFlags: ReturnType<typeof resolveGlobalFlags>,
+  config: ResolvedAcpxConfig,
+): Promise<SessionListResult | "spawn-failed"> {
+  const permissionMode = resolvePermissionMode(globalFlags, config.defaultPermissions);
+  const permissionPolicy = await resolvePermissionPolicyFromFlags(globalFlags);
+  const { listAgentSessions } = await loadSessionModule();
+  try {
+    return await listAgentSessions({
+      agentCommand: agent.agentCommand,
+      cwd: agent.cwd,
+      cursor: flags.cursor,
+      filterCwd: resolveSessionListFilterCwd(flags, agent.cwd),
+      mcpServers: config.mcpServers,
+      permissionMode,
+      nonInteractivePermissions: globalFlags.nonInteractivePermissions,
+      permissionPolicy,
+      authCredentials: config.auth,
+      authPolicy: globalFlags.authPolicy,
+      terminal: globalFlags.terminal,
+      timeoutMs: globalFlags.timeout,
+      verbose: globalFlags.verbose,
+    });
+  } catch (error) {
+    if (error instanceof AgentSpawnError) {
+      return "spawn-failed";
+    }
+    throw error;
+  }
+}
+
 export async function handleSessionsList(
   explicitAgentName: string | undefined,
   flags: SessionsListFlags,
@@ -694,30 +729,13 @@ export async function handleSessionsList(
     return;
   }
 
-  const permissionMode = resolvePermissionMode(globalFlags, config.defaultPermissions);
-  const permissionPolicy = await resolvePermissionPolicyFromFlags(globalFlags);
-  const [{ listAgentSessions }, { printAgentSessionsByFormat }] = await Promise.all([
-    loadSessionModule(),
+  const [result, { printAgentSessionsByFormat }] = await Promise.all([
+    tryListAgentSessions(agent, flags, globalFlags, config),
     loadOutputRenderModule(),
   ]);
-  const result = await listAgentSessions({
-    agentCommand: agent.agentCommand,
-    cwd: agent.cwd,
-    cursor: flags.cursor,
-    filterCwd,
-    mcpServers: config.mcpServers,
-    permissionMode,
-    nonInteractivePermissions: globalFlags.nonInteractivePermissions,
-    permissionPolicy,
-    authCredentials: config.auth,
-    authPolicy: globalFlags.authPolicy,
-    terminal: globalFlags.terminal,
-    timeoutMs: globalFlags.timeout,
-    verbose: globalFlags.verbose,
-  });
 
-  if (!result) {
-    if (flags.cursor || flags.filterCwd) {
+  if (!result || result === "spawn-failed") {
+    if (result !== "spawn-failed" && (flags.cursor || flags.filterCwd)) {
       throw new Error(
         `Agent command "${agent.agentCommand}" does not advertise sessionCapabilities.list; cannot use agent-side session/list filters`,
       );

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -396,12 +396,17 @@ function noSessionHints(lowerMessage: string): string[] {
 }
 
 function isUnsupportedSessionLoadError(lowerMessage: string): boolean {
-  return lowerMessage.includes("does not support session/load");
+  return (
+    lowerMessage.includes("does not support session/resume") ||
+    lowerMessage.includes("does not support session/load")
+  );
 }
 
 function isSessionLoadError(lowerMessage: string): boolean {
   return (
-    lowerMessage.includes("failed to resume acp session") || lowerMessage.includes("session/load")
+    lowerMessage.includes("failed to resume acp session") ||
+    lowerMessage.includes("session/resume") ||
+    lowerMessage.includes("session/load")
   );
 }
 

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -243,6 +243,8 @@ function extractJsonRpcResponseInfo(
   };
 }
 
+const SESSION_RECONNECT_METHODS = new Set(["session/load", "session/resume"]);
+
 function filterRecoverableLoadFallbackOutput(messages: AcpJsonRpcMessage[]): AcpJsonRpcMessage[] {
   const requestMethodById = new Map<string, string>();
   const failedLoadRequestIds = new Set<string>();
@@ -259,7 +261,8 @@ function filterRecoverableLoadFallbackOutput(messages: AcpJsonRpcMessage[]): Acp
       continue;
     }
 
-    if (requestMethodById.get(response.idKey) === "session/load") {
+    const requestMethod = requestMethodById.get(response.idKey);
+    if (requestMethod && SESSION_RECONNECT_METHODS.has(requestMethod)) {
       failedLoadRequestIds.add(response.idKey);
     }
   }
@@ -270,7 +273,11 @@ function filterRecoverableLoadFallbackOutput(messages: AcpJsonRpcMessage[]): Acp
 
   return messages.filter((message) => {
     const request = extractJsonRpcRequestInfo(message);
-    if (request && request.method === "session/load" && failedLoadRequestIds.has(request.idKey)) {
+    if (
+      request &&
+      SESSION_RECONNECT_METHODS.has(request.method) &&
+      failedLoadRequestIds.has(request.idKey)
+    ) {
       return false;
     }
 

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -114,22 +114,29 @@ async function resumeSessionRecordWithClient(
   if (!options.resumeSessionId) {
     throw new Error("resumeSessionId is required");
   }
-  if (!client.supportsLoadSession()) {
+  const resumeMethod = client.supportsResumeSession()
+    ? "session/resume"
+    : client.supportsLoadSession()
+      ? "session/load"
+      : undefined;
+  if (!resumeMethod) {
     throw new Error(
-      `Agent command "${options.agentCommand}" does not support session/load; cannot resume session ${options.resumeSessionId}`,
+      `Agent command "${options.agentCommand}" does not support session/resume or session/load; cannot resume session ${options.resumeSessionId}`,
     );
   }
 
   try {
-    const loadedSession = await withTimeout(
-      client.loadSession(options.resumeSessionId, cwd),
+    const resumedSession = await withTimeout(
+      resumeMethod === "session/resume"
+        ? client.resumeSession(options.resumeSessionId, cwd)
+        : client.loadSession(options.resumeSessionId, cwd),
       options.timeoutMs,
     );
-    const sessionModels = loadedSession.models;
+    const sessionModels = resumedSession.models;
     return {
       sessionId: options.resumeSessionId,
-      agentSessionId: normalizeRuntimeSessionId(loadedSession.agentSessionId),
-      sessionResult: loadedSession,
+      agentSessionId: normalizeRuntimeSessionId(resumedSession.agentSessionId),
+      sessionResult: resumedSession,
       sessionModels,
       requestedModelApplied: await applyRequestedModelIfAdvertised({
         client,

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -350,38 +350,14 @@ type RunningRuntimeTurn = {
   activeSessionId: string;
 };
 
-type MaybeResumeClient = {
-  supportsResumeSession?: () => boolean;
-  resumeSession?: AcpClient["resumeSession"];
-};
-
-function clientSupportsResumeSession(client: AcpClient): boolean {
-  const maybeClient = client as unknown as MaybeResumeClient;
-  return (
-    typeof maybeClient.supportsResumeSession === "function" && maybeClient.supportsResumeSession()
-  );
-}
-
-async function clientResumeSession(
-  client: AcpClient,
-  sessionId: string,
-  cwd: string,
-): ReturnType<AcpClient["resumeSession"]> {
-  const maybeClient = client as unknown as MaybeResumeClient;
-  if (typeof maybeClient.resumeSession !== "function") {
-    throw new Error("Agent does not support session/resume");
-  }
-  return await maybeClient.resumeSession.call(client, sessionId, cwd);
-}
-
 async function createOrLoadRuntimeSession(
   client: AcpClient,
   resumeSessionId: string | undefined,
   cwd: string,
 ): Promise<CreatedRuntimeSession> {
   if (resumeSessionId) {
-    if (clientSupportsResumeSession(client)) {
-      const resumed = await clientResumeSession(client, resumeSessionId, cwd);
+    if (client.supportsResumeSession()) {
+      const resumed = await client.resumeSession(resumeSessionId, cwd);
       return {
         sessionId: resumeSessionId,
         agentSessionId: resumed.agentSessionId,

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -350,12 +350,49 @@ type RunningRuntimeTurn = {
   activeSessionId: string;
 };
 
+type MaybeResumeClient = {
+  supportsResumeSession?: () => boolean;
+  resumeSession?: AcpClient["resumeSession"];
+};
+
+function clientSupportsResumeSession(client: AcpClient): boolean {
+  const maybeClient = client as unknown as MaybeResumeClient;
+  return (
+    typeof maybeClient.supportsResumeSession === "function" && maybeClient.supportsResumeSession()
+  );
+}
+
+async function clientResumeSession(
+  client: AcpClient,
+  sessionId: string,
+  cwd: string,
+): ReturnType<AcpClient["resumeSession"]> {
+  const maybeClient = client as unknown as MaybeResumeClient;
+  if (typeof maybeClient.resumeSession !== "function") {
+    throw new Error("Agent does not support session/resume");
+  }
+  return await maybeClient.resumeSession.call(client, sessionId, cwd);
+}
+
 async function createOrLoadRuntimeSession(
   client: AcpClient,
   resumeSessionId: string | undefined,
   cwd: string,
 ): Promise<CreatedRuntimeSession> {
   if (resumeSessionId) {
+    if (clientSupportsResumeSession(client)) {
+      const resumed = await clientResumeSession(client, resumeSessionId, cwd);
+      return {
+        sessionId: resumeSessionId,
+        agentSessionId: resumed.agentSessionId,
+        sessionResult: resumed,
+      };
+    }
+    if (!client.supportsLoadSession()) {
+      throw new Error(
+        `Agent does not support session/resume or session/load; cannot resume session ${resumeSessionId}`,
+      );
+    }
     const loaded = await client.loadSession(resumeSessionId, cwd);
     return {
       sessionId: resumeSessionId,
@@ -993,7 +1030,7 @@ export class AcpRuntimeManager {
     }
     this.emitRuntimeTurnEvent(task, {
       type: "status",
-      text: loadError ? `load fallback: ${loadError}` : "session resumed",
+      text: loadError ? `session reconnect fallback: ${loadError}` : "session resumed",
     });
   }
 

--- a/src/runtime/engine/reconnect.ts
+++ b/src/runtime/engine/reconnect.ts
@@ -72,11 +72,6 @@ export type ConnectAndLoadSessionResult = {
   loadError?: string;
 };
 
-type MaybeResumeClient = {
-  supportsResumeSession?: () => boolean;
-  resumeSession?: AcpClient["resumeSession"];
-};
-
 const SESSION_LOAD_UNSUPPORTED_CODES = new Set([-32601, -32602]);
 
 function shouldFallbackToNewSession(error: unknown, record: SessionRecord): boolean {
@@ -108,25 +103,6 @@ function isFallbackSafeEmptySessionError(
 
 function requiresSameSession(resumePolicy: SessionResumePolicy | undefined): boolean {
   return resumePolicy === "same-session-only";
-}
-
-function clientSupportsResumeSession(client: AcpClient): boolean {
-  const maybeClient = client as unknown as MaybeResumeClient;
-  return (
-    typeof maybeClient.supportsResumeSession === "function" && maybeClient.supportsResumeSession()
-  );
-}
-
-async function clientResumeSession(
-  client: AcpClient,
-  sessionId: string,
-  cwd: string,
-): ReturnType<AcpClient["resumeSession"]> {
-  const maybeClient = client as unknown as MaybeResumeClient;
-  if (typeof maybeClient.resumeSession !== "function") {
-    throw new Error("agent does not support session/resume");
-  }
-  return await maybeClient.resumeSession.call(client, sessionId, cwd);
 }
 
 function makeSessionResumeRequiredError(params: {
@@ -458,7 +434,7 @@ async function loadOrCreateRuntimeSession(params: {
     };
   }
 
-  if (clientSupportsResumeSession(params.client)) {
+  if (params.client.supportsResumeSession()) {
     return await resumeRuntimeSession(params);
   }
 
@@ -484,7 +460,7 @@ async function resumeRuntimeSession(params: {
 }): Promise<RuntimeSessionLoadState> {
   try {
     const resumeResult = await withTimeout(
-      clientResumeSession(params.client, params.record.acpSessionId, params.record.cwd),
+      params.client.resumeSession(params.record.acpSessionId, params.record.cwd),
       params.timeoutMs,
     );
     reconcileAgentSessionId(params.record, resumeResult.agentSessionId);

--- a/src/runtime/engine/reconnect.ts
+++ b/src/runtime/engine/reconnect.ts
@@ -72,6 +72,11 @@ export type ConnectAndLoadSessionResult = {
   loadError?: string;
 };
 
+type MaybeResumeClient = {
+  supportsResumeSession?: () => boolean;
+  resumeSession?: AcpClient["resumeSession"];
+};
+
 const SESSION_LOAD_UNSUPPORTED_CODES = new Set([-32601, -32602]);
 
 function shouldFallbackToNewSession(error: unknown, record: SessionRecord): boolean {
@@ -103,6 +108,25 @@ function isFallbackSafeEmptySessionError(
 
 function requiresSameSession(resumePolicy: SessionResumePolicy | undefined): boolean {
   return resumePolicy === "same-session-only";
+}
+
+function clientSupportsResumeSession(client: AcpClient): boolean {
+  const maybeClient = client as unknown as MaybeResumeClient;
+  return (
+    typeof maybeClient.supportsResumeSession === "function" && maybeClient.supportsResumeSession()
+  );
+}
+
+async function clientResumeSession(
+  client: AcpClient,
+  sessionId: string,
+  cwd: string,
+): ReturnType<AcpClient["resumeSession"]> {
+  const maybeClient = client as unknown as MaybeResumeClient;
+  if (typeof maybeClient.resumeSession !== "function") {
+    throw new Error("agent does not support session/resume");
+  }
+  return await maybeClient.resumeSession.call(client, sessionId, cwd);
 }
 
 function makeSessionResumeRequiredError(params: {
@@ -335,13 +359,13 @@ function logReconnectAttempt(
   }
   if (storedProcessAlive) {
     process.stderr.write(
-      `[acpx] saved session pid ${record.pid} is running; reconnecting with loadSession\n`,
+      `[acpx] saved session pid ${record.pid} is running; reconnecting to saved ACP session\n`,
     );
     return;
   }
   if (shouldReconnect) {
     process.stderr.write(
-      `[acpx] saved session pid ${record.pid} is dead; respawning agent and attempting session/load\n`,
+      `[acpx] saved session pid ${record.pid} is dead; respawning agent and attempting session reconnect\n`,
     );
   }
 }
@@ -434,6 +458,10 @@ async function loadOrCreateRuntimeSession(params: {
     };
   }
 
+  if (clientSupportsResumeSession(params.client)) {
+    return await resumeRuntimeSession(params);
+  }
+
   if (params.client.supportsLoadSession()) {
     return await loadRuntimeSession(params);
   }
@@ -441,11 +469,36 @@ async function loadOrCreateRuntimeSession(params: {
   if (params.sameSessionOnly) {
     throw makeSessionResumeRequiredError({
       record: params.record,
-      reason: "agent does not support session/load",
+      reason: "agent does not support session/resume or session/load",
     });
   }
 
   return await createFreshRuntimeSession(params.client, params.record, params.timeoutMs);
+}
+
+async function resumeRuntimeSession(params: {
+  client: AcpClient;
+  record: SessionRecord;
+  sameSessionOnly: boolean;
+  timeoutMs?: number;
+}): Promise<RuntimeSessionLoadState> {
+  try {
+    const resumeResult = await withTimeout(
+      clientResumeSession(params.client, params.record.acpSessionId, params.record.cwd),
+      params.timeoutMs,
+    );
+    reconcileAgentSessionId(params.record, resumeResult.agentSessionId);
+    applyConfigOptionsToRecord(params.record, resumeResult);
+    return {
+      sessionId: params.record.acpSessionId,
+      pendingAgentSessionId: params.record.agentSessionId,
+      sessionModels: resumeResult.models,
+      resumed: true,
+      createdFreshSession: false,
+    };
+  } catch (error) {
+    return await recoverRuntimeSessionLoadFailure(params, error);
+  }
 }
 
 async function loadRuntimeSession(params: {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -56,7 +56,6 @@ const MOCK_AGENT_IGNORING_SIGTERM = `${MOCK_AGENT_COMMAND} --ignore-sigterm`;
 const MOCK_CODEX_AGENT_WITH_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --codex-session-id codex-runtime-session`;
 const MOCK_CLAUDE_AGENT_WITH_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --claude-session-id claude-runtime-session`;
 const MOCK_AGENT_WITH_LOAD_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --supports-load-session --load-runtime-session-id loaded-runtime-session`;
-const MOCK_AGENT_WITH_RESUME_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --supports-resume-session --resume-runtime-session-id resumed-runtime-session`;
 const MOCK_AGENT_WITH_DISTINCT_CREATE_AND_LOAD_RUNTIME_SESSION_IDS =
   `${MOCK_AGENT_COMMAND} --runtime-session-id fresh-runtime-session ` +
   "--supports-load-session --load-runtime-session-id resumed-runtime-session";
@@ -433,52 +432,6 @@ test("sessions new --resume-session loads ACP session and stores resumed ids", a
     };
     assert.equal(storedRecord.acp_session_id, resumeSessionId);
     assert.equal(storedRecord.agent_session_id, "resumed-runtime-session");
-  });
-});
-
-test("sessions new --resume-session uses session/resume when advertised", async () => {
-  await withTempHome(async (homeDir) => {
-    const cwd = path.join(homeDir, "workspace");
-    await fs.mkdir(cwd, { recursive: true });
-    await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
-    await fs.writeFile(
-      path.join(homeDir, ".acpx", "config.json"),
-      `${JSON.stringify(
-        {
-          agents: {
-            codex: {
-              command: MOCK_AGENT_WITH_RESUME_RUNTIME_SESSION_ID,
-            },
-          },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-
-    const result = await runCli(
-      [
-        "--cwd",
-        cwd,
-        "--format",
-        "json",
-        "codex",
-        "sessions",
-        "new",
-        "--resume-session",
-        "cs_resume_only",
-      ],
-      homeDir,
-    );
-    assert.equal(result.code, 0, result.stderr);
-
-    const payload = JSON.parse(result.stdout.trim()) as {
-      acpxSessionId?: unknown;
-      agentSessionId?: unknown;
-    };
-    assert.equal(payload.acpxSessionId, "cs_resume_only");
-    assert.equal(payload.agentSessionId, "resumed-runtime-session");
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -56,6 +56,7 @@ const MOCK_AGENT_IGNORING_SIGTERM = `${MOCK_AGENT_COMMAND} --ignore-sigterm`;
 const MOCK_CODEX_AGENT_WITH_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --codex-session-id codex-runtime-session`;
 const MOCK_CLAUDE_AGENT_WITH_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --claude-session-id claude-runtime-session`;
 const MOCK_AGENT_WITH_LOAD_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --supports-load-session --load-runtime-session-id loaded-runtime-session`;
+const MOCK_AGENT_WITH_RESUME_RUNTIME_SESSION_ID = `${MOCK_AGENT_COMMAND} --supports-resume-session --resume-runtime-session-id resumed-runtime-session`;
 const MOCK_AGENT_WITH_DISTINCT_CREATE_AND_LOAD_RUNTIME_SESSION_IDS =
   `${MOCK_AGENT_COMMAND} --runtime-session-id fresh-runtime-session ` +
   "--supports-load-session --load-runtime-session-id resumed-runtime-session";
@@ -435,7 +436,53 @@ test("sessions new --resume-session loads ACP session and stores resumed ids", a
   });
 });
 
-test("sessions new --resume-session fails when agent does not support session/load", async () => {
+test("sessions new --resume-session uses session/resume when advertised", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".acpx", "config.json"),
+      `${JSON.stringify(
+        {
+          agents: {
+            codex: {
+              command: MOCK_AGENT_WITH_RESUME_RUNTIME_SESSION_ID,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = await runCli(
+      [
+        "--cwd",
+        cwd,
+        "--format",
+        "json",
+        "codex",
+        "sessions",
+        "new",
+        "--resume-session",
+        "cs_resume_only",
+      ],
+      homeDir,
+    );
+    assert.equal(result.code, 0, result.stderr);
+
+    const payload = JSON.parse(result.stdout.trim()) as {
+      acpxSessionId?: unknown;
+      agentSessionId?: unknown;
+    };
+    assert.equal(payload.acpxSessionId, "cs_resume_only");
+    assert.equal(payload.agentSessionId, "resumed-runtime-session");
+  });
+});
+
+test("sessions new --resume-session fails when agent does not support session reuse", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
@@ -462,7 +509,7 @@ test("sessions new --resume-session fails when agent does not support session/lo
     );
 
     assert.equal(result.code, 1, result.stderr);
-    assert.match(result.stderr, /does not support session\/load/i);
+    assert.match(result.stderr, /does not support session\/resume or session\/load/i);
   });
 });
 

--- a/test/connect-load.test.ts
+++ b/test/connect-load.test.ts
@@ -152,6 +152,7 @@ test("connectAndLoadSession resumes an existing load-capable session", async () 
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async (sessionId, loadCwd, options) => {
         assert.equal(sessionId, "resume-session");
         assert.equal(loadCwd, cwd);
@@ -218,6 +219,7 @@ test("connectAndLoadSession falls back to createSession when load returns resour
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -272,6 +274,7 @@ test("connectAndLoadSession fails instead of creating a fresh session when resum
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -323,6 +326,7 @@ test("connectAndLoadSession falls back to createSession for empty sessions on ad
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -371,6 +375,7 @@ test("connectAndLoadSession fails clearly when same-session resume is required b
         running: true,
       }),
       supportsLoadSession: () => false,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw new Error("loadSession should not be called");
       },
@@ -422,6 +427,7 @@ test("connectAndLoadSession falls back to session/new on -32602 Invalid params",
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -477,6 +483,7 @@ test("connectAndLoadSession falls back to session/new on -32601 Method not found
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -532,6 +539,7 @@ test("connectAndLoadSession rethrows load failures that should not create a new 
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -590,6 +598,7 @@ test("connectAndLoadSession fails when desired mode replay cannot be restored on
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -655,6 +664,7 @@ test("connectAndLoadSession replays desired model on a fresh session", async () 
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -715,6 +725,7 @@ test("connectAndLoadSession fails clearly when saved model cannot be replayed ge
         running: true,
       }),
       supportsLoadSession: () => false,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw new Error("loadSessionWithOptions should not be called");
       },
@@ -772,6 +783,7 @@ test("connectAndLoadSession restores the original session when desired model rep
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -840,6 +852,7 @@ test("connectAndLoadSession replays desired config options on a fresh session", 
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -903,6 +916,7 @@ test("connectAndLoadSession restores the original session when desired config re
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         throw {
           error: {
@@ -974,6 +988,7 @@ test("connectAndLoadSession reuses an already loaded client session", async () =
         running: true,
       }),
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => {
         loaded = true;
         return {};

--- a/test/connect-load.test.ts
+++ b/test/connect-load.test.ts
@@ -27,6 +27,11 @@ type FakeClient = {
     };
   };
   supportsLoadSession: () => boolean;
+  supportsResumeSession?: () => boolean;
+  resumeSession?: (
+    sessionId: string,
+    cwd: string,
+  ) => Promise<{ agentSessionId?: string; models?: SessionModelState }>;
   loadSessionWithOptions: (
     sessionId: string,
     cwd: string,
@@ -68,6 +73,58 @@ function buildModelsState(currentModelId: string): SessionModelState {
     ],
   };
 }
+
+test("connectAndLoadSession prefers session/resume for resume-capable sessions", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const record = makeSessionRecord({
+      acpxRecordId: "resume-record",
+      acpSessionId: "resume-session",
+      agentCommand: "agent",
+      cwd,
+    });
+
+    const client: FakeClient = {
+      hasReusableSession: () => false,
+      start: async () => {},
+      getAgentLifecycleSnapshot: () => ({
+        running: true,
+      }),
+      supportsLoadSession: () => false,
+      supportsResumeSession: () => true,
+      resumeSession: async (sessionId, resumeCwd) => {
+        assert.equal(sessionId, "resume-session");
+        assert.equal(resumeCwd, cwd);
+        return { agentSessionId: "runtime-session" };
+      },
+      loadSessionWithOptions: async () => {
+        throw new Error("loadSessionWithOptions should not be called");
+      },
+      createSession: async () => {
+        throw new Error("createSession should not be called");
+      },
+      setSessionMode: async () => {},
+      setSessionModel: async () => {},
+    };
+
+    const result = await connectAndLoadSession({
+      client: client as never,
+      record,
+      timeoutMs: 1_000,
+      activeController: ACTIVE_CONTROLLER,
+    });
+
+    assert.deepEqual(result, {
+      sessionId: "resume-session",
+      agentSessionId: "runtime-session",
+      resumed: true,
+      loadError: undefined,
+    });
+    assert.equal(record.agentSessionId, "runtime-session");
+  });
+});
 
 test("connectAndLoadSession resumes an existing load-capable session", async () => {
   await withTempHome(async (homeDir) => {
@@ -295,7 +352,7 @@ test("connectAndLoadSession falls back to createSession for empty sessions on ad
   });
 });
 
-test("connectAndLoadSession fails clearly when same-session resume is required but session/load is unsupported", async () => {
+test("connectAndLoadSession fails clearly when same-session resume is required but session reuse is unsupported", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
@@ -333,7 +390,7 @@ test("connectAndLoadSession fails clearly when same-session resume is required b
           timeoutMs: 1_000,
           activeController: ACTIVE_CONTROLLER,
         }),
-      /Persistent ACP session unsupported-load-session could not be resumed: agent does not support session\/load/i,
+      /Persistent ACP session unsupported-load-session could not be resumed: agent does not support session\/resume or session\/load/i,
     );
   });
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -39,6 +39,7 @@ const FLOW_WORKDIR_FIXTURE_PATH = fileURLToPath(
 );
 const MOCK_AGENT_COMMAND = `node ${JSON.stringify(MOCK_AGENT_PATH)}`;
 const LOAD_CAPABLE_MOCK_AGENT_COMMAND = `${MOCK_AGENT_COMMAND} --supports-load-session`;
+const RESUME_CAPABLE_MOCK_AGENT_COMMAND = `${MOCK_AGENT_COMMAND} --supports-resume-session`;
 
 const unsafeCodeCharEscapes = Object.freeze({
   "<": "\\u003C",
@@ -1825,6 +1826,55 @@ test("integration: configured mcpServers are sent to session/new and session/loa
       if (sessionId) {
         await runCli([...loadCapableAgentArgs, "--format", "json", "sessions", "close"], homeDir);
       }
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: prompt reconnect uses session/resume when advertised", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const resumeAgentArgs = [
+      "--agent",
+      RESUME_CAPABLE_MOCK_AGENT_COMMAND,
+      "--approve-all",
+      "--cwd",
+      cwd,
+    ];
+
+    try {
+      const created = await runCli(
+        [...resumeAgentArgs, "--format", "json", "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+      const createdPayload = JSON.parse(created.stdout.trim()) as {
+        acpxRecordId?: string;
+      };
+      assert.equal(typeof createdPayload.acpxRecordId, "string");
+
+      const prompt = await runCli(
+        [...resumeAgentArgs, "--format", "json", "prompt", "echo resume-method"],
+        homeDir,
+      );
+      assert.equal(prompt.code, 0, prompt.stderr);
+
+      const messages = parseJsonRpcOutputLines(prompt.stdout);
+      const resumeRequest = messages.find(
+        (message) => message.method === "session/resume" && extractJsonRpcId(message) !== undefined,
+      );
+      assert(resumeRequest, `expected session/resume request in output:\n${prompt.stdout}`);
+      assert.equal(
+        (resumeRequest.params as { sessionId?: unknown } | undefined)?.sessionId,
+        createdPayload.acpxRecordId,
+      );
+      assert.equal(
+        messages.some(
+          (message) => message.method === "session/load" && extractJsonRpcId(message) !== undefined,
+        ),
+        false,
+      );
+    } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
   });

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -23,6 +23,8 @@ import {
   type PromptRequest,
   type PromptResponse,
   type RequestPermissionRequest,
+  type ResumeSessionRequest,
+  type ResumeSessionResponse,
   type SessionId,
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
@@ -43,12 +45,15 @@ type MockAgentOptions = {
   hangOnNewSession: boolean;
   newSessionMeta?: Record<string, string>;
   loadSessionMeta?: Record<string, string>;
+  resumeSessionMeta?: Record<string, string>;
   supportsLoadSession: boolean;
+  supportsResumeSession: boolean;
   supportsCloseSession: boolean;
   supportsListSessions: boolean;
   listPageSize: number;
   closeSessionMarker?: string;
   loadSessionNotFound: boolean;
+  resumeSessionNotFound: boolean;
   loadSessionFailsOnEmpty: boolean;
   setSessionModeFails: boolean;
   setSessionModeInvalidParams: boolean;
@@ -271,12 +276,13 @@ function parsePositiveIntegerOption(args: string[], index: number, flag: string)
   return parsed;
 }
 
-type MetaFlagTarget = "newSessionMeta" | "loadSessionMeta";
+type MetaFlagTarget = "newSessionMeta" | "loadSessionMeta" | "resumeSessionMeta";
 
 type MetaFlagSpec = {
   target: MetaFlagTarget;
   key: string;
   supportsLoadSession?: boolean;
+  supportsResumeSession?: boolean;
 };
 
 const META_FLAG_SPECS: Record<string, MetaFlagSpec> = {
@@ -316,17 +322,40 @@ const META_FLAG_SPECS: Record<string, MetaFlagSpec> = {
     key: "agentSessionId",
     supportsLoadSession: true,
   },
+  "--resume-runtime-session-id": {
+    target: "resumeSessionMeta",
+    key: "agentSessionId",
+    supportsResumeSession: true,
+  },
+  "--resume-provider-session-id": {
+    target: "resumeSessionMeta",
+    key: "agentSessionId",
+    supportsResumeSession: true,
+  },
+  "--resume-codex-session-id": {
+    target: "resumeSessionMeta",
+    key: "agentSessionId",
+    supportsResumeSession: true,
+  },
+  "--resume-claude-session-id": {
+    target: "resumeSessionMeta",
+    key: "agentSessionId",
+    supportsResumeSession: true,
+  },
 };
 
 function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   const newSessionMeta: Record<string, string> = {};
   const loadSessionMeta: Record<string, string> = {};
+  const resumeSessionMeta: Record<string, string> = {};
   let supportsLoadSession = false;
+  let supportsResumeSession = false;
   let supportsCloseSession = false;
   let supportsListSessions = false;
   let listPageSize = 100;
   let closeSessionMarker: string | undefined;
   let loadSessionNotFound = false;
+  let resumeSessionNotFound = false;
   let loadSessionFailsOnEmpty = false;
   let setSessionModeFails = false;
   let setSessionModeInvalidParams = false;
@@ -348,6 +377,11 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       continue;
     }
 
+    if (token === "--supports-resume-session") {
+      supportsResumeSession = true;
+      continue;
+    }
+
     if (token === "--load-session-fails-on-empty") {
       supportsLoadSession = true;
       loadSessionFailsOnEmpty = true;
@@ -357,6 +391,12 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     if (token === "--load-session-not-found") {
       supportsLoadSession = true;
       loadSessionNotFound = true;
+      continue;
+    }
+
+    if (token === "--resume-session-not-found") {
+      supportsResumeSession = true;
+      resumeSessionNotFound = true;
       continue;
     }
 
@@ -454,11 +494,16 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       const value = parseOptionValue(argv, index + 1, token);
       if (metaFlag.target === "newSessionMeta") {
         newSessionMeta[metaFlag.key] = value;
-      } else {
+      } else if (metaFlag.target === "loadSessionMeta") {
         loadSessionMeta[metaFlag.key] = value;
+      } else {
+        resumeSessionMeta[metaFlag.key] = value;
       }
       if (metaFlag.supportsLoadSession) {
         supportsLoadSession = true;
+      }
+      if (metaFlag.supportsResumeSession) {
+        supportsResumeSession = true;
       }
       index += 1;
       continue;
@@ -471,12 +516,16 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     hangOnNewSession,
     newSessionMeta: Object.keys(newSessionMeta).length > 0 ? { ...newSessionMeta } : undefined,
     loadSessionMeta: Object.keys(loadSessionMeta).length > 0 ? { ...loadSessionMeta } : undefined,
+    resumeSessionMeta:
+      Object.keys(resumeSessionMeta).length > 0 ? { ...resumeSessionMeta } : undefined,
     supportsLoadSession,
+    supportsResumeSession,
     supportsCloseSession,
     supportsListSessions,
     listPageSize,
     closeSessionMarker,
     loadSessionNotFound,
+    resumeSessionNotFound,
     loadSessionFailsOnEmpty,
     setSessionModeFails,
     setSessionModeInvalidParams,
@@ -622,8 +671,8 @@ class MockAgent implements Agent {
     const sessionCapabilities = {
       ...(this.options.supportsCloseSession ? { close: {} } : {}),
       ...(this.options.supportsListSessions ? { list: {} } : {}),
+      ...(this.options.supportsResumeSession ? { resume: {} } : {}),
     };
-
     return {
       protocolVersion: PROTOCOL_VERSION,
       authMethods: [],
@@ -694,19 +743,41 @@ class MockAgent implements Agent {
       await this.sendAssistantMessage(params.sessionId, this.options.loadReplayText);
     }
 
+    return this.buildSessionReconnectResponse(params.sessionId, this.options.loadSessionMeta);
+  }
+
+  async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
+    if (!this.options.supportsResumeSession) {
+      throw new Error("resumeSession is not supported");
+    }
+
+    if (this.options.resumeSessionNotFound) {
+      throw RequestError.resourceNotFound(params.sessionId);
+    }
+
+    const existing = this.sessions.get(params.sessionId);
+    this.sessions.set(params.sessionId, existing ?? createSessionState(false));
+
+    return this.buildSessionReconnectResponse(params.sessionId, this.options.resumeSessionMeta);
+  }
+
+  private buildSessionReconnectResponse(
+    sessionId: SessionId,
+    responseMeta: Record<string, string> | undefined,
+  ): LoadSessionResponse {
     const response: LoadSessionResponse = {};
 
-    if (this.options.loadSessionMeta) {
-      response._meta = { ...this.options.loadSessionMeta };
+    if (responseMeta) {
+      response._meta = { ...responseMeta };
     }
 
     if (this.options.advertiseModels) {
-      const session = this.sessions.get(params.sessionId);
+      const session = this.sessions.get(sessionId);
       response.models = buildModelsState(session?.modelId ?? DEFAULT_MODEL_ID);
     }
     if (this.options.advertiseConfigOptions) {
       response.configOptions = buildConfigOptions(
-        this.sessions.get(params.sessionId) ?? createSessionState(false),
+        this.sessions.get(sessionId) ?? createSessionState(false),
       );
     }
 

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -44,6 +44,15 @@ type FakeClient = {
   }>;
   hasReusableSession: (sessionId: string) => boolean;
   supportsLoadSession: () => boolean;
+  supportsResumeSession?: () => boolean;
+  resumeSession?: (
+    sessionId: string,
+    cwd: string,
+  ) => Promise<{
+    agentSessionId?: string;
+    configOptions?: SetSessionConfigOptionResponse["configOptions"];
+    models?: SessionModelState;
+  }>;
   supportsCloseSession?: () => boolean;
   loadSessionWithOptions: (
     sessionId: string,
@@ -152,7 +161,7 @@ test("AcpRuntimeManager creates and resumes sessions through the client", async 
     ({
       initializeResult: {
         protocolVersion: 1,
-        agentCapabilities: { loadSession: true },
+        agentCapabilities: { loadSession: true, sessionCapabilities: { resume: {} } },
       },
       start: async () => {},
       close: async () => {},
@@ -172,7 +181,10 @@ test("AcpRuntimeManager creates and resumes sessions through the client", async 
           ],
         };
       },
-      loadSession: async (sessionId, cwd) => {
+      loadSession: async () => {
+        throw new Error("loadSession should not be called");
+      },
+      resumeSession: async (sessionId, cwd) => {
         assert.equal(sessionId, "resume-session");
         assert.equal(cwd, "/workspace");
         return {
@@ -190,6 +202,7 @@ test("AcpRuntimeManager creates and resumes sessions through the client", async 
       },
       hasReusableSession: () => false,
       supportsLoadSession: () => true,
+      supportsResumeSession: () => true,
       loadSessionWithOptions: async () => ({ agentSessionId: "runtime-session" }),
       getAgentLifecycleSnapshot: () => lifecycle,
       prompt: async () => ({ stopReason: "end_turn" }),
@@ -1955,7 +1968,7 @@ test("AcpRuntimeManager applies timeoutMs to backend session shutdown during dis
   assert.equal(unchanged?.acpx?.reset_on_next_ensure, undefined);
 });
 
-test("AcpRuntimeManager fails offline persistent controls clearly when session/load is unavailable", async () => {
+test("AcpRuntimeManager fails offline persistent controls clearly when session reuse is unavailable", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "offline-persistent-session",
     acpSessionId: "offline-persistent-backend-session",
@@ -1993,7 +2006,7 @@ test("AcpRuntimeManager fails offline persistent controls clearly when session/l
 
   await assert.rejects(
     async () => await manager.setMode(createHandle("offline-persistent-session"), "plan"),
-    /Persistent ACP session offline-persistent-backend-session could not be resumed: agent does not support session\/load/,
+    /Persistent ACP session offline-persistent-backend-session could not be resumed: agent does not support session\/resume or session\/load/,
   );
   await assert.rejects(
     async () =>
@@ -2002,7 +2015,7 @@ test("AcpRuntimeManager fails offline persistent controls clearly when session/l
         "approval",
         "manual",
       ),
-    /Persistent ACP session offline-persistent-backend-session could not be resumed: agent does not support session\/load/,
+    /Persistent ACP session offline-persistent-backend-session could not be resumed: agent does not support session\/resume or session\/load/,
   );
   assert.equal(createSessionCalls, 0);
 });
@@ -2131,7 +2144,7 @@ test("AcpRuntimeManager rejects unsupported runtime attachment media types", asy
   );
 });
 
-test("AcpRuntimeManager fails persistent turns clearly when session/load is unavailable", async () => {
+test("AcpRuntimeManager fails persistent turns clearly when session reuse is unavailable", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "persistent-session",
     acpSessionId: "persistent-backend-session",
@@ -2187,7 +2200,7 @@ test("AcpRuntimeManager fails persistent turns clearly when session/load is unav
       code: "RUNTIME",
       detailCode: "SESSION_RESUME_REQUIRED",
       message:
-        "Persistent ACP session persistent-backend-session could not be resumed: agent does not support session/load",
+        "Persistent ACP session persistent-backend-session could not be resumed: agent does not support session/resume or session/load",
       retryable: true,
     },
   });

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -275,6 +275,7 @@ test("AcpRuntimeManager creates a fresh record for each oneshot session", async 
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "runtime-session" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => ({ stopReason: "end_turn" }),
@@ -325,6 +326,7 @@ test("AcpRuntimeManager streams runtime events and saves updated status", async 
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: (sessionId) => sessionId === "turn-sid",
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
     getAgentLifecycleSnapshot: () => ({
       pid: 999,
@@ -413,6 +415,7 @@ test("AcpRuntimeManager keeps reusable persistent clients pooled across turns an
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: (sessionId) => sessionId === "pooled-sid",
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "pooled-agent" }),
     getAgentLifecycleSnapshot: () => ({
       pid: 104_981,
@@ -508,6 +511,7 @@ test("AcpRuntimeManager runTurn remains a compatibility adapter over startTurn",
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: (sessionId) => sessionId === "legacy-turn-sid",
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
     getAgentLifecycleSnapshot: () => ({ running: true }),
     prompt: async () => {
@@ -584,6 +588,7 @@ test("AcpRuntimeManager retains a reusable persistent client across turns", asyn
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: (sessionId: string) => sessionId === "pooled-persistent-sid",
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => {
             loadSessionCalls += 1;
             return { agentSessionId: "unexpected-load-agent-id" };
@@ -665,6 +670,7 @@ test("AcpRuntimeManager closeStream suppresses future live events while preservi
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: () => true,
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
     getAgentLifecycleSnapshot: () => ({ running: true }),
     prompt: async () => {
@@ -768,6 +774,7 @@ test("AcpRuntimeManager does not pool a persistent client after active close", a
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: (sessionId) => sessionId === "active-close-sid",
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "active-close-agent-id" }),
     getAgentLifecycleSnapshot: () => ({ running: promptActive }),
     prompt: async () => {
@@ -846,6 +853,7 @@ test("AcpRuntimeManager live checkpoints preserve active close state", async () 
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: (sessionId) => sessionId === "active-close-checkpoint-sid",
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     supportsCloseSession: () => true,
     closeSession: async () => {},
     loadSessionWithOptions: async () => ({ agentSessionId: "active-close-checkpoint-agent-id" }),
@@ -922,6 +930,7 @@ test("AcpRuntimeManager accepts a session reply even when the prompt RPC times o
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: () => true,
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
     getAgentLifecycleSnapshot: () => ({ running: true }),
     prompt: async () => {
@@ -987,6 +996,7 @@ test("AcpRuntimeManager waits for late reply chunks to settle before ending a sa
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: () => true,
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
     getAgentLifecycleSnapshot: () => ({ running: true }),
     prompt: async () => {
@@ -1084,6 +1094,7 @@ test("AcpRuntimeManager routes controls through the active controller while a tu
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: () => true,
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
     getAgentLifecycleSnapshot: () => ({ running: true }),
     prompt: async () => {
@@ -1207,6 +1218,7 @@ test("AcpRuntimeManager rejects unsupported advertised config option keys after 
           }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({
             configOptions: [
               {
@@ -1272,6 +1284,7 @@ test("AcpRuntimeManager maps generic thinking config to refreshed advertised eff
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({
             agentSessionId: "unused",
             configOptions: [
@@ -1361,6 +1374,7 @@ test("AcpRuntimeManager maps active generic thinking config against live adverti
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({
             agentSessionId: "unused",
             configOptions: [
@@ -1470,6 +1484,7 @@ test("AcpRuntimeManager waits for active load refresh before resolving generic c
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => {
             resolveLoadStarted();
             await loadGate;
@@ -1569,6 +1584,7 @@ test("AcpRuntimeManager waits for oneshot load fallback to resolve before sendin
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: () => false,
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => {
       await loadFailure;
       throw { error: { code: -32002, message: "session not found" } };
@@ -1644,6 +1660,7 @@ test("AcpRuntimeManager honors aborts requested before prompt starts after onesh
     loadSession: async () => ({ agentSessionId: "unused" }),
     hasReusableSession: () => false,
     supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
     loadSessionWithOptions: async () => {
       await loadFailure;
       throw { error: { code: -32002, message: "session not found" } };
@@ -1713,6 +1730,7 @@ test("AcpRuntimeManager handles offline oneshot controls, status, close, and mis
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => false,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => ({ stopReason: "end_turn" }),
@@ -1779,6 +1797,7 @@ test("AcpRuntimeManager closes the backend session when discarding persistent st
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           supportsCloseSession: () => true,
           closeSession: async (sessionId: string) => {
             closedSessionIds.push(sessionId);
@@ -1823,6 +1842,7 @@ test("AcpRuntimeManager closes the backend session when discarding persistent st
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           supportsCloseSession: () => true,
           closeSession: async () => {},
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
@@ -1877,6 +1897,7 @@ test("AcpRuntimeManager treats missing backend sessions as a successful discard 
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           supportsCloseSession: () => true,
           closeSession: async () => {
             throw { error: { code: -32002, message: "session not found" } };
@@ -1933,6 +1954,7 @@ test("AcpRuntimeManager applies timeoutMs to backend session shutdown during dis
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           supportsCloseSession: () => true,
           closeSession: async () => {
             closeSessionCalls += 1;
@@ -1991,6 +2013,7 @@ test("AcpRuntimeManager fails offline persistent controls clearly when session r
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => false,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => ({ stopReason: "end_turn" }),
@@ -2039,6 +2062,7 @@ test("AcpRuntimeManager surfaces normalized prompt failures", async () => {
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => true,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => {
@@ -2117,6 +2141,7 @@ test("AcpRuntimeManager rejects unsupported runtime attachment media types", asy
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => true,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => ({ stopReason: "end_turn" }),
@@ -2168,6 +2193,7 @@ test("AcpRuntimeManager fails persistent turns clearly when session reuse is una
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => false,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => {
@@ -2231,6 +2257,7 @@ test("AcpRuntimeManager still falls back to a fresh session for oneshot turns", 
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => false,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async (sessionId: string) => {
@@ -2290,6 +2317,7 @@ test("AcpRuntimeManager falls back when a kept-open persistent client is no long
             loadSession: async () => ({ agentSessionId: "unused" }),
             hasReusableSession: () => firstClientReusable,
             supportsLoadSession: () => true,
+            supportsResumeSession: () => false,
             loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
             getAgentLifecycleSnapshot: () => ({ running: firstClientReusable }),
             prompt: async () => {
@@ -2312,6 +2340,7 @@ test("AcpRuntimeManager falls back when a kept-open persistent client is no long
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "resumed-agent-id" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => {
@@ -2386,6 +2415,7 @@ test("AcpRuntimeManager reuses a kept-open persistent client for controls before
           },
           hasReusableSession: (sessionId: string) => sessionId === "pending-session-id",
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => {
             loadSessionCalls += 1;
             return { agentSessionId: "unexpected-agent-id" };
@@ -2492,6 +2522,7 @@ function createModelsClientFactory(options: {
       loadSession: async () => ({ agentSessionId: "models-agent" }),
       hasReusableSession: () => false,
       supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
       loadSessionWithOptions: async () => ({ agentSessionId: "models-agent" }),
       getAgentLifecycleSnapshot: () => ({ pid: 1, startedAt: "now", running: true }),
       prompt: async () => ({ stopReason: "end_turn" }),
@@ -2610,6 +2641,7 @@ test("AcpRuntimeManager forwards sessionOptions to createClient on fresh session
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => ({ stopReason: "end_turn" }),
@@ -2668,6 +2700,7 @@ test("AcpRuntimeManager persists sessionOptions { append } and model/allowedTool
           loadSession: async () => ({ agentSessionId: "unused" }),
           hasReusableSession: () => false,
           supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
           loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
           getAgentLifecycleSnapshot: () => ({ running: true }),
           prompt: async () => ({ stopReason: "end_turn" }),


### PR DESCRIPTION
## Summary

- Prefer ACP `session/resume` when adapters advertise `sessionCapabilities.resume`, falling back to `session/load` when they do not.
- Apply the same resume preference to `--resume-session`, reconnect, and runtime `ensureSession` paths.
- Extend the mock agent and regression coverage for resume-only adapters, plus update session docs and changelog.

## Root Cause

`session/resume` is now stable in ACP, but acpx only checked `loadSession` and only called `session/load` when reusing saved sessions. Resume-only adapters therefore could not be reused through `--resume-session` or reconnect flows.

## Validation

- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check:docs`
- `pnpm run test` (`696` tests passed)