### PR TITLE
fix: use agent-side session list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI: treat `--version` after `--` as prompt text instead of intercepting it as a top-level version request.
 - CLI/API: avoid installing CLI-only process handlers when the package entrypoint is imported as a module.
+- CLI/sessions: use agent-side ACP `session/list` when available, including
+  cursor pagination, cwd filtering, and agent-native session metadata. Thanks
+  @amknight.
 
 ## 2026.5.15 (v0.8.0)
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,9 @@ spawns the ACP bridge directly without `pnpm` wrapper noise:
 - `sessions new [--name <name>]` creates a fresh session for that scope and soft-closes the prior one.
 - `sessions ensure [--name <name>]` is idempotent: it returns an existing scoped session or creates one when missing.
 - `sessions close [name]` soft-closes the session: queue owner/processes are terminated, record is kept with `closed: true`.
+- `sessions list` uses agent-side ACP `session/list` when available; use
+  `--cursor`, `--filter-cwd`, or `--local` for pagination, cwd filtering, or
+  saved-record inspection.
 - Auto-resume for cwd scope skips sessions marked closed.
 - Prompt submissions are queue-aware per session. If a prompt is already running, new prompts are queued and drained by the running `acpx` process.
 - Queue owners use an idle TTL (default 300s). `--ttl <seconds>` overrides it; `--ttl 0` keeps owners alive indefinitely.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -299,6 +299,7 @@ Behavior:
 ```bash
 acpx [global_options] <agent> sessions
 acpx [global_options] <agent> sessions list
+acpx [global_options] <agent> sessions list [--cursor <cursor>] [--filter-cwd <dir>] [--local]
 acpx [global_options] <agent> sessions new
 acpx [global_options] <agent> sessions new --name <name>
 acpx [global_options] <agent> sessions ensure
@@ -317,7 +318,17 @@ acpx [global_options] sessions ...   # defaults to codex
 Behavior:
 
 - `sessions` and `sessions list` are equivalent
-- list returns all saved sessions for selected `agentCommand` (across all cwd values)
+- list uses ACP `session/list` when the agent advertises
+  `sessionCapabilities.list`, returning agent-native `SessionInfo` metadata and
+  `nextCursor` in JSON output
+- `sessions list --cursor <cursor>` fetches an agent-side page from an ACP
+  cursor returned by a prior list response
+- `sessions list --filter-cwd <dir>` sends the ACP cwd filter; relative values
+  resolve against global `--cwd`
+- `sessions list --local` reads saved acpx records for selected `agentCommand`
+  instead of contacting the agent
+- when the agent does not support `session/list`, list falls back to local saved
+  records unless agent-side list filters were requested
 - `sessions new` creates a fresh cwd-scoped default session
 - `sessions new --name <name>` creates a fresh named session for cwd
 - creating a fresh session soft-closes the previous open session in that scope (if present)

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -101,16 +101,16 @@ The replacement preserves the surrounding ACP message shape so json consumers ca
 
 ## Session-control command output
 
-Local query commands emit local JSON shapes (not ACP wire traffic) under `--format json`:
+Session-control query commands emit summarized JSON shapes (not ACP wire traffic) under `--format json`:
 
-| Command                 | `text`                            | `json`                                                     | `quiet`                |
-| ----------------------- | --------------------------------- | ---------------------------------------------------------- | ---------------------- |
-| `sessions list`         | TSV: `id name cwd lastUsedAt`     | array of session records                                   | one id per line        |
-| `sessions show`         | key/value lines                   | full session record object                                 | record id              |
-| `sessions history`      | TSV: `timestamp role textPreview` | `{ entries: [...] }`                                       | record id              |
-| `sessions prune`        | summary + pruned ids and time     | `{ action, dryRun, count, bytesFreed, pruned }`            | one pruned id per line |
-| `sessions new`/`ensure` | record id                         | record + `acpxRecordId`/`acpxSessionId`/(`agentSessionId`) | record id              |
-| `status`                | key/value lines                   | full status object                                         | state token            |
+| Command                 | `text`                             | `json`                                                                                                        | `quiet`                |
+| ----------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `sessions list`         | TSV: `id title cwd updatedAt meta` | `{ _meta, source, sessions, cursor, cwd, nextCursor }` for ACP list, or local records with `--local`/fallback | one id per line        |
+| `sessions show`         | key/value lines                    | full session record object                                                                                    | record id              |
+| `sessions history`      | TSV: `timestamp role textPreview`  | `{ entries: [...] }`                                                                                          | record id              |
+| `sessions prune`        | summary + pruned ids and time      | `{ action, dryRun, count, bytesFreed, pruned }`                                                               | one pruned id per line |
+| `sessions new`/`ensure` | record id                          | record + `acpxRecordId`/`acpxSessionId`/(`agentSessionId`)                                                    | record id              |
+| `status`                | key/value lines                    | full status object                                                                                            | state token            |
 
 Closed sessions are marked `[closed]` in `text` and `quiet`.
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -21,7 +21,9 @@ That is what makes `acpx codex` in `~/repos/api` and `acpx codex` in `~/repos/we
 
 ```bash
 acpx codex sessions                  # list (alias for `sessions list`)
-acpx codex sessions list             # list all sessions for codex (any cwd)
+acpx codex sessions list             # list agent sessions via ACP when supported
+acpx codex sessions list --filter-cwd . --cursor <cursor>
+acpx codex sessions list --local     # list saved acpx records
 acpx codex sessions new              # create a fresh cwd-scoped default session
 acpx codex sessions new --name api   # create a fresh named session
 acpx codex sessions ensure           # idempotent: existing or create
@@ -38,6 +40,13 @@ acpx codex sessions prune --before 2026-01-01 --include-history
 ```
 
 Top-level `acpx sessions …` defaults to `codex`.
+
+`sessions list` prefers the agent-side ACP `session/list` method when the
+selected agent advertises `sessionCapabilities.list`. JSON output includes the
+agent's `SessionInfo` fields, any `_meta` metadata, and `nextCursor` for manual
+pagination. Use `--filter-cwd <dir>` to send the ACP cwd filter; relative paths
+resolve against global `--cwd`. Use `--local` when you specifically want the
+saved `~/.acpx/sessions` records.
 
 ## Auto-resume by directory walk
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -171,6 +171,9 @@ Behavior:
 ```bash
 acpx sessions
 acpx sessions list
+acpx sessions list --filter-cwd .
+acpx sessions list --cursor <cursor>
+acpx sessions list --local
 acpx sessions new
 acpx sessions new --name backend
 acpx sessions ensure
@@ -196,6 +199,11 @@ acpx codex status
 Behavior:
 
 - `sessions` and `sessions list` are equivalent
+- `sessions list` uses ACP `session/list` when the agent advertises it; JSON
+  includes agent `SessionInfo`, `_meta`, and `nextCursor`
+- `sessions list --filter-cwd <dir>` applies the ACP cwd filter, and
+  `--cursor <cursor>` requests a specific page
+- `sessions list --local` reads saved acpx records instead
 - `new` creates a fresh session for the current `(agentCommand, cwd, optional name)` scope
 - `new --name <name>` targets a named session scope
 - when `new` replaces an existing open session in that scope, the old one is soft-closed

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -8,6 +8,8 @@ import {
   type CreateTerminalRequest,
   type CreateTerminalResponse,
   type InitializeResponse,
+  type ListSessionsRequest,
+  type ListSessionsResponse,
   type KillTerminalRequest,
   type KillTerminalResponse,
   type LoadSessionResponse,
@@ -406,6 +408,10 @@ export class AcpClient {
 
   supportsCloseSession(): boolean {
     return Boolean(this.initResult?.agentCapabilities?.sessionCapabilities?.close);
+  }
+
+  supportsListSessions(): boolean {
+    return Boolean(this.initResult?.agentCapabilities?.sessionCapabilities?.list);
   }
 
   setEventHandlers(
@@ -1028,6 +1034,11 @@ export class AcpClient {
     if (this.loadedSessionId === sessionId) {
       this.loadedSessionId = undefined;
     }
+  }
+
+  async listSessions(params: ListSessionsRequest = {}): Promise<ListSessionsResponse> {
+    const connection = this.getConnection();
+    return await this.runConnectionRequest(() => connection.listSessions(params));
   }
 
   async requestCancelActivePrompt(): Promise<boolean> {

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -35,6 +35,7 @@ import {
   type GlobalFlags,
   type PromptFlags,
   type SessionsHistoryFlags,
+  type SessionsListFlags,
   type SessionsNewFlags,
   type SessionsPruneFlags,
   type StatusFlags,
@@ -215,6 +216,27 @@ function buildSessionStartOptions(params: {
     verbose: params.globalFlags.verbose,
     sessionOptions: sessionOptionsFromGlobalFlags(params.globalFlags),
   };
+}
+
+function resolveSessionListFilterCwd(
+  flags: Pick<SessionsListFlags, "filterCwd">,
+  agentCwd: string,
+): string | undefined {
+  return flags.filterCwd ? path.resolve(agentCwd, flags.filterCwd) : undefined;
+}
+
+async function printLocalSessionsList(
+  agentCommand: string,
+  filterCwd: string | undefined,
+  format: OutputFormat,
+): Promise<void> {
+  const [{ listSessionsForAgent }, { printSessionsByFormat }] = await Promise.all([
+    loadSessionModule(),
+    loadOutputRenderModule(),
+  ]);
+  const sessions = await listSessionsForAgent(agentCommand);
+  const filtered = filterCwd ? sessions.filter((session) => session.cwd === filterCwd) : sessions;
+  printSessionsByFormat(filtered, format);
 }
 
 function missingScopedSessionMessage(
@@ -648,17 +670,55 @@ export async function handleSetConfigOption(
 
 export async function handleSessionsList(
   explicitAgentName: string | undefined,
+  flags: SessionsListFlags,
   command: Command,
   config: ResolvedAcpxConfig,
 ): Promise<void> {
   const globalFlags = resolveGlobalFlags(command, config);
   const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
-  const [{ listSessionsForAgent }, { printSessionsByFormat }] = await Promise.all([
+  const filterCwd = resolveSessionListFilterCwd(flags, agent.cwd);
+
+  if (flags.local) {
+    if (flags.cursor) {
+      throw new InvalidArgumentError("--cursor cannot be combined with --local");
+    }
+    await printLocalSessionsList(agent.agentCommand, filterCwd, globalFlags.format);
+    return;
+  }
+
+  const permissionMode = resolvePermissionMode(globalFlags, config.defaultPermissions);
+  const permissionPolicy = await resolvePermissionPolicyFromFlags(globalFlags);
+  const [{ listAgentSessions }, { printAgentSessionsByFormat }] = await Promise.all([
     loadSessionModule(),
     loadOutputRenderModule(),
   ]);
-  const sessions = await listSessionsForAgent(agent.agentCommand);
-  printSessionsByFormat(sessions, globalFlags.format);
+  const result = await listAgentSessions({
+    agentCommand: agent.agentCommand,
+    cwd: agent.cwd,
+    cursor: flags.cursor,
+    filterCwd,
+    mcpServers: config.mcpServers,
+    permissionMode,
+    nonInteractivePermissions: globalFlags.nonInteractivePermissions,
+    permissionPolicy,
+    authCredentials: config.auth,
+    authPolicy: globalFlags.authPolicy,
+    terminal: globalFlags.terminal,
+    timeoutMs: globalFlags.timeout,
+    verbose: globalFlags.verbose,
+  });
+
+  if (!result) {
+    if (flags.cursor || flags.filterCwd) {
+      throw new Error(
+        `Agent command "${agent.agentCommand}" does not advertise sessionCapabilities.list; cannot use agent-side session/list filters`,
+      );
+    }
+    await printLocalSessionsList(agent.agentCommand, undefined, globalFlags.format);
+    return;
+  }
+
+  printAgentSessionsByFormat(result, globalFlags.format);
 }
 
 export async function handleSessionsClose(

--- a/src/cli/command-registration.ts
+++ b/src/cli/command-registration.ts
@@ -27,6 +27,7 @@ import {
   parseSessionName,
   type PromptFlags,
   type SessionsHistoryFlags,
+  type SessionsListFlags,
   type SessionsNewFlags,
   type SessionsPruneFlags,
   type StatusFlags,
@@ -48,6 +49,17 @@ type SharedSubcommandDescriptions = {
   status: string;
 };
 
+function addSessionsListOptions(command: Command): Command {
+  return command
+    .option("--local", "List local acpx session records instead of agent protocol sessions")
+    .option("--cursor <cursor>", "Opaque ACP session/list cursor", (value: string) =>
+      parseNonEmptyValue("Cursor", value),
+    )
+    .option("--filter-cwd <dir>", "Filter agent sessions by working directory", (value: string) =>
+      parseNonEmptyValue("Filter cwd", value),
+    );
+}
+
 export function registerSessionsCommand(
   parent: Command,
   explicitAgentName: string | undefined,
@@ -56,16 +68,16 @@ export function registerSessionsCommand(
   const sessionsCommand = parent
     .command("sessions")
     .description("List, ensure, create, or close sessions for this agent");
+  addSessionsListOptions(sessionsCommand);
 
-  sessionsCommand.action(async function (this: Command) {
-    await handleSessionsList(explicitAgentName, this, config);
+  sessionsCommand.action(async function (this: Command, flags: SessionsListFlags) {
+    await handleSessionsList(explicitAgentName, flags, this, config);
   });
 
-  sessionsCommand
-    .command("list")
+  addSessionsListOptions(sessionsCommand.command("list"))
     .description("List sessions")
-    .action(async function (this: Command) {
-      await handleSessionsList(explicitAgentName, this, config);
+    .action(async function (this: Command, flags: SessionsListFlags) {
+      await handleSessionsList(explicitAgentName, flags, this, config);
     });
 
   sessionsCommand

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -68,6 +68,12 @@ export type SessionsHistoryFlags = {
   limit: number;
 };
 
+export type SessionsListFlags = {
+  cursor?: string;
+  filterCwd?: string;
+  local?: boolean;
+};
+
 export type StatusFlags = {
   session?: string;
 };

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { normalizeRuntimeSessionId } from "../../session/runtime-session-id.js";
-import type { OutputFormat, SessionRecord } from "../../types.js";
+import type { AgentSessionListResult, OutputFormat, SessionRecord } from "../../types.js";
 import { probeQueueOwnerHealth } from "../queue/ipc.js";
 import { emitJsonResult } from "./json-output.js";
 
@@ -53,6 +53,48 @@ function printQuietSessions(sessions: SessionRecord[]): void {
   for (const session of sessions) {
     const closedMarker = session.closed ? " [closed]" : "";
     process.stdout.write(`${session.acpxRecordId}${closedMarker}\n`);
+  }
+}
+
+export function printAgentSessionsByFormat(
+  result: AgentSessionListResult,
+  format: OutputFormat,
+): void {
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  if (format === "quiet") {
+    printQuietAgentSessions(result);
+    return;
+  }
+
+  printTextAgentSessions(result);
+}
+
+function printQuietAgentSessions(result: AgentSessionListResult): void {
+  for (const session of result.sessions) {
+    process.stdout.write(`${session.sessionId}\n`);
+  }
+}
+
+function printTextAgentSessions(result: AgentSessionListResult): void {
+  if (result.sessions.length === 0) {
+    process.stdout.write("No sessions\n");
+  } else {
+    for (const session of result.sessions) {
+      const title = session.title ?? "-";
+      const updatedAt = session.updatedAt ?? "-";
+      const meta = session._meta ? JSON.stringify(session._meta) : "-";
+      process.stdout.write(
+        `${session.sessionId}\t${title}\t${session.cwd}\t${updatedAt}\t${meta}\n`,
+      );
+    }
+  }
+
+  if (result.nextCursor) {
+    process.stdout.write(`Next cursor: ${result.nextCursor}\n`);
   }
 }
 

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -13,6 +13,7 @@ import type {
   PermissionMode,
   PermissionPolicy,
   PromptInput,
+  AgentSessionListResult,
   SessionNotification,
   SessionResumePolicy,
   SessionRecord,
@@ -118,6 +119,23 @@ export type SessionEnsureOptions = {
   walkBoundary?: string;
   sessionOptions?: SessionAgentOptions;
 } & TimedRunOptions;
+
+export type SessionListOptions = {
+  agentCommand: string;
+  cwd: string;
+  cursor?: string;
+  filterCwd?: string;
+  mcpServers?: McpServer[];
+  permissionMode: PermissionMode;
+  nonInteractivePermissions?: NonInteractivePermissionPolicy;
+  permissionPolicy?: PermissionPolicy;
+  authCredentials?: Record<string, string>;
+  authPolicy?: AuthPolicy;
+  terminal?: boolean;
+  verbose?: boolean;
+} & TimedRunOptions;
+
+export type SessionListResult = AgentSessionListResult | undefined;
 
 export type SessionCancelOptions = {
   sessionId: string;

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -22,6 +22,8 @@ import type {
   SessionCreateOptions,
   SessionCreateWithClientResult,
   SessionEnsureOptions,
+  SessionListOptions,
+  SessionListResult,
 } from "./contracts.js";
 import { setSessionModel } from "./session-control.js";
 
@@ -187,6 +189,55 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
   const { record, client } = await createSessionWithClient(options);
   try {
     return record;
+  } finally {
+    await client.close();
+  }
+}
+
+export async function listAgentSessions(options: SessionListOptions): Promise<SessionListResult> {
+  const client = new AcpClient({
+    agentCommand: options.agentCommand,
+    cwd: absolutePath(options.cwd),
+    mcpServers: options.mcpServers,
+    permissionMode: options.permissionMode,
+    nonInteractivePermissions: options.nonInteractivePermissions,
+    permissionPolicy: options.permissionPolicy,
+    authCredentials: options.authCredentials,
+    authPolicy: options.authPolicy,
+    terminal: options.terminal,
+    verbose: options.verbose,
+  });
+
+  try {
+    return await withInterrupt(
+      async () => {
+        await withTimeout(client.start(), options.timeoutMs);
+        if (!client.supportsListSessions()) {
+          return undefined;
+        }
+
+        const cwd = options.filterCwd ? absolutePath(options.filterCwd) : undefined;
+        const response = await withTimeout(
+          client.listSessions({
+            ...(cwd ? { cwd } : {}),
+            ...(options.cursor ? { cursor: options.cursor } : {}),
+          }),
+          options.timeoutMs,
+        );
+
+        return {
+          _meta: response._meta,
+          source: "agent",
+          sessions: response.sessions,
+          cursor: options.cursor,
+          cwd,
+          nextCursor: response.nextCursor,
+        };
+      },
+      async () => {
+        await client.close();
+      },
+    );
   } finally {
     await client.close();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type {
   RequestPermissionRequest,
   SessionNotification,
   SessionConfigOption,
+  SessionInfo,
   SetSessionConfigOptionResponse,
   StopReason,
   ToolKind,
@@ -411,6 +412,17 @@ export type SessionSetModelResult = {
 export type SessionEnsureResult = {
   record: SessionRecord;
   created: boolean;
+};
+
+export type AgentSessionListResult = {
+  _meta?: {
+    [key: string]: unknown;
+  } | null;
+  source: "agent";
+  sessions: SessionInfo[];
+  cursor?: string;
+  cwd?: string;
+  nextCursor?: string | null;
 };
 
 export type SessionEnqueueResult = {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -268,7 +268,7 @@ test("CLI resolves unknown subcommand names as raw agent commands", async () => 
     await writeSessionRecord(homeDir, session);
 
     const result = await runCli(
-      ["--cwd", cwd, "--format", "quiet", "custom-agent", "sessions"],
+      ["--cwd", cwd, "--format", "quiet", "custom-agent", "sessions", "--local"],
       homeDir,
     );
 
@@ -1150,7 +1150,7 @@ test("set returns an error when agent rejects unsupported session config params"
 
 test("--ttl flag is parsed for sessions commands", async () => {
   await withTempHome(async (homeDir) => {
-    const ok = await runCli(["--ttl", "30", "--format", "json", "sessions"], homeDir);
+    const ok = await runCli(["--ttl", "30", "--format", "json", "sessions", "--local"], homeDir);
     assert.equal(ok.code, 0, ok.stderr);
     assert.doesNotThrow(() => JSON.parse(ok.stdout.trim()));
 
@@ -1166,7 +1166,10 @@ test("--ttl flag is parsed for sessions commands", async () => {
 
 test("--auth-policy flag validates supported values", async () => {
   await withTempHome(async (homeDir) => {
-    const ok = await runCli(["--auth-policy", "skip", "--format", "json", "sessions"], homeDir);
+    const ok = await runCli(
+      ["--auth-policy", "skip", "--format", "json", "sessions", "--local"],
+      homeDir,
+    );
     assert.equal(ok.code, 0, ok.stderr);
 
     const invalid = await runCli(["--auth-policy", "bad", "sessions"], homeDir);
@@ -1178,7 +1181,7 @@ test("--auth-policy flag validates supported values", async () => {
 test("--non-interactive-permissions validates supported values", async () => {
   await withTempHome(async (homeDir) => {
     const ok = await runCli(
-      ["--non-interactive-permissions", "deny", "--format", "json", "sessions"],
+      ["--non-interactive-permissions", "deny", "--format", "json", "sessions", "--local"],
       homeDir,
     );
     assert.equal(ok.code, 0, ok.stderr);
@@ -2264,7 +2267,7 @@ test("config defaults are loaded from global and project config files", async ()
       closed: false,
     });
 
-    const result = await runCli(["--cwd", cwd, "my-custom", "sessions"], homeDir);
+    const result = await runCli(["--cwd", cwd, "my-custom", "sessions", "--local"], homeDir);
 
     assert.equal(result.code, 0, result.stderr);
     assert.doesNotThrow(() => JSON.parse(result.stdout.trim()));

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -109,6 +109,7 @@ type ClientInternals = {
     agentCapabilities?: {
       sessionCapabilities?: {
         close?: Record<string, never>;
+        list?: Record<string, never>;
       };
     };
   };
@@ -824,6 +825,55 @@ test("AcpClient closes sessions through session/close and clears the loaded sess
     sessionId: "session-close-1",
   });
   assert.equal(internals.loadedSessionId, undefined);
+});
+
+test("AcpClient lists agent sessions through session/list", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let capturedListSessionsParams:
+    | {
+        cwd?: string | null;
+        cursor?: string | null;
+      }
+    | undefined;
+  internals.initResult = {
+    agentCapabilities: {
+      sessionCapabilities: {
+        list: {},
+      },
+    },
+  };
+  internals.connection = {
+    listSessions: async (params: { cwd?: string | null; cursor?: string | null }) => {
+      capturedListSessionsParams = params;
+      return {
+        sessions: [
+          {
+            sessionId: "agent-session-1",
+            cwd: "/tmp/acpx-client-list",
+            title: "Agent session",
+            updatedAt: "2026-05-21T00:00:00.000Z",
+            _meta: { messageCount: 3 },
+          },
+        ],
+        nextCursor: "cursor-2",
+      };
+    },
+  };
+
+  assert.equal(client.supportsListSessions(), true);
+  const result = await client.listSessions({
+    cwd: "/tmp/acpx-client-list",
+    cursor: "cursor-1",
+  });
+
+  assert.deepEqual(capturedListSessionsParams, {
+    cwd: "/tmp/acpx-client-list",
+    cursor: "cursor-1",
+  });
+  assert.equal(result.nextCursor, "cursor-2");
+  assert.equal(result.sessions[0]?.sessionId, "agent-session-1");
+  assert.deepEqual(result.sessions[0]?._meta, { messageCount: 3 });
 });
 
 test("AcpClient session update handling drains queued callbacks and swallows handler failures", async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1405,6 +1405,119 @@ test("integration: status shows updated model after set model", async () => {
   });
 });
 
+test("integration: sessions list uses agent session/list pagination and metadata", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const listAgentCommand = `${MOCK_AGENT_COMMAND} --supports-list-sessions --list-page-size 1`;
+
+    try {
+      const firstPage = await runCli(
+        [
+          "--agent",
+          listAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "sessions",
+          "list",
+          "--filter-cwd",
+          ".",
+        ],
+        homeDir,
+      );
+      assert.equal(firstPage.code, 0, firstPage.stderr);
+      const firstPayload = JSON.parse(firstPage.stdout.trim()) as {
+        _meta?: { source?: string };
+        source?: string;
+        cwd?: string;
+        nextCursor?: string | null;
+        sessions?: Array<{
+          sessionId?: string;
+          cwd?: string;
+          title?: string | null;
+          _meta?: { messageCount?: number };
+        }>;
+      };
+      assert.equal(firstPayload._meta?.source, "mock-agent-list");
+      assert.equal(firstPayload.source, "agent");
+      assert.equal(firstPayload.cwd, cwd);
+      assert.equal(firstPayload.nextCursor, "1");
+      assert.equal(firstPayload.sessions?.length, 1);
+      assert.equal(firstPayload.sessions?.[0]?.sessionId, "mock-session-alpha");
+      assert.equal(firstPayload.sessions?.[0]?.cwd, cwd);
+      assert.equal(firstPayload.sessions?.[0]?.title, "Alpha task");
+      assert.equal(firstPayload.sessions?.[0]?._meta?.messageCount, 2);
+
+      const secondPage = await runCli(
+        [
+          "--agent",
+          listAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "sessions",
+          "list",
+          "--filter-cwd",
+          ".",
+          "--cursor",
+          "1",
+        ],
+        homeDir,
+      );
+      assert.equal(secondPage.code, 0, secondPage.stderr);
+      const secondPayload = JSON.parse(secondPage.stdout.trim()) as {
+        cursor?: string;
+        nextCursor?: string | null;
+        sessions?: Array<{ sessionId?: string }>;
+      };
+      assert.equal(secondPayload.cursor, "1");
+      assert.equal(secondPayload.nextCursor ?? null, null);
+      assert.equal(secondPayload.sessions?.length, 1);
+      assert.equal(secondPayload.sessions?.[0]?.sessionId, "mock-session-gamma");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: sessions list falls back to local records when agent lacks session/list", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const created = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+      const createdPayload = JSON.parse(created.stdout.trim()) as { acpxRecordId?: string };
+
+      const listed = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "sessions", "list"],
+        homeDir,
+      );
+      assert.equal(listed.code, 0, listed.stderr);
+      const listedPayload = JSON.parse(listed.stdout.trim()) as Array<{
+        acpxRecordId?: string;
+        cwd?: string;
+      }>;
+      assert.equal(Array.isArray(listedPayload), true);
+      assert.equal(
+        listedPayload.some(
+          (session) => session.acpxRecordId === createdPayload.acpxRecordId && session.cwd === cwd,
+        ),
+        true,
+      );
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: perf metrics capture writes ndjson records for CLI runs", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -2,6 +2,7 @@
 
 import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
+import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import {
   AgentSideConnection,
@@ -14,6 +15,8 @@ import {
   type AgentSideConnection as AgentConnection,
   type ContentBlock,
   type InitializeResponse,
+  type ListSessionsRequest,
+  type ListSessionsResponse,
   type LoadSessionRequest,
   type LoadSessionResponse,
   type NewSessionResponse,
@@ -27,6 +30,7 @@ import {
   type SetSessionModelResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
+  type SessionInfo,
   type SessionModelState,
 } from "@agentclientprotocol/sdk";
 
@@ -41,6 +45,8 @@ type MockAgentOptions = {
   loadSessionMeta?: Record<string, string>;
   supportsLoadSession: boolean;
   supportsCloseSession: boolean;
+  supportsListSessions: boolean;
+  listPageSize: number;
   closeSessionMarker?: string;
   loadSessionNotFound: boolean;
   loadSessionFailsOnEmpty: boolean;
@@ -256,6 +262,15 @@ function parseOptionValue(args: string[], index: number, flag: string): string {
   return value.trim();
 }
 
+function parsePositiveIntegerOption(args: string[], index: number, flag: string): number {
+  const value = parseOptionValue(args, index, flag);
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} requires a positive integer`);
+  }
+  return parsed;
+}
+
 type MetaFlagTarget = "newSessionMeta" | "loadSessionMeta";
 
 type MetaFlagSpec = {
@@ -308,6 +323,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   const loadSessionMeta: Record<string, string> = {};
   let supportsLoadSession = false;
   let supportsCloseSession = false;
+  let supportsListSessions = false;
+  let listPageSize = 100;
   let closeSessionMarker: string | undefined;
   let loadSessionNotFound = false;
   let loadSessionFailsOnEmpty = false;
@@ -391,6 +408,18 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       continue;
     }
 
+    if (token === "--supports-list-sessions") {
+      supportsListSessions = true;
+      continue;
+    }
+
+    if (token === "--list-page-size") {
+      supportsListSessions = true;
+      listPageSize = parsePositiveIntegerOption(argv, index + 1, token);
+      index += 1;
+      continue;
+    }
+
     if (token === "--close-session-marker") {
       supportsCloseSession = true;
       closeSessionMarker = parseOptionValue(argv, index + 1, token);
@@ -444,6 +473,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     loadSessionMeta: Object.keys(loadSessionMeta).length > 0 ? { ...loadSessionMeta } : undefined,
     supportsLoadSession,
     supportsCloseSession,
+    supportsListSessions,
+    listPageSize,
     closeSessionMarker,
     loadSessionNotFound,
     loadSessionFailsOnEmpty,
@@ -480,6 +511,52 @@ function createSessionState(hasCompletedPrompt = false): SessionState {
     },
     transientPromptAttempts: {},
   };
+}
+
+function buildMockSessionInventory(cwd: string): SessionInfo[] {
+  return [
+    {
+      sessionId: "mock-session-alpha",
+      cwd,
+      title: "Alpha task",
+      updatedAt: "2026-05-21T00:00:00.000Z",
+      _meta: {
+        source: "mock-agent",
+        messageCount: 2,
+      },
+    },
+    {
+      sessionId: "mock-session-beta",
+      cwd: path.join(cwd, "other"),
+      title: "Beta task",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      _meta: {
+        source: "mock-agent",
+        messageCount: 4,
+      },
+    },
+    {
+      sessionId: "mock-session-gamma",
+      cwd,
+      updatedAt: "2026-05-19T00:00:00.000Z",
+      _meta: {
+        source: "mock-agent",
+        messageCount: 6,
+      },
+    },
+  ];
+}
+
+function parseListCursor(cursor: string | null | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+
+  const parsed = Number(cursor);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw RequestError.invalidParams({ cursor }, "Invalid list cursor");
+  }
+  return parsed;
 }
 
 function buildConfigOptions(state: SessionState): SetSessionConfigOptionResponse["configOptions"] {
@@ -542,12 +619,17 @@ class MockAgent implements Agent {
   }
 
   async initialize(): Promise<InitializeResponse> {
+    const sessionCapabilities = {
+      ...(this.options.supportsCloseSession ? { close: {} } : {}),
+      ...(this.options.supportsListSessions ? { list: {} } : {}),
+    };
+
     return {
       protocolVersion: PROTOCOL_VERSION,
       authMethods: [],
       agentCapabilities: {
         ...(this.options.supportsLoadSession ? { loadSession: true } : {}),
-        ...(this.options.supportsCloseSession ? { sessionCapabilities: { close: {} } } : {}),
+        ...(Object.keys(sessionCapabilities).length > 0 ? { sessionCapabilities } : {}),
       },
     };
   }
@@ -637,6 +719,26 @@ class MockAgent implements Agent {
       writeFileSync(this.options.closeSessionMarker, `${params.sessionId}\n`, { flag: "a" });
     }
     return {};
+  }
+
+  async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
+    if (!this.options.supportsListSessions) {
+      throw RequestError.methodNotFound("session/list");
+    }
+
+    const start = parseListCursor(params.cursor);
+    const cwd = params.cwd ?? undefined;
+    const sessions = buildMockSessionInventory(cwd ?? process.cwd()).filter((session) =>
+      cwd ? session.cwd === cwd : true,
+    );
+    const pageEnd = start + this.options.listPageSize;
+    return {
+      _meta: {
+        source: "mock-agent-list",
+      },
+      sessions: sessions.slice(start, pageEnd),
+      nextCursor: pageEnd < sessions.length ? String(pageEnd) : undefined,
+    };
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {


### PR DESCRIPTION
## Summary

- Route `sessions list` through ACP `session/list` when the selected agent advertises `sessionCapabilities.list`.
- Add `--cursor`, `--filter-cwd`, and `--local` so callers can page agent results, filter by cwd, or explicitly inspect saved acpx records.
- Preserve agent response/session metadata in JSON output and document the updated behavior.

## Root Cause

`handleSessionsList` only read local `~/.acpx/sessions` records via `listSessionsForAgent`, so it could not surface an agent's protocol-native session inventory, pagination, cwd filtering, or metadata.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run check:docs`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run build:test`
- `node --test dist-test/test/client.test.js dist-test/test/integration.test.js`
- `git diff --check`