### PR TITLE
fix: hide stale session pids in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Repo: https://github.com/openclaw/acpx
 - CLI/ACP: validate rich prompt blocks against advertised ACP
   `promptCapabilities` and support audio prompt content end-to-end. Thanks
   @amknight.
+- CLI/status: hide stale cached session PIDs when no live helper process exists. Thanks @dutifulbob.
 
 ## 2026.5.15 (v0.8.0)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -357,7 +357,7 @@ acpx [global_options] status -s <name>
 Shows local process status for the cwd-scoped session:
 
 - `running`, `idle`, `dead`, or `no-session`
-- session id, agent command, pid
+- session id, agent command, live queue-owner pid when available
 - uptime when running
 - last prompt timestamp
 - last known exit code/signal when dead
@@ -366,7 +366,8 @@ Shows local process status for the cwd-scoped session:
 currently running. The next prompt starts a queue owner and reconnects the
 session.
 
-Status checks are local and PID-based (`kill(pid, 0)` semantics).
+Status checks are local and PID-based (`kill(pid, 0)` semantics). Cached session
+PIDs are not reported unless a live queue-owner lease ties them to the session.
 
 ## `config` command
 

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -71,16 +71,20 @@ acpx status              # defaults to codex
 
 Reports local process status for the cwd-scoped session:
 
-| State        | Meaning                                                        |
-| ------------ | -------------------------------------------------------------- |
-| `running`    | Queue owner alive and processing a prompt                      |
-| `idle`       | Saved session resumable, no queue owner running                |
-| `dead`       | Saved adapter PID is gone; next prompt will respawn and reload |
-| `no-session` | No saved record matches this scope                             |
+| State        | Meaning                                                                          |
+| ------------ | -------------------------------------------------------------------------------- |
+| `running`    | Queue owner alive and processing a prompt                                        |
+| `idle`       | Saved session resumable, no queue owner running                                  |
+| `dead`       | Queue owner was expected but is unavailable, or the last agent exit was abnormal |
+| `no-session` | No saved record matches this scope                                               |
 
-Plus, when applicable: session id, agent command, pid, uptime, last prompt timestamp, and last known exit code or signal for `dead`.
+Plus, when applicable: session id, agent command, live queue-owner pid, uptime,
+last prompt timestamp, and last known exit code or signal for `dead`.
 
-`status` is local — it uses `kill(pid, 0)` semantics and does not touch the agent. It is safe to run from automation that polls for queue readiness.
+`status` is local — it uses `kill(pid, 0)` semantics and does not touch the
+agent. Cached session PIDs are not reported unless a live queue-owner lease ties
+them to the session. It is safe to run from automation that polls for queue
+readiness.
 
 ### Output
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -186,7 +186,7 @@ This makes long-running scripted sessions resilient to crashes, OS restarts, and
 | `no-session` | No saved record matches this scope                                               |
 
 Status checks are local (`kill(pid, 0)` semantics) — they do not touch the agent.
-`closed` describes the logical session lifecycle. A helper process can exit while the session remains open and resumable. Cached PIDs from `~/.acpx/sessions/*.json` are only shown when the process is still live; queue owner liveness comes from `~/.acpx/queues/*.lock` plus its heartbeat and process probe.
+`closed` describes the logical session lifecycle. A helper process can exit while the session remains open and resumable. Status reports a PID only when a live queue-owner lease ties that process to the session; queue owner liveness comes from `~/.acpx/queues/*.lock` plus its heartbeat and process probe.
 
 ## CWD scoping
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -4,6 +4,7 @@ description: Persistent multi-turn ACP sessions in acpx — scope rules, named s
 ---
 
 `acpx` sessions are how multi-turn agent conversations survive between invocations. A session is a JSON record on disk plus, when active, a queue owner process that holds the live ACP connection.
+The session record tracks the logical conversation; the queue owner lease is the source of truth for whether `acpx` currently expects a helper process to be alive.
 
 ## Scope key
 
@@ -165,7 +166,7 @@ See [Session control](session-control.md) for `set-mode`, `set <key> <value>`, a
 
 ## Crash recovery
 
-Saved sessions track adapter PIDs. If a saved PID is dead on the next prompt:
+Saved sessions may include a cached adapter PID from the last connected helper process. That PID is a runtime hint, not proof that the logical session is closed or broken. If a cached PID is gone on the next prompt:
 
 1. `acpx` respawns the agent.
 2. Attempts ACP `session/resume` with the saved provider session id when the agent advertises it, otherwise ACP `session/load`.
@@ -177,14 +178,15 @@ This makes long-running scripted sessions resilient to crashes, OS restarts, and
 
 `acpx codex status` reports local process state:
 
-| State        | Meaning                                                |
-| ------------ | ------------------------------------------------------ |
-| `running`    | Queue owner alive and processing a prompt              |
-| `idle`       | Saved session resumable, no queue owner running        |
-| `dead`       | Saved PID is gone; next prompt will respawn and reload |
-| `no-session` | No saved record matches this scope                     |
+| State        | Meaning                                                                          |
+| ------------ | -------------------------------------------------------------------------------- |
+| `running`    | Queue owner alive and processing a prompt                                        |
+| `idle`       | Saved session resumable, no queue owner running                                  |
+| `dead`       | Queue owner was expected but is unavailable, or the last agent exit was abnormal |
+| `no-session` | No saved record matches this scope                                               |
 
 Status checks are local (`kill(pid, 0)` semantics) — they do not touch the agent.
+`closed` describes the logical session lifecycle. A helper process can exit while the session remains open and resumable. Cached PIDs from `~/.acpx/sessions/*.json` are only shown when the process is still live; queue owner liveness comes from `~/.acpx/queues/*.lock` plus its heartbeat and process probe.
 
 ## CWD scoping
 

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -1,6 +1,7 @@
 import { AcpClient, type SessionCreateResult } from "../../acp/client.js";
 import { formatErrorMessage } from "../../acp/error-normalization.js";
 import { withInterrupt, withTimeout } from "../../async-control.js";
+import { applyLifecycleSnapshotToRecord } from "../../runtime/engine/lifecycle.js";
 import { persistSessionOptions } from "../../runtime/engine/session-options.js";
 import { applyConfigOptionsToRecord } from "../../session/config-options.js";
 import { createSessionConversation } from "../../session/conversation-model.js";
@@ -79,7 +80,7 @@ async function createSessionRecordWithClient(
     eventLog: defaultSessionEventLog(sessionId),
     closed: false,
     closedAt: undefined,
-    pid: lifecycle.pid,
+    pid: lifecycle.running ? lifecycle.pid : undefined,
     agentStartedAt: lifecycle.startedAt,
     protocolVersion: client.initializeResult?.protocolVersion,
     agentCapabilities: client.initializeResult?.agentCapabilities,
@@ -198,6 +199,8 @@ export async function createSession(options: SessionCreateOptions): Promise<Sess
     return record;
   } finally {
     await client.close();
+    applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
+    await writeSessionRecord(record);
   }
 }
 

--- a/src/cli/status-command.ts
+++ b/src/cli/status-command.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { isProcessAlive } from "../process-liveness.js";
 import { findSession } from "../session/persistence.js";
 import type { SessionRecord } from "../types.js";
 import type { ResolvedAcpxConfig } from "./config.js";
@@ -146,7 +147,7 @@ function createStatusPayload(
   return {
     sessionId: record.acpxRecordId,
     agentCommand: record.agentCommand,
-    pid: statusPid(health.pid, record.pid),
+    pid: statusPid(health, record.pid),
     status: statusState,
     model: acpx.model,
     mode: acpx.mode,
@@ -171,8 +172,17 @@ function statusAcpxFields(record: SessionRecord): {
   };
 }
 
-function statusPid(healthPid: number | undefined, recordPid: number | undefined): number | null {
-  return healthPid ?? recordPid ?? null;
+function statusPid(
+  health: Awaited<ReturnType<typeof probeQueueOwnerHealth>>,
+  recordPid: number | undefined,
+): number | null {
+  if (health.pidAlive) {
+    return health.pid ?? null;
+  }
+  if (isProcessAlive(recordPid)) {
+    return recordPid ?? null;
+  }
+  return null;
 }
 
 function optionalStatusString(value: string | undefined | null): string | null {

--- a/src/cli/status-command.ts
+++ b/src/cli/status-command.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import { isProcessAlive } from "../process-liveness.js";
 import { findSession } from "../session/persistence.js";
 import type { SessionRecord } from "../types.js";
 import type { ResolvedAcpxConfig } from "./config.js";
@@ -147,7 +146,7 @@ function createStatusPayload(
   return {
     sessionId: record.acpxRecordId,
     agentCommand: record.agentCommand,
-    pid: statusPid(health, record.pid),
+    pid: statusPid(health),
     status: statusState,
     model: acpx.model,
     mode: acpx.mode,
@@ -172,15 +171,9 @@ function statusAcpxFields(record: SessionRecord): {
   };
 }
 
-function statusPid(
-  health: Awaited<ReturnType<typeof probeQueueOwnerHealth>>,
-  recordPid: number | undefined,
-): number | null {
+function statusPid(health: Awaited<ReturnType<typeof probeQueueOwnerHealth>>): number | null {
   if (health.pidAlive) {
     return health.pid ?? null;
-  }
-  if (isProcessAlive(recordPid)) {
-    return recordPid ?? null;
   }
   return null;
 }

--- a/src/runtime/engine/lifecycle.ts
+++ b/src/runtime/engine/lifecycle.ts
@@ -10,7 +10,7 @@ export function applyLifecycleSnapshotToRecord(
     return;
   }
 
-  record.pid = snapshot.pid;
+  record.pid = snapshot.running ? snapshot.pid : undefined;
   record.agentStartedAt = snapshot.startedAt;
 
   if (snapshot.lastExit) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -685,10 +685,7 @@ test("sessions ensure exits even when agent ignores SIGTERM", async () => {
       ),
     ) as SessionRecord;
 
-    if (storedRecord.pid != null) {
-      const exited = await waitForPidExit(storedRecord.pid, 2_000);
-      assert.equal(exited, true);
-    }
+    assert.equal(storedRecord.pid, undefined);
   });
 });
 
@@ -2510,21 +2507,6 @@ async function runCli(
       resolve({ code, stdout, stderr });
     });
   });
-}
-
-async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + Math.max(0, timeoutMs);
-  while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch {
-      return true;
-    }
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50);
-    });
-  }
-  return false;
 }
 
 function makeSessionRecord(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1712,7 +1712,7 @@ test("status reports idle for resumable sessions without a live queue owner", as
       lastUsedAt: "2026-01-01T00:01:00.000Z",
       lastPromptAt: "2026-01-01T00:01:00.000Z",
       closed: false,
-      pid: 12345,
+      pid: 999_999,
       agentStartedAt: "2026-01-01T00:00:00.000Z",
       lastAgentExitCode: 0,
       lastAgentExitAt: "2026-01-01T00:02:00.000Z",
@@ -1724,11 +1724,13 @@ test("status reports idle for resumable sessions without a live queue owner", as
     assert.equal(payload.action, "status_snapshot");
     assert.equal(payload.status, "idle");
     assert.equal(payload.summary, "session idle; queue owner will start on next prompt");
+    assert.equal(payload.pid, undefined);
     assert.equal(payload.exitCode, undefined);
 
     const text = await runCli(["--cwd", cwd, "codex", "status"], homeDir);
     assert.equal(text.code, 0, text.stderr);
     assert.match(text.stdout, /status: idle/);
+    assert.match(text.stdout, /pid: -/);
     assert.doesNotMatch(text.stdout, /exitCode:/);
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1702,36 +1702,41 @@ test("status reports idle for resumable sessions without a live queue owner", as
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
+    const keeper = await startKeeperProcess();
 
-    await writeSessionRecord(homeDir, {
-      acpxRecordId: "idle-status-session",
-      acpSessionId: "idle-status-session",
-      agentCommand: AGENT_REGISTRY.codex,
-      cwd,
-      createdAt: "2026-01-01T00:00:00.000Z",
-      lastUsedAt: "2026-01-01T00:01:00.000Z",
-      lastPromptAt: "2026-01-01T00:01:00.000Z",
-      closed: false,
-      pid: 999_999,
-      agentStartedAt: "2026-01-01T00:00:00.000Z",
-      lastAgentExitCode: 0,
-      lastAgentExitAt: "2026-01-01T00:02:00.000Z",
-    });
+    try {
+      await writeSessionRecord(homeDir, {
+        acpxRecordId: "idle-status-session",
+        acpSessionId: "idle-status-session",
+        agentCommand: AGENT_REGISTRY.codex,
+        cwd,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastUsedAt: "2026-01-01T00:01:00.000Z",
+        lastPromptAt: "2026-01-01T00:01:00.000Z",
+        closed: false,
+        pid: keeper.pid,
+        agentStartedAt: "2026-01-01T00:00:00.000Z",
+        lastAgentExitCode: 0,
+        lastAgentExitAt: "2026-01-01T00:02:00.000Z",
+      });
 
-    const json = await runCli(["--cwd", cwd, "--format", "json", "codex", "status"], homeDir);
-    assert.equal(json.code, 0, json.stderr);
-    const payload = JSON.parse(json.stdout.trim()) as Record<string, unknown>;
-    assert.equal(payload.action, "status_snapshot");
-    assert.equal(payload.status, "idle");
-    assert.equal(payload.summary, "session idle; queue owner will start on next prompt");
-    assert.equal(payload.pid, undefined);
-    assert.equal(payload.exitCode, undefined);
+      const json = await runCli(["--cwd", cwd, "--format", "json", "codex", "status"], homeDir);
+      assert.equal(json.code, 0, json.stderr);
+      const payload = JSON.parse(json.stdout.trim()) as Record<string, unknown>;
+      assert.equal(payload.action, "status_snapshot");
+      assert.equal(payload.status, "idle");
+      assert.equal(payload.summary, "session idle; queue owner will start on next prompt");
+      assert.equal(payload.pid, undefined);
+      assert.equal(payload.exitCode, undefined);
 
-    const text = await runCli(["--cwd", cwd, "codex", "status"], homeDir);
-    assert.equal(text.code, 0, text.stderr);
-    assert.match(text.stdout, /status: idle/);
-    assert.match(text.stdout, /pid: -/);
-    assert.doesNotMatch(text.stdout, /exitCode:/);
+      const text = await runCli(["--cwd", cwd, "codex", "status"], homeDir);
+      assert.equal(text.code, 0, text.stderr);
+      assert.match(text.stdout, /status: idle/);
+      assert.match(text.stdout, /pid: -/);
+      assert.doesNotMatch(text.stdout, /exitCode:/);
+    } finally {
+      stopProcess(keeper);
+    }
   });
 });
 

--- a/test/runtime-helpers.test.ts
+++ b/test/runtime-helpers.test.ts
@@ -102,7 +102,7 @@ test("runtime lifecycle helpers update records from runtime snapshots and conver
   applyLifecycleSnapshotToRecord(record, {
     pid: 321,
     startedAt: "2026-01-01T00:01:00.000Z",
-    running: true,
+    running: false,
     lastExit: {
       exitCode: 9,
       signal: "SIGKILL",
@@ -111,7 +111,7 @@ test("runtime lifecycle helpers update records from runtime snapshots and conver
       unexpectedDuringPrompt: false,
     },
   });
-  assert.equal(record.pid, 321);
+  assert.equal(record.pid, undefined);
   assert.equal(record.agentStartedAt, "2026-01-01T00:01:00.000Z");
   assert.equal(record.lastAgentExitCode, 9);
   assert.equal(record.lastAgentExitSignal, "SIGKILL");


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Open ACPX sessions could keep a helper `pid` after the helper process had already been shut down.
That made session records and `acpx status` blur two different things: the logical session is resumable, but there may be no live helper.
This change clears helper PIDs when the helper is no longer running and makes `status` report PIDs only from queue-owner liveness.

## What Changed

The session record now treats `pid` as live runtime metadata, not durable proof of session health.
The logical session lifecycle stays in `closed`, while helper liveness comes from queue owner leases, heartbeat checks, and process probing.

- Clear persisted session `pid` values when lifecycle snapshots show the helper is not running.
- Rewrite `sessions new` / `sessions ensure` records after the temporary helper closes, preserving exit metadata while clearing the stale `pid`.
- Stop `status` from falling back to cached session PIDs when there is no queue owner lease.
- Keep idle sessions resumable and keep `dead` reserved for broken expected helpers or abnormal exits.
- Update session docs and session-control docs to explain the split between logical sessions and live helpers.
- Add regression coverage for idle status with a live-but-unowned cached PID.

## Behavior Proof

I verified the changed status behavior with a temporary ACPX home.
The saved session record contained a live cached process PID, but there was no queue-owner lease.

```text
created temp session with cached live pid: <redacted-live-pid>

JSON status:
{"action":"status_snapshot","status":"idle","summary":"session idle; queue owner will start on next prompt","acpxRecordId":"proof-idle-live-cached-pid","acpxSessionId":"proof-idle-live-cached-pid"}

Text status:
session: proof-idle-live-cached-pid
agent: <codex-agent-command>
pid: -
status: idle
model: -
mode: -
uptime: -
lastPromptTime: -
```

This proves the fixed contract: an idle resumable session does not surface a cached session PID, even when that PID currently belongs to a live unrelated process.

## Testing

I tested the focused behavior and the repo checks relevant to this change.
The full local mutation suite was not rerun, but CI mutation passed.

- `pnpm run build:test && node --test dist-test/test/cli.test.js dist-test/test/runtime-helpers.test.js`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check:docs`
- `codex review --base main`
- commit hook also ran `pnpm run build`

## Risks

The behavior change is narrow but visible to scripts that read ACPX status output.
Those scripts should use queue-owner status as the liveness signal instead of saved session PIDs.

- Idle sessions no longer expose cached session `pid` values in text or JSON status output.
- Live queue-owner PIDs are still reported when ACPX has a queue-owner lease and the process probe succeeds.
- Session resume behavior is unchanged.

AI-assisted change.
