### PR TITLE
fix: route custom agents after global flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - CLI: treat `--version` after `--` as prompt text instead of intercepting it as a top-level version request.
+- CLI: keep custom raw agent commands routed correctly when global flags such as `--system-prompt`, `--append-system-prompt`, `--prompt-retries`, or `--no-terminal` appear before the agent name. Thanks @amknight.
 - CLI/API: avoid installing CLI-only process handlers when the package entrypoint is imported as a module.
 
 ## 2026.5.15 (v0.8.0)

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -74,29 +74,11 @@ const TOP_LEVEL_VERSION_BOOLEAN_FLAGS = new Set([
   "--verbose",
 ]);
 
-const AGENT_SCAN_VALUE_FLAGS = new Set([
-  "--cwd",
-  "--auth-policy",
-  "--non-interactive-permissions",
-  "--permission-policy",
-  "--policy",
-  "--format",
-  "--model",
-  "--allowed-tools",
-  "--max-turns",
-  "--timeout",
-  "--ttl",
-  "--file",
-]);
+const AGENT_SCAN_VALUE_FLAG_VALUES = [...TOP_LEVEL_VERSION_VALUE_FLAG_VALUES, "--file"] as const;
 
-const AGENT_SCAN_BOOLEAN_FLAGS = new Set([
-  "--approve-all",
-  "--approve-reads",
-  "--deny-all",
-  "--json-strict",
-  "--verbose",
-  "--suppress-reads",
-]);
+const AGENT_SCAN_VALUE_FLAGS = new Set<string>(AGENT_SCAN_VALUE_FLAG_VALUES);
+
+const AGENT_SCAN_BOOLEAN_FLAGS = new Set<string>(TOP_LEVEL_VERSION_BOOLEAN_FLAGS);
 
 let skillflagModulePromise: Promise<SkillflagModule> | undefined;
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -277,6 +277,41 @@ test("CLI resolves unknown subcommand names as raw agent commands", async () => 
   });
 });
 
+test("CLI resolves unknown raw agent commands after newer global flags", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const session = makeSessionRecord({
+      acpxRecordId: "custom-session",
+      acpSessionId: "custom-session",
+      agentCommand: "custom-agent",
+      cwd,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: "2026-01-01T00:00:00.000Z",
+      closed: false,
+    });
+    await writeSessionRecord(homeDir, session);
+
+    const flagCases = [
+      ["--system-prompt", "be precise"],
+      ["--append-system-prompt", "be concise"],
+      ["--prompt-retries", "1"],
+      ["--no-terminal"],
+    ];
+
+    for (const flags of flagCases) {
+      const result = await runCli(
+        ["--cwd", cwd, "--format", "quiet", ...flags, "custom-agent", "sessions"],
+        homeDir,
+      );
+
+      assert.equal(result.code, 0, `${flags.join(" ")}\n${result.stderr}`);
+      assert.match(result.stdout, /custom-session/, flags.join(" "));
+    }
+  });
+});
+
 test("global passthrough flags are present in help output", async () => {
   await withTempHome(async (homeDir) => {
     const result = await runCli(["--help"], homeDir);


### PR DESCRIPTION
## Summary

- reuse the top-level global flag lists when scanning for a custom raw agent token
- keep `--file` available to the prompt subcommand scanner
- add regression coverage for custom raw agent routing after `--system-prompt`, `--append-system-prompt`, `--prompt-retries`, and `--no-terminal`
- add an Unreleased changelog entry

## Root Cause

The CLI pre-parser that decides whether to dynamically register unknown agent commands had its own stale global flag allowlist. Newer Commander-supported global flags could stop the scan before the custom agent token, so the command fell through to the default agent path.

## Validation

- `node --test --test-name-pattern "raw agent commands" dist-test/test/cli.test.js`
- `pnpm run check`
- `pnpm run check:docs`
- `pnpm exec oxfmt --check CHANGELOG.md`
- `pnpm exec markdownlint-cli2 CHANGELOG.md`