### PR TITLE
chore: switch codex adapter to agentclientprotocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ Main landing documentation policy:
 6. Harness-specific docs for other supported agents MUST live under `agents/` and MUST use capitalized filenames, for example `agents/Cursor.md` and `agents/Copilot.md`.
 7. No other specific harness MUST BE ALLOWED to receive special placement, singled-out examples, or harness-specific promotion in main landing docs. This rule applies even when the change is framed as harmless, helpful, or accidental.
 8. Other harnesses may still be supported elsewhere in the repo, but main landing docs must describe them impartially and MUST NOT promote them unjustly.
-9. Documentation MUST NOT include adapter package version specifiers or semver ranges such as `pi-acp@^0.0.22` or `@zed-industries/codex-acp@^0.9.5`. Keep documentation generic. Keep actual adapter pinning in code, config, or release logic instead.
+9. Documentation MUST NOT include adapter package version specifiers or semver ranges such as `pi-acp@^0.0.22` or `@agentclientprotocol/codex-acp@^0.0.44`. Keep documentation generic. Keep actual adapter pinning in code, config, or release logic instead.
 
 Harness documentation synchronization policy:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Repo: https://github.com/openclaw/acpx
 
 - Tooling: add Slophammer TypeScript quality gates for coverage, complexity,
   unsafe types, mutation testing, DRY checks, and dependency boundaries.
+- Agents/built-ins: switch the default Codex adapter to `@agentclientprotocol/codex-acp`, with Codex model selection handled through advertised ACP model ids.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Repo: https://github.com/openclaw/acpx
 
 - Tooling: add Slophammer TypeScript quality gates for coverage, complexity,
   unsafe types, mutation testing, DRY checks, and dependency boundaries.
-- Agents/built-ins: switch the default Codex adapter to `@agentclientprotocol/codex-acp`, with Codex model selection handled through advertised ACP model ids.
+- Agents/built-ins: switch the default Codex adapter to `@agentclientprotocol/codex-acp`, with Codex model selection handled through advertised ACP model ids, and bump the default Claude ACP adapter range.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ acpx codex --file - "extra context"            # explicit stdin + appended args
 acpx codex --no-wait 'draft test migration plan' # enqueue without waiting if session is busy
 acpx codex cancel                               # cooperative cancel of in-flight prompt
 acpx codex set-mode auto                        # session/set_mode (adapter-defined mode id)
-acpx codex set thought_level high               # codex compatibility alias -> reasoning_effort
+acpx codex set model 'gpt-5.2[high]'            # session/set_model with adapter-advertised id
 acpx exec 'summarize this repo'                # default agent shortcut (codex)
 acpx codex exec 'what does this repo do?'      # one-shot, no saved session
 
@@ -344,7 +344,7 @@ Built-ins:
 | ---------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `pi`       | [pi-acp](https://github.com/svkozak/pi-acp)                                 | [Pi Coding Agent](https://github.com/mariozechner/pi)                                                           |
 | `openclaw` | native (`openclaw acp`)                                                     | [OpenClaw ACP bridge](https://github.com/openclaw/openclaw)                                                     |
-| `codex`    | [codex-acp](https://github.com/zed-industries/codex-acp)                    | [Codex CLI](https://codex.openai.com)                                                                           |
+| `codex`    | [codex-acp](https://github.com/agentclientprotocol/codex-acp)               | [Codex CLI](https://codex.openai.com)                                                                           |
 | `claude`   | [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) | [Claude Code](https://claude.ai/code)                                                                           |
 | `gemini`   | native (`gemini --acp`)                                                     | [Gemini CLI](https://github.com/google/gemini-cli)                                                              |
 | `cursor`   | native (`cursor-agent acp`)                                                 | [Cursor CLI](https://cursor.com/docs/cli/acp)                                                                   |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ The following are usually out of scope for this repository:
 If the issue is actually in an upstream tool, please report it to that project. Examples include:
 
 - OpenClaw bridge issues: [openclaw/openclaw](https://github.com/openclaw/openclaw)
-- Codex ACP adapter issues: [zed-industries/codex-acp](https://github.com/zed-industries/codex-acp)
+- Codex ACP adapter issues: [agentclientprotocol/codex-acp](https://github.com/agentclientprotocol/codex-acp)
 - Gemini CLI issues: [google/gemini-cli](https://github.com/google/gemini-cli)
 
 ## Trust Boundaries

--- a/agents/Codex.md
+++ b/agents/Codex.md
@@ -1,8 +1,8 @@
 # Codex
 
 - Built-in name: `codex`
-- Default command: `npx @zed-industries/codex-acp`
-- Upstream: https://github.com/zed-industries/codex-acp
-- Runtime config options exposed by current codex-acp releases include `mode`, `model`, and `reasoning_effort`.
-- `acpx --model <id> codex ...` applies the requested model after session creation via `session/set_config_option`.
-- `acpx codex set thought_level <value>` is supported as a compatibility alias and is translated to codex-acp `reasoning_effort`.
+- Default command: `npx -y @agentclientprotocol/codex-acp`
+- Upstream: https://github.com/agentclientprotocol/codex-acp
+- Runtime controls exposed by current codex-acp releases include ACP modes, advertised models, and `session/set_model`.
+- Reasoning effort is encoded in advertised Codex model ids such as `gpt-5.2[high]` when the adapter reports those variants.
+- `acpx --model <id> codex ...` and `acpx codex set model <id>` apply the requested model through ACP model selection.

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,7 +4,7 @@ Built-in agents:
 
 - `pi -> npx pi-acp`
 - `openclaw -> openclaw acp`
-- `codex -> npx @zed-industries/codex-acp`
+- `codex -> npx -y @agentclientprotocol/codex-acp`
 - `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - `gemini -> gemini --acp`
 - `cursor -> cursor-agent acp`
@@ -21,7 +21,7 @@ Built-in agents:
 
 Harness-specific docs in this directory:
 
-- [Codex](Codex.md): built-in `codex -> npx @zed-industries/codex-acp`
+- [Codex](Codex.md): built-in `codex -> npx -y @agentclientprotocol/codex-acp`
 - [Claude](Claude.md): built-in `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - [Copilot](Copilot.md): built-in `copilot -> copilot --acp --stdio`
 - [Droid](Droid.md): built-in `droid -> droid exec --output-format acp` with `factory-droid` and `factorydroid` aliases

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -57,7 +57,7 @@ Run against another adapter command:
 
 ```bash
 pnpm run conformance:run -- \
-  --agent-command "npx -y @zed-industries/codex-acp"
+  --agent-command "npx -y @agentclientprotocol/codex-acp"
 ```
 
 Emit machine-readable JSON and write a report file:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -187,7 +187,7 @@ acpx [global_options] codex exec [prompt_text...]
 acpx [global_options] codex sessions [list | new [--name <name>] | ensure [--name <name>] | close [name]]
 ```
 
-Built-in command mapping: `codex -> npx @zed-industries/codex-acp`
+Built-in command mapping: `codex -> npx -y @agentclientprotocol/codex-acp`
 
 ### `claude`
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,7 +13,7 @@ The default agent for top-level commands like `acpx exec …` and `acpx prompt �
 | ---------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `pi`       | `npx pi-acp`                                   | [Pi Coding Agent](https://github.com/mariozechner/pi)                                                           |
 | `openclaw` | `openclaw acp`                                 | [OpenClaw ACP bridge](https://github.com/openclaw/openclaw)                                                     |
-| `codex`    | `npx @zed-industries/codex-acp`                | [Codex CLI](https://codex.openai.com)                                                                           |
+| `codex`    | `npx -y @agentclientprotocol/codex-acp`        | [Codex CLI](https://codex.openai.com)                                                                           |
 | `claude`   | `npx -y @agentclientprotocol/claude-agent-acp` | [Claude Code](https://claude.ai/code)                                                                           |
 | `gemini`   | `gemini --acp`                                 | [Gemini CLI](https://github.com/google/gemini-cli)                                                              |
 | `cursor`   | `cursor-agent acp`                             | [Cursor CLI](https://cursor.com/docs/cli/acp)                                                                   |
@@ -54,11 +54,10 @@ Notes that override or extend the cross-agent behavior live below.
 ### Codex
 
 - Built-in name: `codex`
-- Default command: `npx @zed-industries/codex-acp`
-- Upstream: [zed-industries/codex-acp](https://github.com/zed-industries/codex-acp)
-- Runtime config keys exposed by current `codex-acp` releases: `mode`, `model`, `reasoning_effort`.
-- `acpx --model <id> codex …` applies the requested model after session creation via `session/set_config_option`.
-- `acpx codex set thought_level <value>` is accepted as a compatibility alias for codex-acp's `reasoning_effort`.
+- Default command: `npx -y @agentclientprotocol/codex-acp`
+- Upstream: [agentclientprotocol/codex-acp](https://github.com/agentclientprotocol/codex-acp)
+- Runtime controls exposed by current `codex-acp` releases: ACP modes, advertised models, and `session/set_model`.
+- `acpx --model <id> codex …` and `acpx codex set model <id>` apply the requested model through ACP model selection.
 
 ### Claude
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ Some older Corepack builds bundled with supported Node.js versions have stale
 package-signing keys and fail while preparing current pnpm releases. Installing
 pnpm with npm avoids that bootstrap failure.
 
-`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@zed-industries/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`) are auto-fetched with `npx` on first use.
+`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`) are auto-fetched with `npx` on first use.
 
 ## Global install (recommended)
 

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -126,16 +126,6 @@ Behavior varies by adapter:
 
 For mid-session model switches, use `set model <id>` instead. See [Session control](session-control.md#set-key-value).
 
-## Codex compatibility aliases
-
-Some Codex-specific knobs are surfaced through generic ACP methods:
-
-```bash
-acpx codex set thought_level high     # alias -> codex-acp `reasoning_effort`
-```
-
-`thought_level` is intercepted and translated. Other keys pass through as-is via `session/set_config_option`.
-
 ## Permissions inside a prompt
 
 Prompts can trigger permission requests for tool calls. The default policy auto-approves reads and prompts for writes; non-interactive runs default to deny. See [Permissions](permissions.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,7 @@ If you would rather not install globally, every command below works with `npx ac
 `acpx` ships with adapters for a dozen coding agents. The two most common starting points:
 
 ```bash
-# Codex (OpenAI), via @zed-industries/codex-acp
+# Codex (OpenAI), via @agentclientprotocol/codex-acp
 acpx codex --help
 
 # Claude Code, via @agentclientprotocol/claude-agent-acp

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -44,24 +44,18 @@ Unsupported mode ids are rejected by the adapter, often as `Invalid params`. `ac
 ## `set <key> <value>`
 
 ```bash
-acpx codex set thought_level high
-acpx codex set reasoning_effort high
 acpx claude set verbosity terse
 acpx set model gpt-5.4         # defaults to codex
 ```
 
-Calls ACP `session/set_config_option` with the literal `<key>` and `<value>`. Non-mode `set_config_option` values are persisted by `acpx` and replayed onto fresh adapter sessions, so options like Codex `reasoning_effort` survive a session fallback or reuse.
-
-### Codex compatibility aliases
-
-For Codex specifically, `thought_level` is accepted as an alias and translated to codex-acp's `reasoning_effort`. Other keys pass through unchanged.
+Calls ACP `session/set_config_option` with the literal `<key>` and `<value>`. Non-mode `set_config_option` values are persisted by `acpx` and replayed onto fresh adapter sessions when the adapter supports those config keys.
 
 ### `set model <id>`
 
 `set model <id>` is a special-case interception. Some adapters expose model switching via ACP `session/set_model` rather than `session/set_config_option`. `acpx` always sends `session/set_model` for the `model` key so it works on every adapter that supports either method.
 
 ```bash
-acpx codex set model gpt-5.4
+acpx codex set model 'gpt-5.2[high]'
 acpx claude set model claude-sonnet-4-6
 ```
 

--- a/scripts/lint-persisted-key-casing.ts
+++ b/scripts/lint-persisted-key-casing.ts
@@ -12,7 +12,7 @@ function makeRecord(): SessionRecord {
     acpxRecordId: "lint-record",
     acpSessionId: "lint-session",
     agentSessionId: "agent-session",
-    agentCommand: "npx @zed-industries/codex-acp",
+    agentCommand: "npx -y @agentclientprotocol/codex-acp",
     cwd: "/tmp/lint",
     createdAt: "2026-02-27T00:00:00.000Z",
     lastUsedAt: "2026-02-27T00:00:00.000Z",

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -80,7 +80,7 @@ Friendly agent names resolve to commands:
 
 - `pi` -> `npx pi-acp`
 - `openclaw` -> `openclaw acp`
-- `codex` -> `npx @zed-industries/codex-acp`
+- `codex` -> `npx -y @agentclientprotocol/codex-acp`
 - `claude` -> `npx -y @agentclientprotocol/claude-agent-acp` (ACPX-owned package range)
 - `gemini` -> `gemini --acp`
 - `cursor` -> `cursor-agent acp`
@@ -151,7 +151,7 @@ Behavior:
 ```bash
 acpx codex cancel
 acpx codex set-mode auto
-acpx codex set thought_level high
+acpx codex set model gpt-5.2[high]
 acpx codex set model gpt-5.4
 ```
 
@@ -161,7 +161,7 @@ Behavior:
 - `set-mode`: calls ACP `session/set_mode`.
 - `set-mode` mode ids are adapter-defined; unsupported values are rejected by the adapter (often `Invalid params`).
 - `set`: calls ACP `session/set_config_option`.
-- For codex, `thought_level` is accepted as a compatibility alias for codex-acp `reasoning_effort`.
+- For codex, reasoning effort is selected through advertised ACP model ids when the adapter reports model variants.
 - `--model <id>`: Claude-compatible adapters may consume session creation metadata; other agents must advertise ACP models and support `session/set_model`, otherwise `acpx` fails clearly instead of silently falling back.
 - `set model <id>`: calls `session/set_model`. This is the generic ACP method for mid-session model switching.
 - `set-mode`/`set` route through queue-owner IPC when active, otherwise reconnect directly.

--- a/src/acp/codex-compat.ts
+++ b/src/acp/codex-compat.ts
@@ -15,10 +15,6 @@ export function isCodexAcpCommand(command: string, args: readonly string[]): boo
   return args.some((arg) => arg.includes("codex-acp"));
 }
 
-export function isCodexInvocation(agentName: string, agentCommand: string): boolean {
-  if (agentName === "codex") {
-    return true;
-  }
-
-  return /\bcodex-acp\b/u.test(agentCommand);
+export function isLegacyZedCodexAcpInvocation(agentCommand: string): boolean {
+  return /@zed-industries\/codex-acp\b/u.test(agentCommand);
 }

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.26",
   codex: "^0.0.44",
-  claude: "^0.31.0",
+  claude: "^0.36.1",
 } as const;
 
 type BuiltInAgentPackageSpec = {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.26",
-  codex: "^0.12.0",
+  codex: "^0.0.44",
   claude: "^0.31.0",
 } as const;
 
@@ -38,7 +38,7 @@ type BuiltInLaunchResolverOptions = {
 export const AGENT_REGISTRY: Record<string, string> = {
   pi: `npx pi-acp@${ACP_ADAPTER_PACKAGE_RANGES.pi}`,
   openclaw: "openclaw acp",
-  codex: `npx @zed-industries/codex-acp@${ACP_ADAPTER_PACKAGE_RANGES.codex}`,
+  codex: `npx -y @agentclientprotocol/codex-acp@${ACP_ADAPTER_PACKAGE_RANGES.codex}`,
   claude: `npx -y @agentclientprotocol/claude-agent-acp@${ACP_ADAPTER_PACKAGE_RANGES.claude}`,
   gemini: "gemini --acp",
   cursor: "cursor-agent acp",
@@ -56,7 +56,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
 
 export const BUILT_IN_AGENT_PACKAGES = {
   codex: {
-    packageName: "@zed-industries/codex-acp",
+    packageName: "@agentclientprotocol/codex-acp",
     packageRange: ACP_ADAPTER_PACKAGE_RANGES.codex,
     preferredBinName: "codex-acp",
     fallbackCommand: AGENT_REGISTRY.codex,

--- a/src/cli-public.ts
+++ b/src/cli-public.ts
@@ -69,7 +69,7 @@ Examples:
   acpx codex exec "what does this repo do"
   acpx codex cancel
   acpx codex set-mode plan
-  acpx codex set thought_level high
+  acpx codex set model 'gpt-5.2[high]'
   acpx codex -s backend "fix the API"
   acpx codex sessions
   acpx codex sessions new --name backend

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Command, InvalidArgumentError } from "commander";
-import { isCodexInvocation } from "../acp/codex-compat.js";
+import { isLegacyZedCodexAcpInvocation } from "../acp/codex-compat.js";
 import { AgentSpawnError } from "../errors.js";
 import { loadPermissionPolicySpec } from "../permission-policy.js";
 import {
@@ -149,11 +149,8 @@ function applyPermissionExitCode(result: {
   }
 }
 
-function resolveCompatibleConfigId(
-  agent: { agentName: string; agentCommand: string },
-  configId: string,
-): string {
-  if (isCodexInvocation(agent.agentName, agent.agentCommand) && configId === "thought_level") {
+function resolveCompatibleConfigId(agent: { agentCommand: string }, configId: string): string {
+  if (isLegacyZedCodexAcpInvocation(agent.agentCommand) && configId === "thought_level") {
     return "reasoning_effort";
   }
   return configId;

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -79,8 +79,8 @@ test("default agent is codex", () => {
 });
 
 test("claude built-in uses the current ACP adapter package range", () => {
-  assert.equal(BUILT_IN_AGENT_PACKAGES.claude.packageRange, "^0.31.0");
-  assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.31.0");
+  assert.equal(BUILT_IN_AGENT_PACKAGES.claude.packageRange, "^0.36.1");
+  assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.36.1");
 });
 
 test("npm-backed built-ins use current adapter package ranges", () => {
@@ -107,7 +107,7 @@ test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when a
     path.join(packageRoot, "package.json"),
     JSON.stringify({
       name: BUILT_IN_AGENT_PACKAGES.claude.packageName,
-      version: "0.31.0",
+      version: "0.36.1",
       bin: {
         "claude-agent-acp": "bin/claude-agent-acp.js",
       },
@@ -126,7 +126,7 @@ test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when a
     args: [path.join(packageRoot, "bin", "claude-agent-acp.js")],
     packageName: BUILT_IN_AGENT_PACKAGES.claude.packageName,
     packageRange: BUILT_IN_AGENT_PACKAGES.claude.packageRange,
-    packageVersion: "0.31.0",
+    packageVersion: "0.36.1",
     binPath: path.join(packageRoot, "bin", "claude-agent-acp.js"),
   });
 });

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -84,8 +84,8 @@ test("claude built-in uses the current ACP adapter package range", () => {
 });
 
 test("npm-backed built-ins use current adapter package ranges", () => {
-  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^0.12.0");
-  assert.equal(AGENT_REGISTRY.codex, "npx @zed-industries/codex-acp@^0.12.0");
+  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^0.0.44");
+  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^0.0.44");
   assert.equal(AGENT_REGISTRY.pi, "npx pi-acp@^0.0.26");
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -934,7 +934,7 @@ test("set-mode persists across load fallback and replays on fresh ACP sessions",
   });
 });
 
-test("codex thought_level aliases to reasoning_effort", async () => {
+test("codex thought_level passes through for current built-in adapter", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
@@ -976,16 +976,10 @@ test("codex thought_level aliases to reasoning_effort", async () => {
       action?: string;
       configId?: string;
       value?: string;
-      configOptions?: Array<{ id?: string; currentValue?: string; category?: string }>;
     };
     assert.equal(payload.action, "config_set");
     assert.equal(payload.configId, "thought_level");
     assert.equal(payload.value, "high");
-    const reasoningEffort = payload.configOptions?.find(
-      (option) => option.id === "reasoning_effort",
-    );
-    assert.equal(reasoningEffort?.currentValue, "high");
-    assert.equal(reasoningEffort?.category, "thought_level");
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -748,7 +748,7 @@ test("AcpClient createSession forwards systemPrompt append in _meta alongside cl
 test("AcpClient createSession forwards codex model metadata without setting it explicitly", async () => {
   const cwd = path.resolve("/tmp/acpx-client-codex-model");
   const client = makeClient({
-    agentCommand: "npx @zed-industries/codex-acp",
+    agentCommand: "npx -y @agentclientprotocol/codex-acp",
     sessionOptions: {
       model: "GPT-5-2",
     },


### PR DESCRIPTION
## Summary

ACPX still used the Zed Codex ACP adapter as its built-in Codex backend.
This changes the built-in Codex command to the Agent Client Protocol package and updates the matching docs, tests, and local agent guidance.
It also bumps the built-in Claude ACP adapter range to the latest published `@agentclientprotocol/claude-agent-acp` package.

## What Changed

The built-in `codex` registry entry now resolves to the Agent Client Protocol package.
Codex model selection is documented as normal ACP model selection through advertised model ids and `session/set_model`.
The built-in `claude` registry entry now resolves to the current Claude ACP adapter range.

- Switched `src/agent-registry.ts` to `npx -y @agentclientprotocol/codex-acp@^0.0.44`.
- Bumped `@agentclientprotocol/claude-agent-acp` from `^0.31.0` to `^0.36.1`.
- Updated registry tests and client tests for the new package names and ranges.
- Limited the old Codex `thought_level -> reasoning_effort` alias to legacy `@zed-industries/codex-acp` commands.
- Updated README, agent docs, CLI docs, conformance docs, security routing, changelog, and the acpx skill docs.
- Updated the persisted-key casing lint fixture to use the current built-in command.

## Verification

The normal code and docs gates pass, and the published Codex adapter starts successfully through the new default command.
I also ran a real authenticated one-shot Codex message through the published adapter and got the expected response.
The published Claude adapter package at `0.36.1` resolves and starts from its package binary.

- `pnpm run check`
- `pnpm run check:docs`
- `pnpm run build:test && node --test dist-test/test/agent-registry.test.js`
- `npm view @agentclientprotocol/claude-agent-acp version time --json`
- `npx -y --package @agentclientprotocol/codex-acp@0.0.44 codex-acp --version`
- `timeout 15s npx -y --package @agentclientprotocol/claude-agent-acp@0.36.1 claude-agent-acp --help`
- `pnpm run conformance:run -- --case acp.v1.initialize.handshake --agent-command "npx -y @agentclientprotocol/codex-acp@0.0.44" --cwd /tmp/acpx-codex-conformance`
- `HOME=/tmp/acpx-codex-default-home CODEX_HOME=/tmp/acpx-codex-default-home ACPX_HOME=/tmp/acpx-codex-default-acpx timeout 30s node dist/cli.js --cwd /tmp/acpx-codex-default-work --auth-policy fail --format json codex sessions new`
- `timeout 120s node dist/cli.js --agent "npx -y @agentclientprotocol/codex-acp@0.0.44" --cwd /tmp/acpx-codex-message --approve-all --format quiet exec "Reply with exactly acpx-codex-ok and nothing else."`

Behavior addressed: default `acpx codex` now launches `@agentclientprotocol/codex-acp` instead of `@zed-industries/codex-acp`, and default `acpx claude` now launches `@agentclientprotocol/claude-agent-acp@^0.36.1`.
Real environment tested: local Linux checkout with the published `@agentclientprotocol/codex-acp@0.0.44` package, isolated temp directories for startup/auth smoke, a real authenticated one-shot Codex prompt in `/tmp/acpx-codex-message`, and the published `@agentclientprotocol/claude-agent-acp@0.36.1` package binary.
Exact steps or command run after this patch: `pnpm run check`, `pnpm run check:docs`, focused registry test rebuild/run, published package version/binary smokes, ACP conformance initialize handshake, isolated `acpx codex sessions new` startup/auth-required smoke, and a real Codex `exec` prompt.
Evidence after fix: conformance reported `Cases: 1 Passed: 1 Failed: 0`; the default `acpx codex sessions new` path returned structured `AUTH_REQUIRED` from the new adapter instead of failing to spawn; the real prompt returned `acpx-codex-ok` and exit code 0; the Claude package binary resolved and exited 0.
Observed result after fix: the new Codex adapter package is reachable from the built-in command path, ACP initialize/auth negotiation works, a real Codex message turn completes successfully, and the Claude built-in range points at the latest published adapter.
What was not tested: multi-turn persistent Codex session reuse with the new adapter, and a live Claude Code prompt through the bumped Claude adapter.

## Risks

The main compatibility risk is users relying on the old Zed adapter's `thought_level` alias through the built-in `codex` name.
That alias is kept only for explicit legacy Zed adapter commands, while the new default follows the current adapter's advertised ACP model ids.
