### PR TITLE
fix(cli): let Claude adjudicate stale model selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
+- CLI/Claude: let Claude Code adjudicate model selectors missing from a stale advertised model list on later persistent turns, and preserve the adapter-reported current model after model switches. Thanks @oakif.
 - Client/ACP: advertise scoped Devin/Windsurf-compatible client metadata and handle Devin extension requests/notifications without noisy method-not-found logs. Thanks @LivioGama.
 
 ## 2026.5.23 (v0.10.0)

--- a/src/acp/model-support.ts
+++ b/src/acp/model-support.ts
@@ -166,10 +166,10 @@ export function assertRequestedModelSupported(params: {
   models: SessionModelState | undefined;
   agentCommand?: string;
   context: "apply" | "replay";
-}): void {
+}): string | undefined {
   if (!params.models) {
     if (supportsLegacyClaudeCodeModelMetadata(params.agentCommand)) {
-      return;
+      return undefined;
     }
     const action = params.context === "replay" ? "replay saved model" : "apply --model";
     throw new RequestedModelUnsupportedError(
@@ -179,9 +179,13 @@ export function assertRequestedModelSupported(params: {
 
   const advertised = new Set(params.models.availableModels.map((model) => model.modelId));
   if (!advertised.has(params.requestedModel)) {
+    if (supportsLegacyClaudeCodeModelMetadata(params.agentCommand)) {
+      return `requested model "${params.requestedModel}" was not in the Claude ACP advertised model list (${formatAvailableModelIds(params.models)}); forwarding it to Claude Code so the adapter can accept or reject it.`;
+    }
     const action = params.context === "replay" ? "replay saved model" : "apply --model";
     throw new RequestedModelUnsupportedError(
       `Cannot ${action} "${params.requestedModel}": the ACP agent did not advertise that model. Available models: ${formatAvailableModelIds(params.models)}.`,
     );
   }
+  return undefined;
 }

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -218,6 +218,9 @@ function buildSessionStartOptions(params: {
     timeoutMs: params.globalFlags.timeout,
     verbose: params.globalFlags.verbose,
     sessionOptions: sessionOptionsFromGlobalFlags(params.globalFlags),
+    onModelWarning: params.globalFlags.jsonStrict
+      ? undefined
+      : (message) => process.stderr.write(`[acpx] warning: ${message}\n`),
   };
 }
 

--- a/src/cli/queue/ipc-server.ts
+++ b/src/cli/queue/ipc-server.ts
@@ -98,7 +98,10 @@ export type QueueOwnerControlHandlers = {
   cancelPrompt: () => Promise<boolean>;
   closeSession: (timeoutMs?: number) => Promise<boolean>;
   setSessionMode: (modeId: string, timeoutMs?: number) => Promise<void>;
-  setSessionModel: (modelId: string, timeoutMs?: number) => Promise<void>;
+  setSessionModel: (
+    modelId: string,
+    timeoutMs?: number,
+  ) => Promise<SetSessionConfigOptionResponse | undefined>;
   setSessionConfigOption: (
     configId: string,
     value: string,
@@ -427,11 +430,15 @@ export class SessionQueueOwner {
         socket,
         requestId: request.requestId,
         run: async () => {
-          await this.controlHandlers.setSessionModel(request.modelId, request.timeoutMs);
+          const response = await this.controlHandlers.setSessionModel(
+            request.modelId,
+            request.timeoutMs,
+          );
           return {
             type: "set_model_result",
             requestId: request.requestId,
             modelId: request.modelId,
+            response,
           };
         },
       });

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -580,7 +580,7 @@ async function submitSetModelToQueueOwner(
   owner: QueueOwnerRecord,
   modelId: string,
   timeoutMs?: number,
-): Promise<boolean | undefined> {
+): Promise<QueueOwnerSetModelResultMessage | undefined> {
   const request: QueueSetModelRequest = {
     type: "set_model",
     requestId: randomUUID(),
@@ -603,7 +603,7 @@ async function submitSetModelToQueueOwner(
       retryable: true,
     });
   }
-  return true;
+  return response;
 }
 
 async function submitSetConfigOptionToQueueOwner(
@@ -825,7 +825,7 @@ export async function trySetModelOnRunningOwner(
   modelId: string,
   timeoutMs: number | undefined,
   verbose: boolean | undefined,
-): Promise<boolean | undefined> {
+): Promise<QueueOwnerSetModelResultMessage | undefined> {
   const owner = await readQueueOwnerRecord(sessionId);
   if (!owner) {
     return undefined;
@@ -838,7 +838,7 @@ export async function trySetModelOnRunningOwner(
         `[acpx] requested a model config update on owner pid ${owner.pid} for session ${sessionId}\n`,
       );
     }
-    return true;
+    return submitted;
   }
 
   const health = await probeQueueOwnerHealth(sessionId);

--- a/src/cli/queue/messages.ts
+++ b/src/cli/queue/messages.ts
@@ -132,6 +132,7 @@ export type QueueOwnerSetModelResultMessage = {
   requestId: string;
   ownerGeneration?: number;
   modelId: string;
+  response?: SetSessionConfigOptionResponse;
 };
 
 export type QueueOwnerSetConfigOptionResultMessage = {
@@ -650,8 +651,7 @@ const QUEUE_OWNER_MESSAGE_PARSERS: Record<string, QueueOwnerMessageParser> = {
     parseBooleanResultOwnerMessage(message, context, "close_session_result", "closed"),
   set_mode_result: (message, context) =>
     parseStringResultOwnerMessage(message, context, "set_mode_result", "modeId"),
-  set_model_result: (message, context) =>
-    parseStringResultOwnerMessage(message, context, "set_model_result", "modelId"),
+  set_model_result: parseSetModelOwnerMessage,
   set_config_option_result: parseSetConfigOptionOwnerMessage,
   error: parseErrorOwnerMessage,
 };
@@ -721,6 +721,25 @@ function parseStringResultOwnerMessage<TType extends "set_mode_result" | "set_mo
     QueueOwnerMessage,
     { type: TType }
   >;
+}
+
+function parseSetModelOwnerMessage(
+  message: Record<string, unknown>,
+  context: QueueOwnerMessageContext,
+): QueueOwnerSetModelResultMessage | null {
+  if (typeof message.modelId !== "string") {
+    return null;
+  }
+  const response = asRecord(message.response);
+  if (message.response !== undefined && (!response || !Array.isArray(response.configOptions))) {
+    return null;
+  }
+  return {
+    type: "set_model_result",
+    ...context,
+    modelId: message.modelId,
+    ...(response ? { response: response as SetSessionConfigOptionResponse } : {}),
+  };
 }
 
 function parseSetConfigOptionOwnerMessage(

--- a/src/cli/queue/owner-turn-controller.ts
+++ b/src/cli/queue/owner-turn-controller.ts
@@ -7,7 +7,7 @@ export type QueueOwnerActiveSessionController = {
   hasActivePrompt: () => boolean;
   requestCancelActivePrompt: () => Promise<boolean>;
   setSessionMode: (modeId: string) => Promise<void>;
-  setSessionModel: (modelId: string) => Promise<void>;
+  setSessionModel: (modelId: string) => Promise<SetSessionConfigOptionResponse | undefined>;
   setSessionConfigOption: (
     configId: string,
     value: string,
@@ -17,7 +17,10 @@ export type QueueOwnerActiveSessionController = {
 type QueueOwnerTurnControllerOptions = {
   withTimeout: <T>(run: () => Promise<T>, timeoutMs?: number) => Promise<T>;
   setSessionModeFallback: (modeId: string, timeoutMs?: number) => Promise<void>;
-  setSessionModelFallback: (modelId: string, timeoutMs?: number) => Promise<void>;
+  setSessionModelFallback: (
+    modelId: string,
+    timeoutMs?: number,
+  ) => Promise<SetSessionConfigOptionResponse | undefined>;
   setSessionConfigOptionFallback: (
     configId: string,
     value: string,
@@ -128,18 +131,20 @@ export class QueueOwnerTurnController {
     await this.options.setSessionModeFallback(modeId, timeoutMs);
   }
 
-  async setSessionModel(modelId: string, timeoutMs?: number): Promise<void> {
+  async setSessionModel(
+    modelId: string,
+    timeoutMs?: number,
+  ): Promise<SetSessionConfigOptionResponse | undefined> {
     this.assertCanHandleControlRequest();
     const activeController = this.activeController;
     if (activeController) {
-      await this.options.withTimeout(
+      return await this.options.withTimeout(
         async () => await activeController.setSessionModel(modelId),
         timeoutMs,
       );
-      return;
     }
 
-    await this.options.setSessionModelFallback(modelId, timeoutMs);
+    return await this.options.setSessionModelFallback(modelId, timeoutMs);
   }
 
   async setSessionConfigOption(

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -74,6 +74,7 @@ export type SessionCreateOptions = {
   terminal?: boolean;
   verbose?: boolean;
   sessionOptions?: SessionAgentOptions;
+  onModelWarning?: (message: string) => void;
 } & TimedRunOptions;
 
 export type SessionSendOptions = {
@@ -118,6 +119,7 @@ export type SessionEnsureOptions = {
   verbose?: boolean;
   walkBoundary?: string;
   sessionOptions?: SessionAgentOptions;
+  onModelWarning?: (message: string) => void;
 } & TimedRunOptions;
 
 export type SessionListOptions = {

--- a/src/cli/session/prompt-runner.ts
+++ b/src/cli/session/prompt-runner.ts
@@ -12,6 +12,7 @@ import {
   setDesiredModeId,
   setDesiredModelId,
 } from "../../session/mode-preference.js";
+import { currentModelIdFromSetModelResponse } from "../../session/model-application.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import { resolveSessionRecord, writeSessionRecord } from "../../session/persistence.js";
 import type {
@@ -140,11 +141,12 @@ export async function runSessionSetModelDirect(
       );
       applyConfigOptionsToRecord(record, response);
       setDesiredModelId(record, options.modelId, models?.configId);
-      setCurrentModelId(record, options.modelId);
+      setCurrentModelId(record, currentModelIdFromSetModelResponse(response, options.modelId));
+      return response;
     }),
   );
 
-  return toSessionMutationResult(result);
+  return { ...toSessionMutationResult(result), response: result.value };
 }
 
 export async function runSessionSetConfigOptionDirect(
@@ -160,7 +162,7 @@ export async function runSessionSetConfigOptionDirect(
       applyConfigOptionsToRecord(record, response);
       if (options.configId === modelConfigId) {
         setDesiredModelId(record, options.value, options.configId);
-        setCurrentModelId(record, options.value);
+        setCurrentModelId(record, currentModelIdFromSetModelResponse(response, options.value));
       } else if (options.configId === "mode") {
         setDesiredModeId(record, options.value);
       } else {

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -107,7 +107,7 @@ function createQueueOwnerTurnController(
       });
     },
     setSessionModelFallback: async (modelId: string, timeoutMs?: number) => {
-      await runSessionSetModelDirect({
+      const result = await runSessionSetModelDirect({
         sessionRecordId: options.sessionId,
         modelId,
         mcpServers: options.mcpServers,
@@ -118,6 +118,7 @@ function createQueueOwnerTurnController(
         timeoutMs,
         verbose: options.verbose,
       });
+      return result.response;
     },
     setSessionConfigOptionFallback: async (configId: string, value: string, timeoutMs?: number) => {
       const result = await runSessionSetConfigOptionDirect({
@@ -265,9 +266,8 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
         setSessionMode: async (modeId: string, timeoutMs?: number) => {
           await turnController.setSessionMode(modeId, timeoutMs);
         },
-        setSessionModel: async (modelId: string, timeoutMs?: number) => {
-          await turnController.setSessionModel(modelId, timeoutMs);
-        },
+        setSessionModel: async (modelId: string, timeoutMs?: number) =>
+          await turnController.setSessionModel(modelId, timeoutMs),
         setSessionConfigOption: async (configId: string, value: string, timeoutMs?: number) => {
           return await turnController.setSessionConfigOption(configId, value, timeoutMs);
         },

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -42,7 +42,10 @@ import {
   setCurrentModelId,
   setDesiredModelId,
 } from "../../session/mode-preference.js";
-import { applyRequestedModelIfAdvertised } from "../../session/model-application.js";
+import {
+  applyRequestedModelIfAdvertised,
+  currentModelIdFromSetModelResponse,
+} from "../../session/model-application.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import {
   absolutePath,
@@ -231,6 +234,7 @@ async function applyPromptModelIfAdvertised(params: {
   requestedModel: string | undefined;
   record: SessionRecord;
   timeoutMs?: number;
+  suppressWarnings?: boolean;
 }): Promise<void> {
   const requestedModel = requestedModelId(params.requestedModel);
   if (!requestedModel) {
@@ -238,12 +242,13 @@ async function applyPromptModelIfAdvertised(params: {
   }
 
   const models = advertisedModelState(params.record.acpx);
-  assertRequestedModelSupported({
+  const warning = assertRequestedModelSupported({
     requestedModel,
     models,
     agentCommand: params.record.agentCommand,
     context: "apply",
   });
+  emitModelSupportWarning(warning, params.suppressWarnings);
   if (!models) {
     return;
   }
@@ -258,7 +263,13 @@ async function applyPromptModelIfAdvertised(params: {
   );
   applyConfigOptionsToRecord(params.record, response);
   setDesiredModelId(params.record, requestedModel, models.configId);
-  setCurrentModelId(params.record, requestedModel);
+  setCurrentModelId(params.record, currentModelIdFromSetModelResponse(response, requestedModel));
+}
+
+function emitModelSupportWarning(warning: string | undefined, suppressWarnings?: boolean): void {
+  if (warning && !suppressWarnings) {
+    process.stderr.write(`[acpx] warning: ${warning}\n`);
+  }
 }
 
 function jsonRpcIdKey(value: unknown): string | undefined {
@@ -717,9 +728,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       acpxState = applyConfigOptionResponseToState(acpxState, response);
       const nextState = cloneSessionAcpxState(acpxState) ?? {};
       nextState.session_options = { ...nextState.session_options, model: modelId };
-      nextState.current_model_id = modelId;
+      nextState.current_model_id = currentModelIdFromSetModelResponse(response, modelId);
       clearDesiredConfigOption(nextState, models?.configId);
       acpxState = nextState;
+      return response;
     },
     setSessionConfigOption: async (configId: string, value: string) => {
       const response = await client.setSessionConfigOption(
@@ -732,7 +744,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       const modelConfigId = modelStateFromConfigOptions(nextState.config_options)?.configId;
       if (configId === modelConfigId) {
         nextState.session_options = { ...nextState.session_options, model: value };
-        nextState.current_model_id = value;
+        nextState.current_model_id = currentModelIdFromSetModelResponse(response, value);
         clearDesiredConfigOption(nextState, configId);
       } else if (configId === "mode") {
         nextState.desired_mode_id = value;
@@ -769,6 +781,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
           resumePolicy: options.resumePolicy,
           timeoutMs: options.timeoutMs,
           verbose: options.verbose,
+          suppressWarnings: options.suppressSdkConsoleErrors,
           activeController,
           onClientAvailable: (controller) => {
             options.onClientAvailable?.(controller);
@@ -905,6 +918,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
           requestedModel: sessionOptions?.model,
           record,
           timeoutMs: options.timeoutMs,
+          suppressWarnings: options.suppressSdkConsoleErrors,
         });
         acpxState = cloneSessionAcpxState(record.acpx);
 
@@ -1050,6 +1064,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
           models: createdSession.models,
           agentCommand: options.agentCommand,
           timeoutMs: options.timeoutMs,
+          onWarning: options.suppressSdkConsoleErrors
+            ? undefined
+            : (message) => process.stderr.write(`[acpx] warning: ${message}\n`),
         });
 
         output.setContext({

--- a/src/cli/session/session-control.ts
+++ b/src/cli/session/session-control.ts
@@ -7,6 +7,7 @@ import {
   setDesiredModeId,
   setDesiredModelId,
 } from "../../session/mode-preference.js";
+import { currentModelIdFromSetModelResponse } from "../../session/model-application.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import { resolveSessionRecord, writeSessionRecord, isoNow } from "../../session/persistence.js";
 import type {
@@ -91,11 +92,16 @@ export async function setSessionModel(
   );
   if (submittedToOwner) {
     const record = await resolveSessionRecord(options.sessionId);
+    applyConfigOptionsToRecord(record, submittedToOwner.response);
     setDesiredModelId(record, options.modelId, advertisedModelState(record.acpx)?.configId);
-    setCurrentModelId(record, options.modelId);
+    setCurrentModelId(
+      record,
+      currentModelIdFromSetModelResponse(submittedToOwner.response, options.modelId),
+    );
     await writeSessionRecord(record);
     return {
       record,
+      response: submittedToOwner.response,
       resumed: false,
     };
   }
@@ -129,7 +135,7 @@ export async function setSessionConfigOption(
     applyConfigOptionsToRecord(record, ownerResponse);
     if (options.configId === modelConfigId) {
       setDesiredModelId(record, options.value, options.configId);
-      setCurrentModelId(record, options.value);
+      setCurrentModelId(record, currentModelIdFromSetModelResponse(ownerResponse, options.value));
     } else if (options.configId === "mode") {
       setDesiredModeId(record, options.value);
     } else {

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -8,7 +8,10 @@ import { applyConfigOptionsToRecord } from "../../session/config-options.js";
 import { createSessionConversation } from "../../session/conversation-model.js";
 import { defaultSessionEventLog } from "../../session/event-log.js";
 import { setCurrentModelId, syncAdvertisedModelState } from "../../session/mode-preference.js";
-import { applyRequestedModelIfAdvertised } from "../../session/model-application.js";
+import {
+  applyRequestedModelIfAdvertised,
+  currentModelIdFromSetModelResponse,
+} from "../../session/model-application.js";
 import {
   absolutePath,
   findGitRepositoryRoot,
@@ -95,7 +98,10 @@ function applyCreatedSessionModelState(
       : state.sessionModels,
   );
   if (state.requestedModelApplied) {
-    setCurrentModelId(record, requestedModel);
+    setCurrentModelId(
+      record,
+      currentModelIdFromSetModelResponse(state.requestedModelResponse, requestedModel),
+    );
   }
 }
 
@@ -112,6 +118,7 @@ async function createFreshSessionState(
     models: createdSession.models,
     agentCommand: options.agentCommand,
     timeoutMs: options.timeoutMs,
+    onWarning: options.onModelWarning,
   });
   return {
     sessionId: createdSession.sessionId,
@@ -157,6 +164,7 @@ async function resumeSessionRecordWithClient(
       models: sessionModels,
       agentCommand: options.agentCommand,
       timeoutMs: options.timeoutMs,
+      onWarning: options.onModelWarning,
     });
     return {
       sessionId: options.resumeSessionId,

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -19,7 +19,7 @@ import { connectAndLoadSession, type ConnectedSessionController } from "./reconn
 import { sessionOptionsFromRecord } from "./session-options.js";
 
 export type FullConnectedSessionController = ConnectedSessionController & {
-  setSessionModel: (modelId: string) => Promise<void>;
+  setSessionModel: (modelId: string) => Promise<SetSessionConfigOptionResponse | undefined>;
   setSessionConfigOption: (
     configId: string,
     value: string,
@@ -83,6 +83,7 @@ function createActiveSessionController(params: {
       const models = advertisedModelState(params.record.acpx);
       const response = await params.client.setSessionModel(getActiveSessionId(), modelId, models);
       applyConfigOptionsToRecord(params.record, response);
+      return response;
     },
     setSessionConfigOption: async (configId: string, value: string) => {
       return await params.client.setSessionConfigOption(getActiveSessionId(), configId, value);

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -29,7 +29,10 @@ import {
   setDesiredModeId,
   syncAdvertisedModelState,
 } from "../../session/mode-preference.js";
-import { applyRequestedModelIfAdvertised } from "../../session/model-application.js";
+import {
+  applyRequestedModelIfAdvertised,
+  currentModelIdFromSetModelResponse,
+} from "../../session/model-application.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import type {
   ClientOperation,
@@ -72,7 +75,7 @@ type ActiveSessionController = {
   hasActivePrompt: () => boolean;
   requestCancelActivePrompt: () => Promise<boolean>;
   setSessionMode: (modeId: string) => Promise<void>;
-  setSessionModel: (modelId: string) => Promise<void>;
+  setSessionModel: (modelId: string) => ReturnType<AcpClient["setSessionModel"]>;
   setSessionConfigOption: (
     configId: string,
     value: string,
@@ -769,7 +772,10 @@ export class AcpRuntimeManager {
         : session.sessionResult.models,
     );
     if (modelApplication.applied) {
-      setCurrentModelId(record, input.sessionOptions?.model);
+      setCurrentModelId(
+        record,
+        currentModelIdFromSetModelResponse(modelApplication.response, input.sessionOptions?.model),
+      );
     }
     applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
     persistSessionOptions(record, input.sessionOptions);
@@ -998,9 +1004,10 @@ export class AcpRuntimeManager {
         applyConfigOptionResponseToTurn(turn, response);
         const nextState = cloneSessionAcpxState(turn.acpxState) ?? {};
         nextState.session_options = { ...nextState.session_options, model: modelId };
-        nextState.current_model_id = modelId;
+        nextState.current_model_id = currentModelIdFromSetModelResponse(response, modelId);
         clearDesiredConfigOption(nextState, models?.configId);
         turn.acpxState = nextState;
+        return response;
       },
       setSessionConfigOption: async (configId: string, value: string) => {
         const result = await task.state.activeController!.setResolvedSessionConfigOption(

--- a/src/runtime/engine/reconnect.ts
+++ b/src/runtime/engine/reconnect.ts
@@ -38,7 +38,7 @@ export type ConnectedSessionController = {
   hasActivePrompt: () => boolean;
   requestCancelActivePrompt: () => Promise<boolean>;
   setSessionMode: (modeId: string) => Promise<void>;
-  setSessionModel: (modelId: string) => Promise<void>;
+  setSessionModel: (modelId: string) => ReturnType<AcpClient["setSessionModel"]>;
   setSessionConfigOption: (
     configId: string,
     value: string,
@@ -64,6 +64,7 @@ export type ConnectAndLoadSessionOptions = {
   resumePolicy?: SessionResumePolicy;
   timeoutMs?: number;
   verbose?: boolean;
+  suppressWarnings?: boolean;
   activeController: ConnectedSessionController;
   onClientAvailable?: (controller: ConnectedSessionController) => void;
   onConnectedRecord?: (record: SessionRecord) => void;
@@ -165,18 +166,20 @@ async function replayDesiredModel(params: {
   models: import("../../acp/client.js").SessionLoadResult["models"] | undefined;
   timeoutMs?: number;
   verbose?: boolean;
+  suppressWarnings?: boolean;
 }): Promise<ModelReplayResult> {
   if (!params.desiredModelId) {
     return { replayed: false };
   }
 
   try {
-    assertRequestedModelSupported({
+    const warning = assertRequestedModelSupported({
       requestedModel: params.desiredModelId,
       models: params.models,
       agentCommand: params.record.agentCommand,
       context: "replay",
     });
+    emitModelSupportWarning(warning, params.suppressWarnings);
     if (!params.models || params.models.currentModelId === params.desiredModelId) {
       return { replayed: false };
     }
@@ -206,6 +209,12 @@ async function replayDesiredModel(params: {
         retryable: true,
       },
     );
+  }
+}
+
+function emitModelSupportWarning(warning: string | undefined, suppressWarnings?: boolean): void {
+  if (warning && !suppressWarnings) {
+    process.stderr.write(`[acpx] warning: ${warning}\n`);
   }
 }
 
@@ -342,6 +351,7 @@ export async function connectAndLoadSession(
     sessionModels,
     timeoutMs: options.timeoutMs,
     verbose: options.verbose,
+    suppressWarnings: options.suppressWarnings,
   });
 
   applyReconnectedModelState(
@@ -463,6 +473,7 @@ async function replayFreshSessionPreferences(params: {
   sessionModels: import("../../acp/client.js").SessionLoadResult["models"];
   timeoutMs?: number;
   verbose?: boolean;
+  suppressWarnings?: boolean;
 }): Promise<FreshPreferenceReplayResult> {
   if (!params.createdFreshSession) {
     return {
@@ -491,6 +502,7 @@ async function replayFreshSessionPreferences(params: {
       models: params.sessionModels,
       timeoutMs: params.timeoutMs,
       verbose: params.verbose,
+      suppressWarnings: params.suppressWarnings,
     });
     configReplay = await replayDesiredConfigOptions({
       client: params.client,

--- a/src/session/model-application.ts
+++ b/src/session/model-application.ts
@@ -1,7 +1,17 @@
 import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import type { AcpClient, SessionCreateResult } from "../acp/client.js";
-import { assertRequestedModelSupported } from "../acp/model-support.js";
+import {
+  assertRequestedModelSupported,
+  modelStateFromConfigOptions,
+} from "../acp/model-support.js";
 import { withTimeout } from "../async-control.js";
+
+export function currentModelIdFromSetModelResponse(
+  response: SetSessionConfigOptionResponse | undefined,
+  fallbackModelId: string | undefined,
+): string | undefined {
+  return modelStateFromConfigOptions(response?.configOptions)?.currentModelId ?? fallbackModelId;
+}
 
 export async function applyRequestedModelIfAdvertised(params: {
   client: AcpClient;
@@ -10,6 +20,7 @@ export async function applyRequestedModelIfAdvertised(params: {
   models: SessionCreateResult["models"];
   agentCommand?: string;
   timeoutMs?: number;
+  onWarning?: (message: string) => void;
 }): Promise<{
   applied: boolean;
   response?: SetSessionConfigOptionResponse;
@@ -19,12 +30,15 @@ export async function applyRequestedModelIfAdvertised(params: {
   if (!requestedModel) {
     return { applied: false };
   }
-  assertRequestedModelSupported({
+  const warning = assertRequestedModelSupported({
     requestedModel,
     models: params.models,
     agentCommand: params.agentCommand,
     context: "apply",
   });
+  if (warning) {
+    params.onWarning?.(warning);
+  }
   if (!params.models) {
     return { applied: false };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -437,6 +437,7 @@ export type SessionSetConfigOptionResult = {
 
 export type SessionSetModelResult = {
   record: SessionRecord;
+  response?: SetSessionConfigOptionResponse;
   resumed: boolean;
   loadError?: string;
 };

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1369,6 +1369,63 @@ test("integration: exec --model rejects models not advertised by the agent", asy
   });
 });
 
+test("integration: Claude ACP prompt forwards saved model missing from reconnect advertisement", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-claude-"));
+
+    try {
+      const fakeClaude = await writeFakeClaudeAgent(fakeBinDir);
+      const modelAgentCommand = `${JSON.stringify(fakeClaude)} --supports-load-session --advertise-models --omit-reconnect-model gpt-5.4`;
+      const created = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--model",
+          "gpt-5.4",
+          "sessions",
+          "new",
+        ],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      const result = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "--model",
+          "gpt-5.4",
+          "prompt",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const setModelRequest = payloads.find(
+        (payload) =>
+          payload.method === "session/set_config_option" &&
+          (payload.params as { configId?: unknown } | undefined)?.configId === "model",
+      ) as { params?: { configId?: string; value?: string } } | undefined;
+      assert(setModelRequest, "expected model session config despite stale advertisement");
+      assert.equal(setModelRequest.params?.value, "gpt-5.4");
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: prompt --model updates existing session model before prompt", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -1408,6 +1465,36 @@ test("integration: prompt --model updates existing session model before prompt",
       assert(setModelRequest, "expected model session config before the persistent prompt");
       assert.equal(setModelRequest.params?.configId, "llm");
       assert.equal(setModelRequest.params?.value, "fast-model");
+
+      const status = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "--format", "json", "status"],
+        homeDir,
+      );
+      assert.equal(status.code, 0, status.stderr);
+      assert.equal((JSON.parse(status.stdout.trim()) as { model?: string }).model, "fast-model");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: status preserves model actually reported after set model", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const modelAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-models --report-model-as fast-model`;
+
+    try {
+      const created = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "sessions", "new"],
+        homeDir,
+      );
+      assert.equal(created.code, 0, created.stderr);
+
+      const setResult = await runCli(
+        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "set", "model", "gpt-5.4"],
+        homeDir,
+      );
+      assert.equal(setResult.code, 0, setResult.stderr);
 
       const status = await runCli(
         ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "--format", "json", "status"],
@@ -4182,6 +4269,26 @@ async function writeFakeDroidAgent(binDir: string): Promise<void> {
     ].join("\n"),
     { encoding: "utf8", mode: 0o755 },
   );
+}
+
+async function writeFakeClaudeAgent(binDir: string): Promise<string> {
+  const binName = process.platform === "win32" ? "claude-agent-acp.cmd" : "claude-agent-acp";
+  const binPath = path.join(binDir, binName);
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      binPath,
+      ["@echo off", "setlocal", `"${process.execPath}" "${MOCK_AGENT_PATH}" %*`, ""].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return binPath;
+  }
+
+  await fs.writeFile(
+    binPath,
+    ["#!/bin/sh", `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`, ""].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+  return binPath;
 }
 
 async function writeFakeDevinAgent(binDir: string): Promise<void> {

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -62,6 +62,8 @@ type MockAgentOptions = {
   advertiseLegacyModels: boolean;
   modelConfigId: string;
   omitReconnectConfigOptions: boolean;
+  omitReconnectModelId?: string;
+  reportModelAs?: string;
   replayLoadSessionUpdates: boolean;
   loadReplayText: string;
   ignoreSigterm: boolean;
@@ -367,6 +369,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let advertiseLegacyModels = false;
   let modelConfigId = "model";
   let omitReconnectConfigOptions = false;
+  let omitReconnectModelId: string | undefined;
+  let reportModelAs: string | undefined;
   let replayLoadSessionUpdates = false;
   let loadReplayText = "replayed load session update";
   let ignoreSigterm = false;
@@ -449,6 +453,18 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
 
     if (token === "--omit-reconnect-config-options") {
       omitReconnectConfigOptions = true;
+      continue;
+    }
+
+    if (token === "--omit-reconnect-model") {
+      omitReconnectModelId = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (token === "--report-model-as") {
+      reportModelAs = argv[index + 1];
+      index += 1;
       continue;
     }
 
@@ -557,6 +573,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     advertiseLegacyModels,
     modelConfigId,
     omitReconnectConfigOptions,
+    omitReconnectModelId,
+    reportModelAs,
     replayLoadSessionUpdates,
     loadReplayText,
     ignoreSigterm,
@@ -645,11 +663,21 @@ function parseListCursor(cursor: string | null | undefined): number {
 function buildConfigOptions(
   state: SessionState,
   modelConfigId: string,
+  omitModelId?: string,
+  currentModelId = state.modelId,
 ): SetSessionConfigOptionResponse["configOptions"] {
   const reasoningEffort =
     typeof state.configValues.reasoning_effort === "string"
       ? state.configValues.reasoning_effort
       : "medium";
+
+  const modelOptions = [
+    { value: DEFAULT_MODEL_ID, name: DEFAULT_MODEL_ID },
+    { value: "fast-model", name: "fast-model" },
+    { value: "smart-model", name: "smart-model" },
+    { value: "gpt-5.4", name: "gpt-5.4" },
+    { value: "gpt-5.2", name: "gpt-5.2" },
+  ].filter((option) => option.value !== omitModelId);
 
   return [
     {
@@ -671,14 +699,8 @@ function buildConfigOptions(
       name: "Model",
       category: "model",
       type: "select",
-      currentValue: state.modelId,
-      options: [
-        { value: DEFAULT_MODEL_ID, name: DEFAULT_MODEL_ID },
-        { value: "fast-model", name: "fast-model" },
-        { value: "smart-model", name: "smart-model" },
-        { value: "gpt-5.4", name: "gpt-5.4" },
-        { value: "gpt-5.2", name: "gpt-5.2" },
-      ],
+      currentValue: currentModelId,
+      options: modelOptions,
     },
     {
       id: "reasoning_effort",
@@ -749,6 +771,7 @@ class MockAgent implements Agent {
       response.configOptions = buildConfigOptions(
         this.sessions.get(sessionId) ?? createSessionState(false),
         this.options.modelConfigId,
+        this.options.omitReconnectModelId,
       );
     }
 
@@ -1007,7 +1030,12 @@ class MockAgent implements Agent {
     }
 
     return {
-      configOptions: buildConfigOptions(session, this.options.modelConfigId),
+      configOptions: buildConfigOptions(
+        session,
+        this.options.modelConfigId,
+        this.options.omitReconnectModelId,
+        this.options.reportModelAs,
+      ),
     };
   }
 

--- a/test/model-support.test.ts
+++ b/test/model-support.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertRequestedModelSupported } from "../src/acp/model-support.js";
+
+test("Claude ACP model validation warns for unadvertised selectors", () => {
+  const warning = assertRequestedModelSupported({
+    requestedModel: "opus[1m]",
+    models: {
+      configId: "model",
+      currentModelId: "sonnet",
+      availableModels: [
+        { modelId: "default", name: "Default" },
+        { modelId: "sonnet", name: "Sonnet" },
+      ],
+    },
+    agentCommand: "npx -y @agentclientprotocol/claude-agent-acp@^0.37.0",
+    context: "apply",
+  });
+
+  assert.match(
+    warning ?? "",
+    /requested model "opus\[1m\]" was not in the Claude ACP advertised model list/,
+  );
+});
+
+test("non-Claude model validation rejects unadvertised selectors", () => {
+  assert.throws(
+    () =>
+      assertRequestedModelSupported({
+        requestedModel: "missing-model",
+        models: {
+          configId: "model",
+          currentModelId: "default",
+          availableModels: [{ modelId: "default", name: "Default" }],
+        },
+        agentCommand: "mock-agent --advertise-models",
+        context: "apply",
+      }),
+    /did not advertise that model/,
+  );
+});

--- a/test/turn-controller.test.ts
+++ b/test/turn-controller.test.ts
@@ -127,22 +127,36 @@ test("QueueOwnerTurnController routes setSessionModel through active controller"
     setSessionModelFallback: async (_modelId, timeoutMs) => {
       fallbackCalls += 1;
       fallbackTimeouts.push(timeoutMs);
+      return { configOptions: [] };
     },
   });
 
+  const reportedResponse: SetSessionConfigOptionResponse = {
+    configOptions: [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        options: [{ value: "fast-model", name: "Fast" }],
+        currentValue: "fast-model",
+      },
+    ],
+  };
   controller.setActiveController(
     makeActiveController({
       setSessionModel: async () => {
         activeCalls += 1;
+        return reportedResponse;
       },
     }),
   );
 
-  await controller.setSessionModel("gpt-5.4", 1500);
+  const response = await controller.setSessionModel("gpt-5.4", 1500);
   assert.equal(activeCalls, 1);
   assert.equal(fallbackCalls, 0);
   assert.deepEqual(observedTimeouts, [1500]);
   assert.deepEqual(fallbackTimeouts, []);
+  assert.equal(response, reportedResponse);
 });
 
 test("QueueOwnerTurnController routes setSessionConfigOption through fallback when inactive", async () => {
@@ -202,7 +216,10 @@ test("QueueOwnerTurnController rejects control requests while closing", async ()
 type QueueOwnerTurnControllerOverrides = Partial<{
   withTimeout: <T>(run: () => Promise<T>, timeoutMs?: number) => Promise<T>;
   setSessionModeFallback: (modeId: string, timeoutMs?: number) => Promise<void>;
-  setSessionModelFallback: (modelId: string, timeoutMs?: number) => Promise<void>;
+  setSessionModelFallback: (
+    modelId: string,
+    timeoutMs?: number,
+  ) => Promise<SetSessionConfigOptionResponse | undefined>;
   setSessionConfigOptionFallback: (
     configId: string,
     value: string,
@@ -222,9 +239,9 @@ function createQueueOwnerTurnController(
     });
   const setSessionModelFallback =
     overrides.setSessionModelFallback ??
-    (async (): Promise<void> => {
-      // no-op
-    });
+    (async () => ({
+      configOptions: [],
+    }));
   const setSessionConfigOptionFallback =
     overrides.setSessionConfigOptionFallback ??
     (async () => ({
@@ -254,9 +271,9 @@ function makeActiveController(
       }),
     setSessionModel:
       overrides.setSessionModel ??
-      (async () => {
-        // no-op
-      }),
+      (async () => ({
+        configOptions: [],
+      })),
     setSessionConfigOption:
       overrides.setSessionConfigOption ?? (async () => ({ configOptions: [] })),
   };


### PR DESCRIPTION
Fixes https://github.com/openclaw/acpx/issues/374.

## What changed
- Allows Claude ACP to forward model selectors missing from a stale advertised model list so Claude Code can accept or reject them.
- Keeps non-Claude adapters strict: unadvertised model selectors still fail before adapter contact.
- Preserves adapter-reported current model/config options after model switches, including running queue-owner control paths.
- Adds regression coverage for Claude stale advertisements, non-Claude rejection, adapter-reported current model, and queue-owner set-model response propagation.

## Live proof
Current-main repro on 0c9b420: `codex -s` equivalent persistent Claude flow failed on second prompt before adapter/provider contact with `Cannot apply --model "opus[1m]": the ACP agent did not advertise that model`.

Final candidate a44931f, built CLI, Node v22.22.3, isolated temp HOME/workspace, targeted Anthropic key shape only (`len=108`, `prefix=sk-ant`):

```text
sessions-new exit=0
set-model exit=0: model set: opus[1m]
first-prompt exit=1:
  [client] initialize (running)
  [client] session/new (running)
  [client] session/set_config_option (running)
  [error] RUNTIME: Internal error: Credit balance is too low
second-prompt exit=1:
  [error] RUNTIME: Internal error: Credit balance is too low
final_live_result:REACHED_LIVE_PROVIDER_NO_ACPX_PREFLIGHT_REJECTION
```

The provider account is credit-limited, but the final candidate no longer fails with the acpx advertised-model preflight rejection on the second persistent turn.

## Validation
- `fnm exec --using=22.22.3 pnpm run build:test && fnm exec --using=22.22.3 node --test --test-name-pattern 'QueueOwnerTurnController routes setSessionModel|Claude ACP model validation|non-Claude model validation|Claude ACP prompt|status preserves model|exec --model rejects models|prompt --model updates' dist-test/test/turn-controller.test.js dist-test/test/model-support.test.js dist-test/test/integration.test.js`
- `fnm exec --using=22.22.3 pnpm run check` (format, typecheck, lint, build, viewer typecheck/build, coverage, mutation score 91.07)
- autoreview clean: no accepted/actionable findings reported after owner-path fixes
