### PR TITLE
fix: honor parent session flag for prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
-- CLI/sessions: honor `-s` when it is placed before `prompt`, so named prompt sessions route like other subcommands.
 
 ## 2026.5.23 (v0.10.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
+- CLI/sessions: honor `-s` when it is placed before `prompt`, so named prompt sessions route like other subcommands.
 
 ## 2026.5.23 (v0.10.0)
 

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -319,7 +319,7 @@ export async function handlePrompt(
     agent.agentCommand,
     agent.agentName,
     agent.cwd,
-    flags.session,
+    resolveSessionNameFromFlags(flags, command),
   );
   const outputFormatter = createOutputFormatter(outputPolicy.format, {
     jsonContext: {

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -88,6 +88,10 @@ export type StatusFlags = {
   session?: string;
 };
 
+type SessionSelectionFlags = {
+  session?: string;
+};
+
 export type SessionsPruneFlags = {
   dryRun?: boolean;
   before?: Date;
@@ -358,7 +362,7 @@ export function addSessionNameOption(command: Command): Command {
 }
 
 export function resolveSessionNameFromFlags(
-  flags: StatusFlags,
+  flags: SessionSelectionFlags,
   command: Command,
 ): string | undefined {
   const directSession = parseOptionalSessionName(flags.session);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1844,7 +1844,7 @@ test("set resolves named session when -s is before subcommand", async () => {
   });
 });
 
-test("prompt resolves named session when -s is before subcommand", async () => {
+test("prompt resolves named session across session flag placements", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
@@ -1876,11 +1876,20 @@ test("prompt resolves named session when -s is before subcommand", async () => {
       closed: false,
     });
 
-    const result = await runCli(["--cwd", cwd, "codex", "-s", "named", "prompt", "ping"], homeDir);
+    const cases = [
+      ["codex", "-s", "named", "prompt", "ping"],
+      ["codex", "--session", "named", "prompt", "ping"],
+      ["codex", "prompt", "-s", "named", "ping"],
+      ["codex", "prompt", "--session", "named", "ping"],
+    ];
 
-    assert.equal(result.code, 1);
-    assert.doesNotMatch(result.stderr, /No acpx session found/);
-    assert.match(result.stderr, /session named \(named-prompt-session\)/);
+    for (const args of cases) {
+      const result = await runCli(["--cwd", cwd, ...args], homeDir);
+
+      assert.equal(result.code, 1, args.join(" "));
+      assert.doesNotMatch(result.stderr, /No acpx session found/, args.join(" "));
+      assert.match(result.stderr, /session named \(named-prompt-session\)/, args.join(" "));
+    }
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1844,6 +1844,46 @@ test("set resolves named session when -s is before subcommand", async () => {
   });
 });
 
+test("prompt resolves named session when -s is before subcommand", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
+
+    const missingAgentCommand = "acpx-test-missing-agent-binary-3";
+    await fs.writeFile(
+      path.join(homeDir, ".acpx", "config.json"),
+      `${JSON.stringify(
+        {
+          agents: {
+            codex: { command: missingAgentCommand },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "named-prompt-session",
+      acpSessionId: "named-prompt-session",
+      agentCommand: missingAgentCommand,
+      cwd,
+      name: "named",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: "2026-01-01T00:00:00.000Z",
+      closed: false,
+    });
+
+    const result = await runCli(["--cwd", cwd, "codex", "-s", "named", "prompt", "ping"], homeDir);
+
+    assert.equal(result.code, 1);
+    assert.doesNotMatch(result.stderr, /No acpx session found/);
+    assert.match(result.stderr, /session named \(named-prompt-session\)/);
+  });
+});
+
 test("prompt reads from stdin when no prompt argument is provided", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");


### PR DESCRIPTION
## Summary
- resolve prompt session names through parent/global command flags like the other session subcommands
- add regression coverage for `codex -s <name> prompt ...`
- drop the release-owned changelog edit from this PR

Fixes #355.

## Validation
- `pnpm run build:test && node --test dist-test/test/cli.test.js --test-name-pattern "prompt resolves named session"`
- `pnpm run format:check`
- manual CLI proof with built `dist/cli.js`

## Proof
Focused regression proof:

```text
✔ prompt resolves named session from parent -s flag
ℹ tests 78
ℹ pass 78
```

Manual real CLI proof for `-s` before `prompt`:

```text
command: HOME=<tmp> node dist/cli.js --cwd <tmp>/workspace codex -s named prompt ping
exit_code: 1
stdout: [error] RUNTIME: Failed to spawn agent command: acpx-proof-missing-agent
stderr: [acpx] session named (named-prompt-session) · <tmp>/workspace · agent needs reconnect
```
