### PR TITLE
Fix Devin ACP compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,9 @@ The enforceable local constraints are:
   actually gates all `src/**` files at the same threshold.
 - `pnpm run mutate` runs Stryker against the current mutation target declared in
   `slophammer.yml`.
-- `slophammer.yml` sets the TypeScript policy targets: coverage `85`,
-  complexity max `8`, zero production DRY findings for `src/`, mutation targets,
-  and import dependency boundaries.
+- `slophammer.yml` uses the Slophammer v0.2 TypeScript policy schema:
+  `coverage.threshold: 85`, `complexity.max: 8`, zero production DRY findings
+  for `src/`, mutation targets, and import dependency boundaries.
 - CI must run the published checker's direct dependency-boundary rule. `rules`
   and `dry` alone are not a dependency-boundary gate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
-- Client/ACP: advertise Devin/Windsurf-compatible client metadata and handle Devin extension requests/notifications without noisy method-not-found logs.
+- Client/ACP: advertise scoped Devin/Windsurf-compatible client metadata and handle Devin extension requests/notifications without noisy method-not-found logs. Thanks @LivioGama.
 
 ## 2026.5.23 (v0.10.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
+- Client/ACP: advertise Devin/Windsurf-compatible client metadata and handle Devin extension requests/notifications without noisy method-not-found logs.
 
 ## 2026.5.23 (v0.10.0)
 

--- a/agents/Devin.md
+++ b/agents/Devin.md
@@ -1,0 +1,60 @@
+# Devin
+
+- Built-in name: `devin`
+- Default command: `devin <model> acp` (requires `--model` flag before `acp`)
+- Upstream: https://www.devin.ai
+
+## ACP compatibility contract
+
+Devin requires Windsurf-compatible client metadata during ACP initialization. `acpx` satisfies this by detecting Devin ACP launches and advertising a Windsurf identity with Cognition/Windsurf capability flags.
+
+### Detection
+
+`acpx` detects Devin ACP launches when the command matches `devin <model> acp` (e.g., `devin --model swe-1-6 acp`).
+
+### Client identity
+
+When Devin ACP is detected, `acpx` advertises:
+
+- `clientInfo.name`: `windsurf` (instead of `acpx`)
+- `clientInfo.version`: Controlled by `ACPX_DEVIN_WINDSURF_VERSION` env var (default: `1.110.1`)
+
+### Capability flags
+
+The following Cognition/Windsurf-specific capability flags are advertised under `clientCapabilities._meta`:
+
+- `cognition.ai/groupedSessionConfigOptions`
+- `cognition.ai/lazyEditorFiles`
+- `cognition.ai/mcp`
+- `cognition.ai/messageGrouping`
+- `cognition.ai/multiRootWorkspace`
+- `cognition.ai/partialContent`
+- `cognition.ai/requestDiagnostics`
+- `cognition.ai/revert`
+- `cognition.ai/subagentSupport`
+- `cognition.ai/toolCallQuestions`
+- `cognition.ai/windsurfConfigBridge`
+- `terminal_output`
+
+### Extension handling
+
+`acpx` handles Devin's vendor extension methods:
+
+- `_cognition.ai/request_diagnostics`: Returns an empty object `{}` to satisfy the request
+- Other vendor extension notifications: Silently ignored to prevent method-not-found noise
+
+### Version override
+
+Set `ACPX_DEVIN_WINDSURF_VERSION` to override the advertised Windsurf version:
+
+```bash
+ACPX_DEVIN_WINDSURF_VERSION=1.120.0 acpx devin --model swe-1-6 acp 'fix the bug'
+```
+
+### Scope
+
+This compatibility shim is active only for Devin ACP launches. Other agents receive standard `acpx` identity and capabilities.
+
+### Minimum required capability set
+
+The current implementation advertises the full Windsurf capability set observed in the wild. If Devin's requirements change, the minimum set should be narrowed to only what Devin actually requires to reduce compatibility risk.

--- a/agents/Devin.md
+++ b/agents/Devin.md
@@ -1,16 +1,26 @@
 # Devin
 
-- Built-in name: `devin`
-- Default command: `devin <model> acp` (requires `--model` flag before `acp`)
+- Built-in name: none
+- Raw command: `devin acp`
 - Upstream: https://www.devin.ai
 
 ## ACP compatibility contract
 
-Devin requires Windsurf-compatible client metadata during ACP initialization. `acpx` satisfies this by detecting Devin ACP launches and advertising a Windsurf identity with Cognition/Windsurf capability flags.
+Devin requires Windsurf-compatible client metadata during ACP initialization. `acpx` satisfies this by detecting Devin ACP launches and advertising a narrow Windsurf identity shim.
 
 ### Detection
 
-`acpx` detects Devin ACP launches when the command matches `devin <model> acp` (e.g., `devin --model swe-1-6 acp`).
+`acpx` detects Devin ACP launches when the raw command starts with `devin` and includes `acp`, `--acp`, or `--experimental-acp`.
+
+```bash
+acpx --agent 'devin acp' exec 'summarize this repo'
+```
+
+Pass Devin global flags such as `--model <model>` before `acp` when needed:
+
+```bash
+acpx --agent 'devin --model swe-1-6 acp' exec 'summarize this repo'
+```
 
 ### Client identity
 
@@ -19,42 +29,35 @@ When Devin ACP is detected, `acpx` advertises:
 - `clientInfo.name`: `windsurf` (instead of `acpx`)
 - `clientInfo.version`: Controlled by `ACPX_DEVIN_WINDSURF_VERSION` env var (default: `1.110.1`)
 
-### Capability flags
+### Capabilities
 
-The following Cognition/Windsurf-specific capability flags are advertised under `clientCapabilities._meta`:
+Devin receives the same standard ACP client capabilities as other adapters:
 
-- `cognition.ai/groupedSessionConfigOptions`
-- `cognition.ai/lazyEditorFiles`
-- `cognition.ai/mcp`
-- `cognition.ai/messageGrouping`
-- `cognition.ai/multiRootWorkspace`
-- `cognition.ai/partialContent`
-- `cognition.ai/requestDiagnostics`
-- `cognition.ai/revert`
-- `cognition.ai/subagentSupport`
-- `cognition.ai/toolCallQuestions`
-- `cognition.ai/windsurfConfigBridge`
-- `terminal_output`
+- `fs.readTextFile`
+- `fs.writeTextFile`
+- `terminal` when terminal support is enabled
+
+The only Devin-specific capability flag is `_meta["cognition.ai/requestDiagnostics"] = true`, because `acpx` handles that Devin extension request.
 
 ### Extension handling
 
-`acpx` handles Devin's vendor extension methods:
+`acpx` handles Devin's vendor extension traffic:
 
 - `_cognition.ai/request_diagnostics`: Returns an empty object `{}` to satisfy the request
-- Other vendor extension notifications: Silently ignored to prevent method-not-found noise
+- Vendor extension notifications: Silently ignored to prevent method-not-found noise
 
 ### Version override
 
 Set `ACPX_DEVIN_WINDSURF_VERSION` to override the advertised Windsurf version:
 
 ```bash
-ACPX_DEVIN_WINDSURF_VERSION=1.120.0 acpx devin --model swe-1-6 acp 'fix the bug'
+ACPX_DEVIN_WINDSURF_VERSION=1.120.0 acpx --agent 'devin acp' exec 'fix the bug'
 ```
 
 ### Scope
 
 This compatibility shim is active only for Devin ACP launches. Other agents receive standard `acpx` identity and capabilities.
 
-### Minimum required capability set
+### Compatibility boundary
 
-The current implementation advertises the full Windsurf capability set observed in the wild. If Devin's requirements change, the minimum set should be narrowed to only what Devin actually requires to reduce compatibility risk.
+Do not add broad Windsurf/Cognition capability flags unless `acpx` implements the corresponding client operation or fresh Devin proof shows the flag is required for initialization.

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -97,6 +97,7 @@ Friendly agent names resolve to commands:
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.
 - `qwen` -> `qwen --acp`
 - `trae` -> `traecli acp serve`
+- `devin` -> `devin <model> acp` (requires `--model` flag before `acp`)
 
 Rules:
 
@@ -307,6 +308,31 @@ For ACP `authenticate` handshakes, use either config `auth` entries or explicit
 `ACPX_AUTH_<METHOD_ID>` environment variables such as `ACPX_AUTH_OPENAI_API_KEY`.
 Ambient provider env vars such as `OPENAI_API_KEY` are still passed through to
 child agents, but they do not trigger ACP auth-method selection on their own.
+
+## Devin ACP compatibility
+
+When `acpx` detects a Devin ACP launch (`devin <model> acp`), it advertises Windsurf-compatible client metadata to satisfy Devin's client requirements:
+
+- **Client identity**: Advertises `clientInfo.name` as `windsurf` instead of `acpx`
+- **Version override**: Uses `ACPX_DEVIN_WINDSURF_VERSION` env var (default: `1.110.1`) for `clientInfo.version`
+- **Capability flags**: Advertises Cognition/Windsurf-specific capability flags under `_meta` including:
+  - `cognition.ai/groupedSessionConfigOptions`
+  - `cognition.ai/lazyEditorFiles`
+  - `cognition.ai/mcp`
+  - `cognition.ai/messageGrouping`
+  - `cognition.ai/multiRootWorkspace`
+  - `cognition.ai/partialContent`
+  - `cognition.ai/requestDiagnostics`
+  - `cognition.ai/revert`
+  - `cognition.ai/subagentSupport`
+  - `cognition.ai/toolCallQuestions`
+  - `cognition.ai/windsurfConfigBridge`
+  - `terminal_output`
+- **Extension handling**: Handles Devin's `_cognition.ai/request_diagnostics` extension request (returns empty object) and silences method-not-found noise for vendor extension notifications
+
+This compatibility shim is scoped to Devin ACP launches only. Other agents continue to receive standard `acpx` identity and capabilities.
+
+See [`agents/Devin.md`](agents/Devin.md) for the full Devin compatibility contract.
 
 ## Session behavior
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -97,7 +97,6 @@ Friendly agent names resolve to commands:
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.
 - `qwen` -> `qwen --acp`
 - `trae` -> `traecli acp serve`
-- `devin` -> `devin <model> acp` (requires `--model` flag before `acp`)
 
 Rules:
 
@@ -311,28 +310,24 @@ child agents, but they do not trigger ACP auth-method selection on their own.
 
 ## Devin ACP compatibility
 
-When `acpx` detects a Devin ACP launch (`devin <model> acp`), it advertises Windsurf-compatible client metadata to satisfy Devin's client requirements:
+Devin is not a built-in agent shortcut. Use the raw command escape hatch:
 
-- **Client identity**: Advertises `clientInfo.name` as `windsurf` instead of `acpx`
-- **Version override**: Uses `ACPX_DEVIN_WINDSURF_VERSION` env var (default: `1.110.1`) for `clientInfo.version`
-- **Capability flags**: Advertises Cognition/Windsurf-specific capability flags under `_meta` including:
-  - `cognition.ai/groupedSessionConfigOptions`
-  - `cognition.ai/lazyEditorFiles`
-  - `cognition.ai/mcp`
-  - `cognition.ai/messageGrouping`
-  - `cognition.ai/multiRootWorkspace`
-  - `cognition.ai/partialContent`
-  - `cognition.ai/requestDiagnostics`
-  - `cognition.ai/revert`
-  - `cognition.ai/subagentSupport`
-  - `cognition.ai/toolCallQuestions`
-  - `cognition.ai/windsurfConfigBridge`
-  - `terminal_output`
-- **Extension handling**: Handles Devin's `_cognition.ai/request_diagnostics` extension request (returns empty object) and silences method-not-found noise for vendor extension notifications
+```bash
+acpx --agent 'devin acp' exec 'summarize this repo'
+```
+
+Pass Devin global flags such as `--model <model>` before `acp` when needed.
+
+When `acpx` detects a Devin ACP launch (`devin ... acp`, `devin ... --acp`, or `devin ... --experimental-acp`), it advertises the minimum Windsurf-compatible metadata needed for Devin's ACP gate:
+
+- `clientInfo.name`: `windsurf` instead of `acpx`
+- `clientInfo.version`: `ACPX_DEVIN_WINDSURF_VERSION` env var, default `1.110.1`
+- `clientCapabilities`: standard `fs` and `terminal` support, plus `_meta["cognition.ai/requestDiagnostics"] = true`
+- Extension handling: returns `{}` for Devin `_cognition.ai/request_diagnostics` requests and accepts extension notifications without method-not-found noise
 
 This compatibility shim is scoped to Devin ACP launches only. Other agents continue to receive standard `acpx` identity and capabilities.
 
-See [`agents/Devin.md`](agents/Devin.md) for the full Devin compatibility contract.
+See the repository [`agents/Devin.md`](https://github.com/openclaw/acpx/blob/main/agents/Devin.md) for the full Devin compatibility contract.
 
 ## Session behavior
 

--- a/slophammer.yml
+++ b/slophammer.yml
@@ -1,6 +1,8 @@
 typescript:
-  coverage_threshold: 85
-  complexity_max: 8
+  coverage:
+    threshold: 85
+  complexity:
+    max: 8
   dry:
     max_findings: 0
     paths:
@@ -15,8 +17,9 @@ typescript:
     copied_blocks:
       enabled: true
       min_tokens: 100
-  mutation_targets:
-    - src/cli/flags.ts
+  mutation:
+    targets:
+      - src/cli/flags.ts
   dependency_boundaries:
     - from: src/acp
       allow:
@@ -30,6 +33,7 @@ typescript:
         - src/session/runtime-session-id
         - src/spawn-command-options
         - src/types
+        - src/version
     - from: src/cli
       allow:
         - src/acp

--- a/src/acp/agent-command.ts
+++ b/src/acp/agent-command.ts
@@ -65,6 +65,13 @@ export function isQoderAcpCommand(command: string, args: readonly string[]): boo
   return basenameToken(command) === "qodercli" && args.includes("--acp");
 }
 
+export function isDevinAcpCommand(command: string, args: readonly string[]): boolean {
+  return (
+    basenameToken(command) === "devin" &&
+    (args.includes("acp") || args.includes("--acp") || args.includes("--experimental-acp"))
+  );
+}
+
 function hasCommandFlag(args: readonly string[], flagName: string): boolean {
   return args.some((arg) => arg === flagName || arg.startsWith(`${flagName}=`));
 }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -126,18 +126,7 @@ const AGENT_CLOSE_TERM_GRACE_MS = 1_500;
 const AGENT_CLOSE_KILL_GRACE_MS = 1_000;
 const STARTUP_STDERR_MAX_CHARS = 8_192;
 const DEVIN_COMPATIBILITY_CLIENT_CAPABILITIES_META = Object.freeze({
-  "cognition.ai/groupedSessionConfigOptions": true,
-  "cognition.ai/lazyEditorFiles": true,
-  "cognition.ai/mcp": true,
-  "cognition.ai/messageGrouping": true,
-  "cognition.ai/multiRootWorkspace": true,
-  "cognition.ai/partialContent": true,
   "cognition.ai/requestDiagnostics": true,
-  "cognition.ai/revert": true,
-  "cognition.ai/subagentSupport": true,
-  "cognition.ai/toolCallQuestions": true,
-  "cognition.ai/windsurfConfigBridge": true,
-  terminal_output: true,
 });
 const DEVIN_COMPATIBILITY_CLIENT_NAME = "windsurf";
 // This is the embedded Windsurf IDE version bundled with Devin Desktop 3.1.7, the first locally verified version that passes Devin's server-side ACP precondition.
@@ -176,9 +165,6 @@ function resolveClientCapabilities(params: {
   return {
     ...baseCapabilities,
     _meta: DEVIN_COMPATIBILITY_CLIENT_CAPABILITIES_META,
-    elicitation: {
-      form: {},
-    },
   };
 }
 
@@ -635,7 +621,7 @@ export class AcpClient {
       createNdJsonMessageStream(this.options.agentCommand, input, output),
     );
 
-    const connection = this.createConnection(stream);
+    const connection = this.createConnection(stream, launch);
     connection.signal.addEventListener(
       "abort",
       () => {
@@ -722,10 +708,13 @@ export class AcpClient {
     return requireAgentStdio(spawnedChild);
   }
 
-  private createConnection(stream: {
-    readable: ReadableStream<AnyMessage>;
-    writable: WritableStream<AnyMessage>;
-  }): ClientSideConnection {
+  private createConnection(
+    stream: {
+      readable: ReadableStream<AnyMessage>;
+      writable: WritableStream<AnyMessage>;
+    },
+    launch: Pick<AgentLaunchPlan, "devinAcp">,
+  ): ClientSideConnection {
     return new ClientSideConnection(
       () => ({
         sessionUpdate: async (params: SessionNotification) => {
@@ -737,7 +726,7 @@ export class AcpClient {
           return this.handlePermissionRequest(params);
         },
         extMethod: async (method: string): Promise<Record<string, unknown>> => {
-          if (isDevinRequestDiagnosticsMethod(method)) {
+          if (launch.devinAcp && isDevinRequestDiagnosticsMethod(method)) {
             return {};
           }
           throw RequestError.methodNotFound(method);
@@ -767,7 +756,7 @@ export class AcpClient {
         ): Promise<ReleaseTerminalResponse> => {
           return this.handleReleaseTerminal(params);
         },
-        extNotification: async () => {},
+        extNotification: async (): Promise<void> => {},
       }),
       stream,
     );

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -3,8 +3,10 @@ import { Readable, Writable } from "node:stream";
 import {
   ClientSideConnection,
   PROTOCOL_VERSION,
+  RequestError,
   type AnyMessage,
   type AuthMethod,
+  type ClientCapabilities,
   type CreateTerminalRequest,
   type CreateTerminalResponse,
   type InitializeResponse,
@@ -61,6 +63,7 @@ import type {
   PermissionStats,
   PromptInput,
 } from "../types.js";
+import { getAcpxVersion } from "../version.js";
 import {
   buildClaudeAcpSessionCreateTimeoutMessage,
   buildClaudeCodeOptionsMeta,
@@ -69,6 +72,7 @@ import {
   ensureCopilotAcpSupport,
   isClaudeAcpCommand,
   isCopilotAcpCommand,
+  isDevinAcpCommand,
   isGeminiAcpCommand,
   isQoderAcpCommand,
   resolveAgentCloseAfterStdinEndMs,
@@ -121,6 +125,66 @@ const DRAIN_POLL_INTERVAL_MS = 20;
 const AGENT_CLOSE_TERM_GRACE_MS = 1_500;
 const AGENT_CLOSE_KILL_GRACE_MS = 1_000;
 const STARTUP_STDERR_MAX_CHARS = 8_192;
+const DEVIN_COMPATIBILITY_CLIENT_CAPABILITIES_META = Object.freeze({
+  "cognition.ai/groupedSessionConfigOptions": true,
+  "cognition.ai/lazyEditorFiles": true,
+  "cognition.ai/mcp": true,
+  "cognition.ai/messageGrouping": true,
+  "cognition.ai/multiRootWorkspace": true,
+  "cognition.ai/partialContent": true,
+  "cognition.ai/requestDiagnostics": true,
+  "cognition.ai/revert": true,
+  "cognition.ai/subagentSupport": true,
+  "cognition.ai/toolCallQuestions": true,
+  "cognition.ai/windsurfConfigBridge": true,
+  terminal_output: true,
+});
+const DEVIN_COMPATIBILITY_CLIENT_NAME = "windsurf";
+// This is the embedded Windsurf IDE version bundled with Devin Desktop 3.1.7, the first locally verified version that passes Devin's server-side ACP precondition.
+const DEFAULT_DEVIN_COMPATIBILITY_CLIENT_VERSION = "1.110.1";
+
+function resolveClientInfo(devinAcp: boolean): { name: string; version: string } {
+  if (!devinAcp) {
+    return {
+      name: "acpx",
+      version: getAcpxVersion(),
+    };
+  }
+
+  return {
+    name: DEVIN_COMPATIBILITY_CLIENT_NAME,
+    version: process.env.ACPX_DEVIN_WINDSURF_VERSION ?? DEFAULT_DEVIN_COMPATIBILITY_CLIENT_VERSION,
+  };
+}
+
+function resolveClientCapabilities(params: {
+  devinAcp: boolean;
+  terminal: boolean;
+}): ClientCapabilities {
+  const baseCapabilities: ClientCapabilities = {
+    fs: {
+      readTextFile: true,
+      writeTextFile: true,
+    },
+    terminal: params.terminal,
+  };
+
+  if (!params.devinAcp) {
+    return baseCapabilities;
+  }
+
+  return {
+    ...baseCapabilities,
+    _meta: DEVIN_COMPATIBILITY_CLIENT_CAPABILITIES_META,
+    elicitation: {
+      form: {},
+    },
+  };
+}
+
+function isDevinRequestDiagnosticsMethod(method: string): boolean {
+  return method === "_cognition.ai/request_diagnostics";
+}
 
 type LoadSessionOptions = {
   suppressReplayUpdates?: boolean;
@@ -192,6 +256,7 @@ type AgentLaunchPlan = {
   spawnCommand: string;
   args: string[];
   resolvedBuiltInLaunch: ReturnType<typeof resolveBuiltInAgentLaunch>;
+  devinAcp: boolean;
   geminiAcp: boolean;
   copilotAcp: boolean;
   claudeAcp: boolean;
@@ -602,6 +667,7 @@ export class AcpClient {
       spawnCommand,
       args,
       resolvedBuiltInLaunch,
+      devinAcp: isDevinAcpCommand(spawnCommand, args),
       geminiAcp: isGeminiAcpCommand(spawnCommand, args),
       copilotAcp: isCopilotAcpCommand(spawnCommand, args),
       claudeAcp: isClaudeAcpCommand(spawnCommand, args),
@@ -670,6 +736,12 @@ export class AcpClient {
         ): Promise<RequestPermissionResponse> => {
           return this.handlePermissionRequest(params);
         },
+        extMethod: async (method: string): Promise<Record<string, unknown>> => {
+          if (isDevinRequestDiagnosticsMethod(method)) {
+            return {};
+          }
+          throw RequestError.methodNotFound(method);
+        },
         readTextFile: async (params: ReadTextFileRequest): Promise<ReadTextFileResponse> => {
           return this.handleReadTextFile(params);
         },
@@ -695,6 +767,7 @@ export class AcpClient {
         ): Promise<ReleaseTerminalResponse> => {
           return this.handleReleaseTerminal(params);
         },
+        extNotification: async () => {},
       }),
       stream,
     );
@@ -709,7 +782,7 @@ export class AcpClient {
   }): Promise<void> {
     try {
       const initResult = await Promise.race([
-        this.initializeProtocolConnection(params.connection, params.launch.geminiAcp),
+        this.initializeProtocolConnection(params.connection, params.launch),
         params.startupFailure.promise,
       ]);
       params.startupFailure.dispose();
@@ -724,23 +797,17 @@ export class AcpClient {
 
   private async initializeProtocolConnection(
     connection: ClientSideConnection,
-    geminiAcp: boolean,
+    launch: Pick<AgentLaunchPlan, "devinAcp" | "geminiAcp">,
   ): Promise<InitializeResponse> {
     const initializePromise = connection.initialize({
       protocolVersion: PROTOCOL_VERSION,
-      clientCapabilities: {
-        fs: {
-          readTextFile: true,
-          writeTextFile: true,
-        },
+      clientCapabilities: resolveClientCapabilities({
+        devinAcp: launch.devinAcp,
         terminal: this.options.terminal !== false,
-      },
-      clientInfo: {
-        name: "acpx",
-        version: "0.1.0",
-      },
+      }),
+      clientInfo: resolveClientInfo(launch.devinAcp),
     });
-    const initialized = geminiAcp
+    const initialized = launch.geminiAcp
       ? await withTimeout(initializePromise, resolveGeminiAcpStartupTimeoutMs())
       : await initializePromise;
     await this.authenticateIfRequired(connection, initialized.authMethods ?? []);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1057,6 +1057,135 @@ test("integration: exec --no-terminal disables advertised terminal capability", 
   });
 });
 
+test("integration: exec accepts agent extension notifications", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const result = await runCli(
+        [
+          ...baseAgentArgs(cwd),
+          "--format",
+          "quiet",
+          "exec",
+          "extension-notification _cognition.ai/output hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /extension notification accepted: _cognition\.ai\/output/);
+      assert.doesNotMatch(result.stderr, /Method not found/);
+      assert.doesNotMatch(result.stderr, /Error handling notification/);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: exec answers Devin diagnostics extension requests", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const result = await runCli(
+        [
+          ...baseAgentArgs(cwd),
+          "--format",
+          "quiet",
+          "exec",
+          "extension-request _cognition.ai/request_diagnostics hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(
+        result.stdout,
+        /extension request accepted: _cognition\.ai\/request_diagnostics \{\}/,
+      );
+      assert.doesNotMatch(result.stderr, /Method not found/);
+      assert.doesNotMatch(result.stderr, /Error handling request/);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: Devin ACP launch advertises Windsurf client info", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-devin-"));
+
+    try {
+      await writeFakeDevinAgent(fakeBinDir);
+
+      const result = await runCli(
+        [
+          "--agent",
+          "devin --model swe-1-6 --acp",
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "exec",
+          "echo hello",
+        ],
+        homeDir,
+        {
+          env: {
+            ACPX_DEVIN_WINDSURF_VERSION: "9.9.9-test",
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const initializeRequest = payloads.find((payload) => payload.method === "initialize") as
+        | {
+            params?: {
+              clientCapabilities?: {
+                _meta?: Record<string, unknown> | null;
+                elicitation?: { form?: unknown } | null;
+              };
+              clientInfo?: {
+                name?: unknown;
+                version?: unknown;
+              };
+            };
+          }
+        | undefined;
+      assert(initializeRequest, result.stdout);
+      assert.deepEqual(initializeRequest.params?.clientInfo, {
+        name: "windsurf",
+        version: "9.9.9-test",
+      });
+      assert.deepEqual(initializeRequest.params?.clientCapabilities?.elicitation, { form: {} });
+
+      const meta = initializeRequest.params?.clientCapabilities?._meta;
+      for (const key of [
+        "cognition.ai/groupedSessionConfigOptions",
+        "cognition.ai/lazyEditorFiles",
+        "cognition.ai/mcp",
+        "cognition.ai/messageGrouping",
+        "cognition.ai/multiRootWorkspace",
+        "cognition.ai/partialContent",
+        "cognition.ai/requestDiagnostics",
+        "cognition.ai/revert",
+        "cognition.ai/subagentSupport",
+        "cognition.ai/toolCallQuestions",
+        "cognition.ai/windsurfConfigBridge",
+        "terminal_output",
+      ]) {
+        assert.equal(meta?.[key], true, key);
+      }
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec --model sets the advertised model config option", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -3976,6 +4105,51 @@ async function writeFakeDroidAgent(binDir: string): Promise<void> {
       'if [ "$1" = "acp" ]; then',
       "  shift",
       "fi",
+      `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
+      "",
+    ].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function writeFakeDevinAgent(binDir: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      path.join(binDir, "devin.cmd"),
+      [
+        "@echo off",
+        "setlocal",
+        ":shift_known",
+        'if "%~1"=="--model" shift & shift & goto shift_known',
+        'if "%~1"=="acp" shift & goto shift_known',
+        'if "%~1"=="--acp" shift & goto shift_known',
+        'if "%~1"=="--experimental-acp" shift & goto shift_known',
+        `"${process.execPath}" "${MOCK_AGENT_PATH}" %*`,
+        "",
+      ].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  await fs.writeFile(
+    path.join(binDir, "devin"),
+    [
+      "#!/bin/sh",
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      "    --model)",
+      "      shift",
+      '      [ "$#" -gt 0 ] && shift',
+      "      ;;",
+      "    acp|--acp|--experimental-acp)",
+      "      shift",
+      "      ;;",
+      "    *)",
+      "      break",
+      "      ;;",
+      "  esac",
+      "done",
       `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
       "",
     ].join("\n"),

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1057,6 +1057,46 @@ test("integration: exec --no-terminal disables advertised terminal capability", 
   });
 });
 
+test("integration: non-Devin ACP launch advertises standard acpx client capabilities", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+
+    try {
+      const result = await runCli(
+        [...baseAgentArgs(cwd), "--format", "json", "exec", "echo hello"],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const initializeRequest = payloads.find((payload) => payload.method === "initialize") as
+        | {
+            params?: {
+              clientCapabilities?: {
+                _meta?: unknown;
+                elicitation?: unknown;
+                fs?: { readTextFile?: unknown; writeTextFile?: unknown };
+                terminal?: unknown;
+              };
+              clientInfo?: { name?: unknown; version?: unknown };
+            };
+          }
+        | undefined;
+      assert(initializeRequest, result.stdout);
+      assert.equal(initializeRequest.params?.clientInfo?.name, "acpx");
+      assert.equal(initializeRequest.params?.clientCapabilities?.terminal, true);
+      assert.deepEqual(initializeRequest.params?.clientCapabilities?.fs, {
+        readTextFile: true,
+        writeTextFile: true,
+      });
+      assert.equal(initializeRequest.params?.clientCapabilities?._meta, undefined);
+      assert.equal(initializeRequest.params?.clientCapabilities?.elicitation, undefined);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec accepts agent extension notifications", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -1082,7 +1122,7 @@ test("integration: exec accepts agent extension notifications", async () => {
   });
 });
 
-test("integration: exec answers Devin diagnostics extension requests", async () => {
+test("integration: non-Devin ACP launch rejects Devin diagnostics extension requests", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
 
@@ -1098,6 +1138,45 @@ test("integration: exec answers Devin diagnostics extension requests", async () 
         homeDir,
       );
       assert.equal(result.code, 0, result.stderr);
+      assert.doesNotMatch(
+        result.stdout,
+        /extension request accepted: _cognition\.ai\/request_diagnostics/,
+      );
+      assert.match(result.stderr, /"Method not found": _cognition\.ai\/request_diagnostics/);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: exec answers Devin diagnostics extension requests", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-devin-"));
+
+    try {
+      await writeFakeDevinAgent(fakeBinDir);
+
+      const result = await runCli(
+        [
+          "--agent",
+          "devin --model swe-1-6 acp",
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "quiet",
+          "exec",
+          "extension-request _cognition.ai/request_diagnostics hello",
+        ],
+        homeDir,
+        {
+          env: {
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+      assert.equal(result.code, 0, result.stderr);
       assert.match(
         result.stdout,
         /extension request accepted: _cognition\.ai\/request_diagnostics \{\}/,
@@ -1105,12 +1184,13 @@ test("integration: exec answers Devin diagnostics extension requests", async () 
       assert.doesNotMatch(result.stderr, /Method not found/);
       assert.doesNotMatch(result.stderr, /Error handling request/);
     } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
       await fs.rm(cwd, { recursive: true, force: true });
     }
   });
 });
 
-test("integration: Devin ACP launch advertises Windsurf client info", async () => {
+test("integration: Devin ACP launch advertises scoped Windsurf client info", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
     const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-devin-"));
@@ -1146,7 +1226,9 @@ test("integration: Devin ACP launch advertises Windsurf client info", async () =
             params?: {
               clientCapabilities?: {
                 _meta?: Record<string, unknown> | null;
-                elicitation?: { form?: unknown } | null;
+                elicitation?: unknown;
+                fs?: { readTextFile?: unknown; writeTextFile?: unknown };
+                terminal?: unknown;
               };
               clientInfo?: {
                 name?: unknown;
@@ -1160,25 +1242,15 @@ test("integration: Devin ACP launch advertises Windsurf client info", async () =
         name: "windsurf",
         version: "9.9.9-test",
       });
-      assert.deepEqual(initializeRequest.params?.clientCapabilities?.elicitation, { form: {} });
-
-      const meta = initializeRequest.params?.clientCapabilities?._meta;
-      for (const key of [
-        "cognition.ai/groupedSessionConfigOptions",
-        "cognition.ai/lazyEditorFiles",
-        "cognition.ai/mcp",
-        "cognition.ai/messageGrouping",
-        "cognition.ai/multiRootWorkspace",
-        "cognition.ai/partialContent",
-        "cognition.ai/requestDiagnostics",
-        "cognition.ai/revert",
-        "cognition.ai/subagentSupport",
-        "cognition.ai/toolCallQuestions",
-        "cognition.ai/windsurfConfigBridge",
-        "terminal_output",
-      ]) {
-        assert.equal(meta?.[key], true, key);
-      }
+      assert.equal(initializeRequest.params?.clientCapabilities?.terminal, true);
+      assert.deepEqual(initializeRequest.params?.clientCapabilities?.fs, {
+        readTextFile: true,
+        writeTextFile: true,
+      });
+      assert.deepEqual(initializeRequest.params?.clientCapabilities?._meta, {
+        "cognition.ai/requestDiagnostics": true,
+      });
+      assert.equal(initializeRequest.params?.clientCapabilities?.elicitation, undefined);
     } finally {
       await fs.rm(fakeBinDir, { recursive: true, force: true });
       await fs.rm(cwd, { recursive: true, force: true });

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -1118,6 +1118,38 @@ class MockAgent implements Agent {
       return "recovered after retry";
     }
 
+    if (text.startsWith("extension-notification ")) {
+      const rest = text.slice("extension-notification ".length).trim();
+      const firstSpace = rest.search(/\s/);
+
+      if (firstSpace <= 0) {
+        throw new Error("Usage: extension-notification <method> <message>");
+      }
+
+      const method = rest.slice(0, firstSpace).trim();
+      const message = rest.slice(firstSpace + 1).trim();
+      if (message.length === 0) {
+        throw new Error("Usage: extension-notification <method> <message>");
+      }
+
+      await this.connection.extNotification(method, { message });
+      return `extension notification accepted: ${method}`;
+    }
+
+    if (text.startsWith("extension-request ")) {
+      const rest = text.slice("extension-request ".length).trim();
+      const firstSpace = rest.search(/\s/);
+
+      if (firstSpace <= 0) {
+        throw new Error("Usage: extension-request <method> <message>");
+      }
+
+      const method = rest.slice(0, firstSpace).trim();
+      const message = rest.slice(firstSpace + 1).trim();
+      const response = await this.connection.extMethod(method, { message });
+      return `extension request accepted: ${method} ${JSON.stringify(response)}`;
+    }
+
     if (text.startsWith("late-tool ")) {
       const rest = text.slice("late-tool ".length).trim();
       const firstSpace = rest.search(/\s/);

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -58,6 +58,18 @@ test("slophammer is CI-only and enforces latest DRY plus dependency boundaries",
   assert.doesNotMatch(ciWorkflow, /assert-slophammer-rules-clean\.mjs/);
 });
 
+test("slophammer config uses the published v0.2 TypeScript schema", () => {
+  const config = readFileSync(path.join(process.cwd(), "slophammer.yml"), "utf8");
+
+  assert.match(config, /typescript:\n/);
+  assert.match(config, /coverage:\n\s+threshold: 85/);
+  assert.match(config, /complexity:\n\s+max: 8/);
+  assert.match(config, /mutation:\n\s+targets:\n\s+- src\/cli\/flags\.ts/);
+  assert.doesNotMatch(config, /coverage_threshold/);
+  assert.doesNotMatch(config, /complexity_max/);
+  assert.doesNotMatch(config, /mutation_targets/);
+});
+
 test("test scripts build packaged output before running package-bin smoke tests", () => {
   const pkg = readPackageJson();
 


### PR DESCRIPTION
## Summary
- Detect Devin ACP launches and advertise Windsurf-compatible client info/capabilities only for that adapter
- Handle Devin extension requests/notifications so _cognition.ai messages do not produce method-not-found noise
- Add integration coverage for Devin client identity, diagnostics requests, and extension notifications

## Verification
- pnpm run build:test && node --test dist-test/test/integration.test.js --test-name-pattern 'extension notifications|Devin diagnostics|Devin ACP launch' (runs full integration file: 85/85 passed)
- pnpm run build
- node dist/cli.js --cwd /tmp --format json --agent 'devin --model swe-1-6 acp' exec 'Reply with exactly: test-ok' → Quota error (proves Devin accepted Windsurf identity and initialized session; prior behavior would have rejected at Windsurf version check)
- pnpm run typecheck
- pnpm run lint

## Real behavior proof

**Before this change** (from main branch):
- acpx advertises `clientInfo.name: "acpx"` and `clientInfo.version: "0.1.0"` to all agents
- Devin rejects acpx as unsupported client (Windsurf version requirement)

**After this change** (current branch):
```bash
$ node dist/cli.js --cwd /tmp --format json --agent 'devin --model swe-1-6 acp' exec 'Reply with exactly: test-ok'
{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true,"_meta":{"cognition.ai/groupedSessionConfigOptions":true,"cognition.ai/lazyEditorFiles":true,"cognition.ai/mcp":true,"cognition.ai/messageGrouping":true,"cognition.ai/multiRootWorkspace":true,"cognition.ai/partialContent":true,"cognition.ai/requestDiagnostics":true,"cognition.ai/revert":true,"cognition.ai/subagentSupport":true,"cognition.ai/toolCallQuestions":true,"cognition.ai/windsurfConfigBridge":true,"terminal_output":true},"elicitation":{"form":{}}},"clientInfo":{"name":"windsurf","version":"1.110.1"}}}
```

The initialize request now advertises:
- `clientInfo.name: "windsurf"` (instead of "acpx")
- `clientInfo.version: "1.110.1"` (default from ACPX_DEVIN_WINDSURF_VERSION)
- Full Cognition/Windsurf capability flags under `_meta`

Devin accepts this identity and proceeds to session initialization (the quota error is expected for this test account and proves the session was created successfully).

## Documentation updates
- Updated `skills/acpx/SKILL.md` with Devin ACP compatibility section
- Created `agents/Devin.md` with full compatibility contract
- Documented ACPX_DEVIN_WINDSURF_VERSION env var and capability flags
- Documented minimum required capability set and version override policy