### PR TITLE
fix: support ACP audio prompt content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Repo: https://github.com/openclaw/acpx
   cursor pagination, cwd filtering, and agent-native session metadata. Thanks
   @amknight.
 - Sessions/reconnect: use ACP `session/resume` when adapters advertise it, so resume-only agents can reuse saved sessions without requiring `session/load`. Thanks @amknight.
+- CLI/ACP: validate rich prompt blocks against advertised ACP
+  `promptCapabilities` and support audio prompt content end-to-end. Thanks
+  @amknight.
 
 ## 2026.5.15 (v0.8.0)
 

--- a/examples/flows/replay-viewer/server/live-run-state.ts
+++ b/examples/flows/replay-viewer/server/live-run-state.ts
@@ -320,6 +320,10 @@ function promptTextFromUserMessage(message: unknown): string | null {
             ? mention.uri
             : null;
       }
+      if ("Audio" in part && part.Audio && typeof part.Audio === "object") {
+        const audio = part.Audio as { mime_type?: unknown };
+        return typeof audio.mime_type === "string" ? `[audio] ${audio.mime_type}` : "[audio]";
+      }
       return null;
     })
     .filter((value: string | null): value is string => {

--- a/examples/flows/replay-viewer/src/lib/view-model-conversation.ts
+++ b/examples/flows/replay-viewer/src/lib/view-model-conversation.ts
@@ -411,6 +411,15 @@ function describeStructuredMessage(
         continue;
       }
 
+      if ("Audio" in part) {
+        const audio = (part as { Audio?: { mime_type?: unknown } }).Audio;
+        const text =
+          audio && typeof audio.mime_type === "string" ? `[audio] ${audio.mime_type}` : "[audio]";
+        textBlocks.push(text);
+        contentParts.push({ type: "text", text });
+        continue;
+      }
+
       if ("ToolUse" in part) {
         const toolUse = (part as { ToolUse?: Record<string, unknown> }).ToolUse;
         if (toolUse && typeof toolUse === "object") {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -43,6 +43,7 @@ import {
   GeminiAcpStartupTimeoutError,
   PermissionDeniedError,
   PermissionPromptUnavailableError,
+  UnsupportedPromptContentError,
 } from "../errors.js";
 import { FileSystemHandlers } from "../filesystem.js";
 import {
@@ -51,7 +52,7 @@ import {
   inferToolKind,
   resolvePermissionRequestWithDetails,
 } from "../permissions.js";
-import { textPrompt } from "../prompt-content.js";
+import { getUnsupportedPromptContentMessage, textPrompt } from "../prompt-content.js";
 import { extractRuntimeSessionId } from "../session/runtime-session-id.js";
 import { buildSpawnCommandOptions } from "../spawn-command-options.js";
 import type {
@@ -915,6 +916,7 @@ export class AcpClient {
 
   async prompt(sessionId: string, prompt: PromptInput | string): Promise<PromptResponse> {
     const connection = this.getConnection();
+    const normalizedPrompt = this.normalizePromptForAgent(prompt);
     const restoreConsoleError = this.options.suppressSdkConsoleErrors
       ? installSdkConsoleErrorSuppression()
       : undefined;
@@ -924,7 +926,7 @@ export class AcpClient {
       promptPromise = this.runConnectionRequest(() =>
         connection.prompt({
           sessionId,
-          prompt: typeof prompt === "string" ? textPrompt(prompt) : prompt,
+          prompt: normalizedPrompt,
         }),
       );
     } catch (error) {
@@ -951,6 +953,18 @@ export class AcpClient {
       this.abortAndDropPermissionSignal(sessionId);
       this.promptPermissionFailures.delete(sessionId);
     }
+  }
+
+  private normalizePromptForAgent(prompt: PromptInput | string): PromptInput {
+    const normalizedPrompt = typeof prompt === "string" ? textPrompt(prompt) : prompt;
+    const unsupportedPromptContent = getUnsupportedPromptContentMessage(
+      normalizedPrompt,
+      this.initResult?.agentCapabilities,
+    );
+    if (unsupportedPromptContent) {
+      throw new UnsupportedPromptContentError(unsupportedPromptContent);
+    }
+    return normalizedPrompt;
   }
 
   private returnPromptResponseOrPermissionFailure(

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -867,7 +867,7 @@ function userContentToText(content: SessionUserContent): string {
     return content.Image.source || "[image]";
   }
   if ("Audio" in content) {
-    return `[audio] ${content.Audio.mime_type}`;
+    return `[audio] ${content.Audio.mime_type || "audio"}`;
   }
   return "";
 }

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -866,6 +866,9 @@ function userContentToText(content: SessionUserContent): string {
   if ("Image" in content) {
     return content.Image.source || "[image]";
   }
+  if ("Audio" in content) {
+    return `[audio] ${content.Audio.mime_type}`;
+  }
   return "";
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -108,6 +108,16 @@ export class AgentDisconnectedError extends AcpxOperationalError {
   }
 }
 
+export class UnsupportedPromptContentError extends AcpxOperationalError {
+  constructor(message: string) {
+    super(message, {
+      outputCode: "USAGE",
+      detailCode: "UNSUPPORTED_PROMPT_CONTENT",
+      origin: "acp",
+    });
+  }
+}
+
 export class SessionResumeRequiredError extends AcpxOperationalError {
   constructor(message: string, options?: AcpxErrorOptions) {
     super(message, {

--- a/src/persisted-key-policy.ts
+++ b/src/persisted-key-policy.ts
@@ -7,6 +7,7 @@ const ZED_TAG_KEYS = new Set([
   "Text",
   "Mention",
   "Image",
+  "Audio",
   "Thinking",
   "RedactedThinking",
   "ToolUse",

--- a/src/prompt-content.ts
+++ b/src/prompt-content.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type { AgentCapabilities, ContentBlock } from "@agentclientprotocol/sdk";
 
 export type PromptInput = ContentBlock[];
 
@@ -31,6 +31,10 @@ function isImageMimeType(value: string): boolean {
   return /^image\/[A-Za-z0-9.+-]+$/i.test(value);
 }
 
+function isAudioMimeType(value: string): boolean {
+  return /^audio\/[A-Za-z0-9.+-]+$/i.test(value);
+}
+
 function isTextBlock(value: unknown): value is Extract<ContentBlock, { type: "text" }> {
   const record = asRecord(value);
   return record?.type === "text" && typeof record.text === "string";
@@ -42,6 +46,17 @@ function isImageBlock(value: unknown): value is Extract<ContentBlock, { type: "i
     record?.type === "image" &&
     isNonEmptyString(record.mimeType) &&
     isImageMimeType(record.mimeType) &&
+    typeof record.data === "string" &&
+    isBase64Data(record.data)
+  );
+}
+
+function isAudioBlock(value: unknown): value is Extract<ContentBlock, { type: "audio" }> {
+  const record = asRecord(value);
+  return (
+    record?.type === "audio" &&
+    isNonEmptyString(record.mimeType) &&
+    isAudioMimeType(record.mimeType) &&
     typeof record.data === "string" &&
     isBase64Data(record.data)
   );
@@ -75,6 +90,7 @@ function isResourceBlock(value: unknown): value is Extract<ContentBlock, { type:
 const CONTENT_BLOCK_VALIDATORS = [
   isTextBlock,
   isImageBlock,
+  isAudioBlock,
   isResourceLinkBlock,
   isResourceBlock,
 ] as const;
@@ -91,6 +107,7 @@ type ContentBlockValidation = (
 const CONTENT_BLOCK_ERROR_VALIDATORS: Record<string, ContentBlockValidation> = {
   text: validateTextContentBlock,
   image: validateImageContentBlock,
+  audio: validateAudioContentBlock,
   resource_link: validateResourceLinkContentBlock,
   resource: validateResourceContentBlock,
 };
@@ -126,6 +143,24 @@ function validateImageContentBlock(
   return isBase64Data(record.data)
     ? undefined
     : `prompt[${index}] image block data must be valid base64`;
+}
+
+function validateAudioContentBlock(
+  record: Record<string, unknown>,
+  index: number,
+): string | undefined {
+  if (!isNonEmptyString(record.mimeType)) {
+    return `prompt[${index}] audio block must include a non-empty mimeType`;
+  }
+  if (!isAudioMimeType(record.mimeType)) {
+    return `prompt[${index}] audio block mimeType must start with audio/`;
+  }
+  if (typeof record.data !== "string" || record.data.length === 0) {
+    return `prompt[${index}] audio block must include non-empty base64 data`;
+  }
+  return isBase64Data(record.data)
+    ? undefined
+    : `prompt[${index}] audio block data must be valid base64`;
 }
 
 function validateResourceLinkContentBlock(
@@ -170,6 +205,43 @@ function getContentBlockValidationError(value: unknown, index: number): string |
 
 export function isPromptInput(value: unknown): value is PromptInput {
   return Array.isArray(value) && value.every((entry) => isContentBlock(entry));
+}
+
+type PromptCapabilityName = "image" | "audio" | "embeddedContext";
+
+type PromptCapabilityRequirement = {
+  blockType: "image" | "audio" | "resource";
+  capability: PromptCapabilityName;
+};
+
+function promptCapabilityRequirement(block: ContentBlock): PromptCapabilityRequirement | undefined {
+  switch (block.type) {
+    case "image":
+      return { blockType: "image", capability: "image" };
+    case "audio":
+      return { blockType: "audio", capability: "audio" };
+    case "resource":
+      return { blockType: "resource", capability: "embeddedContext" };
+    default:
+      return undefined;
+  }
+}
+
+export function getUnsupportedPromptContentMessage(
+  prompt: PromptInput,
+  agentCapabilities: AgentCapabilities | undefined,
+): string | undefined {
+  for (const [index, block] of prompt.entries()) {
+    const requirement = promptCapabilityRequirement(block);
+    if (!requirement) {
+      continue;
+    }
+    if (agentCapabilities?.promptCapabilities?.[requirement.capability] === true) {
+      continue;
+    }
+    return `prompt[${index}] ${requirement.blockType} content requires agentCapabilities.promptCapabilities.${requirement.capability}`;
+  }
+  return undefined;
 }
 
 export function textPrompt(text: string): PromptInput {
@@ -249,6 +321,8 @@ function contentBlockDisplayText(block: ContentBlock): string {
       return resourceBlockDisplayText(block);
     case "image":
       return `[image] ${block.mimeType}`;
+    case "audio":
+      return `[audio] ${block.mimeType}`;
     default:
       return "";
   }

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -167,24 +167,31 @@ function toPromptInput(
   if (!attachments || attachments.length === 0) {
     return text;
   }
-  const blocks: Array<
-    { type: "text"; text: string } | { type: "image"; mimeType: string; data: string }
-  > = [];
+  const blocks: PromptInput = [];
   if (text) {
     blocks.push({ type: "text", text });
   }
   for (const attachment of attachments) {
-    if (!attachment.mediaType.startsWith("image/")) {
-      throw new AcpRuntimeError(
-        "ACP_TURN_FAILED",
-        `Unsupported ACP runtime attachment media type: ${attachment.mediaType}`,
-      );
+    if (attachment.mediaType.startsWith("image/")) {
+      blocks.push({
+        type: "image",
+        mimeType: attachment.mediaType,
+        data: attachment.data,
+      });
+      continue;
     }
-    blocks.push({
-      type: "image",
-      mimeType: attachment.mediaType,
-      data: attachment.data,
-    });
+    if (attachment.mediaType.startsWith("audio/")) {
+      blocks.push({
+        type: "audio",
+        mimeType: attachment.mediaType,
+        data: attachment.data,
+      });
+      continue;
+    }
+    throw new AcpRuntimeError(
+      "ACP_TURN_FAILED",
+      `Unsupported ACP runtime attachment media type: ${attachment.mediaType}`,
+    );
   }
   return blocks.length > 0 ? blocks : textPrompt(text);
 }

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -60,6 +60,10 @@ export type AcpRuntimeEnsureInput = {
 };
 
 export type AcpRuntimeTurnAttachment = {
+  /**
+   * Media type for binary prompt attachments. The runtime currently maps
+   * image/* and audio/* attachments to ACP prompt content blocks.
+   */
   mediaType: string;
   data: string;
 };

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -250,6 +250,7 @@ type ToolContentTextReader = (record: Record<string, unknown>) => string | undef
 
 const TOOL_CONTENT_TEXT_READERS: Record<string, ToolContentTextReader> = {
   text: (record) => asString(record.text),
+  audio: (record) => `[audio] ${asOptionalString(record.mimeType) || "audio"}`,
   resource_link: (record) =>
     asOptionalString(record.title) || asOptionalString(record.name) || asOptionalString(record.uri),
   resource: (record) => {

--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -60,22 +60,24 @@ function normalizeAgentName(value: unknown): string | undefined {
 }
 
 function extractText(content: ContentBlock): string | undefined {
-  if (content.type === "text") {
-    return content.text;
+  switch (content.type) {
+    case "text":
+      return content.text;
+    case "resource_link":
+      return content.title ?? content.name ?? content.uri;
+    case "resource":
+      return extractResourceText(content);
+    case "audio":
+      return `[audio] ${content.mimeType}`;
+    default:
+      return undefined;
   }
+}
 
-  if (content.type === "resource_link") {
-    return content.title ?? content.name ?? content.uri;
-  }
-
-  if (content.type === "resource") {
-    if ("text" in content.resource && typeof content.resource.text === "string") {
-      return content.resource.text;
-    }
-    return content.resource.uri;
-  }
-
-  return undefined;
+function extractResourceText(content: Extract<ContentBlock, { type: "resource" }>): string {
+  return "text" in content.resource && typeof content.resource.text === "string"
+    ? content.resource.text
+    : content.resource.uri;
 }
 
 function contentToUserContent(content: ContentBlock): SessionUserContent | undefined {
@@ -104,6 +106,15 @@ function contentToUserContent(content: ContentBlock): SessionUserContent | undef
       Image: {
         source: content.data,
         size: null,
+      },
+    };
+  }
+
+  if (content.type === "audio") {
+    return {
+      Audio: {
+        source: content.data,
+        mime_type: content.mimeType,
       },
     };
   }

--- a/src/session/persistence/parse.ts
+++ b/src/session/persistence/parse.ts
@@ -99,6 +99,11 @@ function isSessionMessageImage(raw: unknown): boolean {
   return !!size && isFiniteNumber(size.width) && isFiniteNumber(size.height);
 }
 
+function isSessionMessageAudio(raw: unknown): boolean {
+  const record = asRecord(raw);
+  return !!record && typeof record.source === "string" && typeof record.mime_type === "string";
+}
+
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
@@ -120,6 +125,10 @@ function isUserContent(raw: unknown): boolean {
 
   if (record.Image !== undefined) {
     return isSessionMessageImage(record.Image);
+  }
+
+  if (record.Audio !== undefined) {
+    return isSessionMessageAudio(record.Audio);
   }
 
   return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,11 @@ export type SessionMessageImage = {
   } | null;
 };
 
+export type SessionMessageAudio = {
+  source: string;
+  mime_type: string;
+};
+
 export type SessionUserContent =
   | {
       Text: string;
@@ -250,6 +255,9 @@ export type SessionUserContent =
     }
   | {
       Image: SessionMessageImage;
+    }
+  | {
+      Audio: SessionMessageAudio;
     };
 
 export type SessionToolUse = {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1883,6 +1883,7 @@ test("exec accepts structured ACP prompt blocks from stdin", async () => {
         stdin: JSON.stringify([
           { type: "text", text: "inspect-prompt" },
           { type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+          { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
         ]),
       },
     );
@@ -1892,6 +1893,7 @@ test("exec accepts structured ACP prompt blocks from stdin", async () => {
     assert.deepEqual(payload, [
       { type: "text", text: "inspect-prompt" },
       { type: "image", mimeType: "image/png", bytes: 8 },
+      { type: "audio", mimeType: "audio/wav", bytes: 8 },
     ]);
   });
 });
@@ -1914,6 +1916,7 @@ test("prompt preserves structured ACP prompt blocks through the queue owner", as
         stdin: JSON.stringify([
           { type: "text", text: "inspect-prompt" },
           { type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+          { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
         ]),
       },
     );
@@ -1923,6 +1926,7 @@ test("prompt preserves structured ACP prompt blocks through the queue owner", as
     assert.deepEqual(payload, [
       { type: "text", text: "inspect-prompt" },
       { type: "image", mimeType: "image/png", bytes: 8 },
+      { type: "audio", mimeType: "audio/wav", bytes: 8 },
     ]);
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -16,6 +16,7 @@ import {
   AuthPolicyError,
   PermissionDeniedError,
   PermissionPromptUnavailableError,
+  UnsupportedPromptContentError,
 } from "../src/errors.js";
 
 type ClientInternals = {
@@ -107,6 +108,11 @@ type ClientInternals = {
   promptPermissionFailures: Map<string, PermissionPromptUnavailableError>;
   initResult?: {
     agentCapabilities?: {
+      promptCapabilities?: {
+        image?: boolean;
+        audio?: boolean;
+        embeddedContext?: boolean;
+      };
       sessionCapabilities?: {
         close?: Record<string, never>;
         list?: Record<string, never>;
@@ -938,6 +944,61 @@ test("AcpClient lifecycle snapshot and cancel helpers reflect active prompt stat
 
   const cancelled = await client.cancelActivePrompt(50);
   assert.deepEqual(cancelled, { stopReason: "cancelled" });
+});
+
+test("AcpClient rejects rich prompt content not advertised by promptCapabilities", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let promptCalled = false;
+  internals.initResult = {
+    agentCapabilities: {
+      promptCapabilities: {
+        image: true,
+      },
+    },
+  };
+  internals.connection = {
+    prompt: async () => {
+      promptCalled = true;
+      return { stopReason: "end_turn" };
+    },
+  };
+
+  await assert.rejects(
+    async () =>
+      await client.prompt("session-audio", [
+        { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+      ]),
+    (error: unknown) =>
+      error instanceof UnsupportedPromptContentError &&
+      error.message.includes("promptCapabilities.audio"),
+  );
+  assert.equal(promptCalled, false);
+});
+
+test("AcpClient sends audio prompts when the agent advertises audio support", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let capturedPrompt: unknown;
+  internals.initResult = {
+    agentCapabilities: {
+      promptCapabilities: {
+        audio: true,
+      },
+    },
+  };
+  internals.connection = {
+    prompt: async (params: { prompt: unknown }) => {
+      capturedPrompt = params.prompt;
+      return { stopReason: "end_turn" };
+    },
+  };
+
+  await client.prompt("session-audio", [
+    { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+  ]);
+
+  assert.deepEqual(capturedPrompt, [{ type: "audio", mimeType: "audio/wav", data: "UklGRg==" }]);
 });
 
 test("AcpClient prompt rejects when the agent disconnects mid-prompt", async () => {

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -678,6 +678,11 @@ class MockAgent implements Agent {
       authMethods: [],
       agentCapabilities: {
         ...(this.options.supportsLoadSession ? { loadSession: true } : {}),
+        promptCapabilities: {
+          image: true,
+          audio: true,
+          embeddedContext: true,
+        },
         ...(Object.keys(sessionCapabilities).length > 0 ? { sessionCapabilities } : {}),
       },
     };

--- a/test/persisted-key-policy.test.ts
+++ b/test/persisted-key-policy.test.ts
@@ -34,7 +34,7 @@ function makeRecord(): SessionRecord {
       {
         User: {
           id: "user-1",
-          content: [{ Text: "hello" }],
+          content: [{ Text: "hello" }, { Audio: { source: "UklGRg==", mime_type: "audio/wav" } }],
         },
       },
       {

--- a/test/prompt-content.test.ts
+++ b/test/prompt-content.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  getUnsupportedPromptContentMessage,
   isPromptInput,
   mergePromptSourceWithText,
   parsePromptSource,
@@ -17,6 +18,15 @@ test("parsePromptSource accepts valid image blocks", () => {
   assert.deepEqual(prompt, [{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" }]);
 });
 
+test("parsePromptSource accepts valid audio blocks", () => {
+  const prompt = parsePromptSource(
+    JSON.stringify([{ type: "audio", mimeType: "audio/wav", data: "UklGRg==" }]),
+  );
+
+  assert.deepEqual(prompt, [{ type: "audio", mimeType: "audio/wav", data: "UklGRg==" }]);
+  assert.equal(isPromptInput(prompt), true);
+});
+
 test("parsePromptSource rejects image blocks with non-image mime types", () => {
   assert.throws(
     () =>
@@ -26,6 +36,28 @@ test("parsePromptSource rejects image blocks with non-image mime types", () => {
     (error: unknown) =>
       error instanceof PromptInputValidationError &&
       error.message.includes("image block mimeType must start with image/"),
+  );
+});
+
+test("parsePromptSource rejects audio blocks with non-audio mime types", () => {
+  assert.throws(
+    () =>
+      parsePromptSource(
+        JSON.stringify([{ type: "audio", mimeType: "application/octet-stream", data: "UklGRg==" }]),
+      ),
+    (error: unknown) =>
+      error instanceof PromptInputValidationError &&
+      error.message.includes("audio block mimeType must start with audio/"),
+  );
+});
+
+test("parsePromptSource rejects audio blocks with invalid base64 payloads", () => {
+  assert.throws(
+    () =>
+      parsePromptSource(JSON.stringify([{ type: "audio", mimeType: "audio/wav", data: "%%%" }])),
+    (error: unknown) =>
+      error instanceof PromptInputValidationError &&
+      error.message.includes("audio block data must be valid base64"),
   );
 });
 
@@ -159,7 +191,52 @@ test("promptToDisplayText renders text, resources, and images", () => {
     { type: "resource_link", uri: "file:///tmp/spec.md", name: "spec", title: "Spec" },
     { type: "resource", resource: { uri: "file:///tmp/context.txt", text: "Context" } },
     { type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+    { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
   ]);
 
-  assert.equal(display, "hello\n\nSpec\n\nContext\n\n[image] image/png");
+  assert.equal(display, "hello\n\nSpec\n\nContext\n\n[image] image/png\n\n[audio] audio/wav");
+});
+
+test("getUnsupportedPromptContentMessage enforces rich prompt capabilities", () => {
+  const prompt = parsePromptSource(
+    JSON.stringify([
+      { type: "text", text: "hello" },
+      { type: "resource_link", uri: "file:///tmp/spec.md", name: "spec" },
+      { type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+      { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+      { type: "resource", resource: { uri: "file:///tmp/context.txt", text: "Context" } },
+    ]),
+  );
+
+  assert.equal(
+    getUnsupportedPromptContentMessage(prompt, undefined),
+    "prompt[2] image content requires agentCapabilities.promptCapabilities.image",
+  );
+  assert.equal(
+    getUnsupportedPromptContentMessage(prompt, {
+      promptCapabilities: {
+        image: true,
+      },
+    }),
+    "prompt[3] audio content requires agentCapabilities.promptCapabilities.audio",
+  );
+  assert.equal(
+    getUnsupportedPromptContentMessage(prompt, {
+      promptCapabilities: {
+        image: true,
+        audio: true,
+      },
+    }),
+    "prompt[4] resource content requires agentCapabilities.promptCapabilities.embeddedContext",
+  );
+  assert.equal(
+    getUnsupportedPromptContentMessage(prompt, {
+      promptCapabilities: {
+        image: true,
+        audio: true,
+        embeddedContext: true,
+      },
+    }),
+    undefined,
+  );
 });

--- a/test/queue-messages.test.ts
+++ b/test/queue-messages.test.ts
@@ -228,7 +228,10 @@ test("parseQueueRequest accepts control requests and explicit prompt blocks", ()
       type: "submit_prompt",
       requestId: "req-prompt",
       message: "ignored text fallback",
-      prompt: [{ type: "text", text: "structured" }],
+      prompt: [
+        { type: "text", text: "structured" },
+        { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+      ],
       permissionMode: "approve-all",
       suppressSdkConsoleErrors: false,
       waitForCompletion: false,
@@ -238,7 +241,10 @@ test("parseQueueRequest accepts control requests and explicit prompt blocks", ()
       requestId: "req-prompt",
       ownerGeneration: undefined,
       message: "ignored text fallback",
-      prompt: [{ type: "text", text: "structured" }],
+      prompt: [
+        { type: "text", text: "structured" },
+        { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+      ],
       permissionMode: "approve-all",
       nonInteractivePermissions: undefined,
       timeoutMs: undefined,

--- a/test/runtime-events.test.ts
+++ b/test/runtime-events.test.ts
@@ -535,18 +535,20 @@ test("parsePromptEventLine covers status and tool summary fallbacks", () => {
         content: [
           { type: "resource_link", uri: "file:///fallback" },
           { type: "resource", resource: { uri: "file:///resource" } },
+          { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
           { type: "terminal" },
         ],
       }),
     ),
     {
       type: "tool_call",
-      text: "tool call: file:///fallback\nfile:///resource\n[terminal]",
+      text: "tool call: file:///fallback\nfile:///resource\n[audio] audio/wav\n[terminal]",
       tag: "tool_call_update",
       title: "tool call",
       content: [
         { type: "resource_link", uri: "file:///fallback" },
         { type: "resource", resource: { uri: "file:///resource" } },
+        { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
         { type: "terminal" },
       ],
     },

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -2169,6 +2169,60 @@ test("AcpRuntimeManager rejects unsupported runtime attachment media types", asy
   );
 });
 
+test("AcpRuntimeManager maps audio attachments into ACP prompt blocks", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "audio-attachment-session",
+    acpSessionId: "audio-attachment-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let capturedPrompt: unknown;
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => true,
+          supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async (_sessionId: string, input: unknown) => {
+            capturedPrompt = input;
+            return { stopReason: "end_turn" };
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("audio-attachment-session"),
+    text: "transcribe",
+    attachments: [{ mediaType: "audio/wav", data: "UklGRg==" }],
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-audio-attachment",
+  });
+  const { result } = await collectTurn(turn);
+
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
+  assert.deepEqual(capturedPrompt, [
+    { type: "text", text: "transcribe" },
+    { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+  ]);
+});
+
 test("AcpRuntimeManager fails persistent turns clearly when session reuse is unavailable", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "persistent-session",

--- a/test/session-conversation-model.test.ts
+++ b/test/session-conversation-model.test.ts
@@ -188,6 +188,37 @@ test("conversation model captures prompt, chunks, tool calls, and metadata", () 
   assert.deepEqual(acpxState?.available_commands, ["create_plan"]);
 });
 
+test("recordPromptSubmission preserves audio prompt content", () => {
+  const conversation = createSessionConversation("2026-02-27T10:00:00.000Z");
+
+  const messageId = recordPromptSubmission(
+    conversation,
+    [
+      { type: "text", text: "transcribe" },
+      { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
+    ],
+    "2026-02-27T10:00:01.000Z",
+  );
+
+  assert.equal(typeof messageId, "string");
+  assert.deepEqual(conversation.messages, [
+    {
+      User: {
+        id: messageId,
+        content: [
+          { Text: "transcribe" },
+          {
+            Audio: {
+              source: "UklGRg==",
+              mime_type: "audio/wav",
+            },
+          },
+        ],
+      },
+    },
+  ]);
+});
+
 test("recordClientOperation keeps state and advances timestamp", () => {
   const conversation = createSessionConversation("2026-02-27T10:00:00.000Z");
   const state = recordClientOperation(

--- a/test/session-persistence.test.ts
+++ b/test/session-persistence.test.ts
@@ -253,7 +253,10 @@ test("listSessions preserves lifecycle and conversation metadata", async () => {
           {
             User: {
               id: "7c7615ad-5ba0-4cd3-a5f7-6ad9346dcfd5",
-              content: [{ Text: "hello" }],
+              content: [
+                { Text: "hello" },
+                { Audio: { source: "UklGRg==", mime_type: "audio/wav" } },
+              ],
             },
           },
           {
@@ -279,6 +282,12 @@ test("listSessions preserves lifecycle and conversation metadata", async () => {
     assert.equal(record.lastAgentExitAt, "2026-01-01T00:02:00.000Z");
     assert.equal(record.lastAgentDisconnectReason, "process_exit");
     assert.equal(record.messages.length, 2);
+    assert.deepEqual(record.messages[0], {
+      User: {
+        id: "7c7615ad-5ba0-4cd3-a5f7-6ad9346dcfd5",
+        content: [{ Text: "hello" }, { Audio: { source: "UklGRg==", mime_type: "audio/wav" } }],
+      },
+    });
     assert.equal(record.title, "My Thread");
   });
 });


### PR DESCRIPTION
## Summary

- add ACP audio prompt block validation and display handling
- reject rich prompt content before `session/prompt` when the agent does not advertise the matching `promptCapabilities`
- map runtime `audio/*` attachments into ACP audio content blocks
- persist and replay-display submitted audio prompt content in session records and the replay viewer

## Why

ACP requires clients to restrict prompt content according to `agentCapabilities.promptCapabilities`. `acpx` previously accepted and sent image/resource prompt blocks without checking the negotiated capability set, and it did not accept ACP audio content blocks even though ACP defines them.

## Validation

- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run viewer:typecheck`
- `pnpm run viewer:build`
- `pnpm run build:test`
- `node --test dist-test/test/prompt-content.test.js dist-test/test/client.test.js dist-test/test/runtime-manager.test.js dist-test/test/session-conversation-model.test.js dist-test/test/session-persistence.test.js dist-test/test/persisted-key-policy.test.js dist-test/test/queue-messages.test.js dist-test/test/runtime-events.test.js`
- `node --test --test-name-pattern "structured ACP prompt blocks" dist-test/test/cli.test.js`

## Known validation note

`pnpm run test:coverage` currently stops on one unrelated existing CLI routing test on `origin/main`: `CLI resolves unknown raw agent commands after newer global flags`. In that run, 704 tests passed and that one test failed before the coverage phase executed.