### PR TITLE
Add fast-agent to the Agents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Repo: https://github.com/openclaw/acpx
 
 - Agents/built-ins: bump the default Claude ACP adapter range to `@agentclientprotocol/claude-agent-acp@^0.37.0`. Thanks @trumpyla.
 - Runtime/embedding: surface cost, token usage breakdowns, and advertised command metadata on runtime status/events. Thanks @DaniAkash.
-- Agents/built-ins: add `fast-agent` as a built-in EvalState fast-agent ACP adapter via `uvx fast-agent-mcp acp`.
+- Agents/built-ins: add `fast-agent` as a built-in fast-agent ACP adapter via `uvx fast-agent-mcp acp`.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Built-ins:
 | `cursor`     | native (`cursor-agent acp`)                                                 | [Cursor CLI](https://cursor.com/docs/cli/acp)                                                                   |
 | `copilot`    | native (`copilot --acp --stdio`)                                            | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-chat/use-copilot-chat-in-the-command-line) |
 | `droid`      | native (`droid exec --output-format acp`)                                   | [Factory Droid](https://www.factory.ai)                                                                         |
-| `fast-agent` | `uvx fast-agent-mcp acp`                                                    | [EvalState fast-agent](https://github.com/evalstate/fast-agent)                                                 |
+| `fast-agent` | `uvx fast-agent-mcp acp`                                                    | [fast-agent](https://fast-agent.ai)                                                                             |
 | `iflow`      | native (`iflow --experimental-acp`)                                         | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                              |
 | `kilocode`   | `npx -y @kilocode/cli acp`                                                  | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | native (`kimi acp`)                                                         | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |

--- a/agents/FastAgent.md
+++ b/agents/FastAgent.md
@@ -2,8 +2,8 @@
 
 - Built-in name: `fast-agent`
 - Default command: `uvx fast-agent-mcp acp`
-- Upstream: https://github.com/evalstate/fast-agent
+- Upstream: https://fast-agent.ai/acp
 
-`acpx fast-agent` starts EvalState fast-agent through its ACP entrypoint. It requires `uvx` on `PATH`.
+`acpx fast-agent` starts fast-agent through its ACP entrypoint. It requires `uvx` on `PATH`.
 
 Configure model/provider settings through fast-agent environment variables, fast-agent configuration, or an `acpx` agent override with additional `fast-agent-mcp acp` arguments.

--- a/agents/README.md
+++ b/agents/README.md
@@ -26,7 +26,7 @@ Harness-specific docs in this directory:
 - [Claude](Claude.md): built-in `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - [Copilot](Copilot.md): built-in `copilot -> copilot --acp --stdio`
 - [Droid](Droid.md): built-in `droid -> droid exec --output-format acp` with `factory-droid` and `factorydroid` aliases
-- [FastAgent](FastAgent.md): built-in `fast-agent -> uvx fast-agent-mcp acp`
+- [fast-agent](FastAgent.md): built-in `fast-agent -> uvx fast-agent-mcp acp`
 - [Cursor](Cursor.md): built-in `cursor -> cursor-agent acp`
 - [Gemini](Gemini.md): built-in `gemini -> gemini --acp`
 - [iFlow](Iflow.md): built-in `iflow -> iflow --experimental-acp`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -19,7 +19,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `cursor`     | `cursor-agent acp`                             | [Cursor CLI](https://cursor.com/docs/cli/acp)                                                                   |
 | `copilot`    | `copilot --acp --stdio`                        | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-chat/use-copilot-chat-in-the-command-line) |
 | `droid`      | `droid exec --output-format acp`               | [Factory Droid](https://www.factory.ai)                                                                         |
-| `fast-agent` | `uvx fast-agent-mcp acp`                       | [EvalState fast-agent](https://github.com/evalstate/fast-agent)                                                 |
+| `fast-agent` | `uvx fast-agent-mcp acp`                       | [fast-agent](https://fast-agent.ai/)                                                                            |
 | `iflow`      | `iflow --experimental-acp`                     | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                              |
 | `kilocode`   | `npx -y @kilocode/cli acp`                     | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | `kimi acp`                                     | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
@@ -124,12 +124,15 @@ If your Cursor install exposes ACP as `agent acp` instead of `cursor-agent acp`,
 - Default command: `droid exec --output-format acp`
 - Upstream: [factory.ai](https://www.factory.ai)
 
-### Fast Agent
+### fast-agent
 
 - Built-in name: `fast-agent`
 - Default command: `uvx fast-agent-mcp acp`
-- Upstream: [EvalState fast-agent](https://github.com/evalstate/fast-agent)
-- Requires `uvx` on `PATH`. Configure fast-agent model/provider settings through environment variables, fast-agent configuration, or an `acpx` agent override with additional `fast-agent-mcp acp` arguments.
+- Upstream: https://fast-agent.ai/acp
+
+`acpx fast-agent` starts fast-agent through its ACP entrypoint. It requires `uvx` on `PATH`.
+
+Configure model/provider settings through fast-agent environment variables, fast-agent configuration, or an `acpx` agent override with additional `fast-agent-mcp acp` arguments.
 
 ### Qoder
 


### PR DESCRIPTION
This is an update to PR #350 by @osolmaz to normalise the name to `fast-agent` and point directly to the fast-agent.ai website. Tested. 

Original text below.

Opened on behalf of Onur Solmaz (`osolmaz`). This PR is ready for review.

## Summary

`acpx` did not have a friendly built-in name for EvalState fast-agent.
This change adds `acpx fast-agent` and points it at the fast-agent ACP entrypoint, `uvx fast-agent-mcp acp`.
The first convenience wrapper I tried, `uvx fast-agent-acp`, failed in a live startup test with a missing Python module, so the PR now uses the main fast-agent package command that actually initializes and serves ACP.
It also updates the supported-agent docs, the acpx skill, and tests so the new adapter is visible and verified like the other built-ins.

AI-assisted: yes.
I understand the change: it adds one registry mapping, documents the required `uvx` dependency, and tests that the CLI resolves the new built-in command correctly.

## What Changed

The runtime registry now knows how to launch fast-agent through ACP.
The docs now list fast-agent anywhere the built-in registry is described.

- Added `fast-agent -> uvx fast-agent-mcp acp` to the built-in agent registry.
- Added registry and integration tests for the new built-in command path.
- Added `agents/FastAgent.md` and updated the README, docs site, install docs, acpx skill, and changelog.

## Testing

This was tested with focused checks, full repo validation, and a real local fast-agent ACP run.
The live test used `uvx`, `fast-agent-mcp` 0.7.13, and a temporary `fast-agent.yaml` pointed at a local Ollama `qwen2.5:0.5b` model.

- `pnpm run build:test && node --test dist-test/test/agent-registry.test.js dist-test/test/integration.test.js`
- `pnpm run check:docs`
- `pnpm run check`
- Live startup failure found for the rejected command: `node dist/cli.js --timeout 60 --format json fast-agent exec "Reply with exactly: acpx fast-agent live ok"` when the built-in still used `uvx fast-agent-acp`; it failed before initialize with `ModuleNotFoundError: No module named 'fast_agent_acp'`.
- Live success for the final built-in command: with a temp cwd containing `fast-agent.yaml` (`default_model: generic.qwen2.5:0.5b`, local Ollama generic provider), `node dist/cli.js --cwd "$tmp_cwd" --timeout 90 --format json fast-agent exec "Reply with exactly: acpx fast-agent live ok"` initialized ACP, created a session, streamed assistant message chunks, and returned `stopReason: end_turn`.

## Risks

The risk is low because this only adds a registry mapping and docs.
The main operational requirement is that users need `uvx` available on `PATH` and fast-agent model/provider configuration for real prompts.