### PR TITLE
feat: add coder/mux built-in adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Repo: https://github.com/openclaw/acpx
 - Agents/built-ins: bump the default Claude ACP adapter range to `@agentclientprotocol/claude-agent-acp@^0.37.0`. Thanks @trumpyla.
 - Runtime/embedding: surface cost, token usage breakdowns, and advertised command metadata on runtime status/events. Thanks @DaniAkash.
 - Agents/built-ins: add `fast-agent` as a built-in fast-agent ACP adapter via `uvx fast-agent-mcp acp`.
-- Agents/built-ins: add `mux` as a built-in coder/mux ACP adapter via `npx -y mux acp`.
+- Agents/built-ins: add `mux` as a built-in coder/mux ACP adapter via `npx -y mux@^0.27.0 acp`. Thanks @ThomasK33.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Repo: https://github.com/openclaw/acpx
 - Agents/built-ins: bump the default Claude ACP adapter range to `@agentclientprotocol/claude-agent-acp@^0.37.0`. Thanks @trumpyla.
 - Runtime/embedding: surface cost, token usage breakdowns, and advertised command metadata on runtime status/events. Thanks @DaniAkash.
 - Agents/built-ins: add `fast-agent` as a built-in fast-agent ACP adapter via `uvx fast-agent-mcp acp`.
+- Agents/built-ins: add `mux` as a built-in coder/mux ACP adapter via `npx -y mux acp`.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Built-ins:
 | `kilocode`   | `npx -y @kilocode/cli acp`                                                  | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | native (`kimi acp`)                                                         | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | native (`kiro-cli-chat acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
+| `mux`        | `npx -y mux acp`                                                            | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                                                    | [OpenCode](https://opencode.ai)                                                                                 |
 | `qoder`      | native (`qodercli --acp`)                                                   | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | native (`qwen --acp`)                                                       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Built-ins:
 | `kilocode`   | `npx -y @kilocode/cli acp`                                                  | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | native (`kimi acp`)                                                         | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | native (`kiro-cli-chat acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
-| `mux`        | `npx -y mux acp`                                                            | [Mux](https://mux.coder.com)                                                                                    |
+| `mux`        | `npx -y mux@^0.27.0 acp`                                                    | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                                                    | [OpenCode](https://opencode.ai)                                                                                 |
 | `qoder`      | native (`qodercli --acp`)                                                   | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | native (`qwen --acp`)                                                       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |

--- a/agents/Mux.md
+++ b/agents/Mux.md
@@ -1,9 +1,9 @@
 # Mux
 
 - Built-in name: `mux`
-- Default command: `npx -y mux acp`
+- Default command: `npx -y mux@^0.27.0 acp`
 - Upstream: https://mux.coder.com/integrations/acp
 
 `acpx mux` starts coder/mux through its ACP stdio bridge (`mux acp`). `mux acp` auto-starts an in-process mux server, so a separate `mux server` is not required.
 
-Configure at least one model provider before prompting (for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`); see https://mux.coder.com/config/providers. To target a remote mux server, override the command with `mux acp --server-url <url> --auth-token <token>` (or set `MUX_SERVER_URL` / `MUX_SERVER_AUTH_TOKEN`).
+Configure at least one model provider before prompting (for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`); see https://mux.coder.com/config/providers. When using direct provider keys, make sure mux route priority includes `direct` before providers you have not authenticated. To target a remote mux server, override the command with `mux acp --server-url <url> --auth-token <token>` (or set `MUX_SERVER_URL` / `MUX_SERVER_AUTH_TOKEN`).

--- a/agents/Mux.md
+++ b/agents/Mux.md
@@ -1,0 +1,9 @@
+# Mux
+
+- Built-in name: `mux`
+- Default command: `npx -y mux acp`
+- Upstream: https://mux.coder.com/integrations/acp
+
+`acpx mux` starts coder/mux through its ACP stdio bridge (`mux acp`). `mux acp` auto-starts an in-process mux server, so a separate `mux server` is not required.
+
+Configure at least one model provider before prompting (for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`); see https://mux.coder.com/config/providers. To target a remote mux server, override the command with `mux acp --server-url <url> --auth-token <token>` (or set `MUX_SERVER_URL` / `MUX_SERVER_AUTH_TOKEN`).

--- a/agents/README.md
+++ b/agents/README.md
@@ -15,6 +15,7 @@ Built-in agents:
 - `kilocode -> npx -y @kilocode/cli acp`
 - `kimi -> kimi acp`
 - `kiro -> kiro-cli-chat acp`
+- `mux -> npx -y mux acp`
 - `opencode -> npx -y opencode-ai acp`
 - `qoder -> qodercli --acp`
 - `qwen -> qwen --acp`
@@ -33,6 +34,7 @@ Harness-specific docs in this directory:
 - [Kilocode](Kilocode.md): built-in `kilocode -> npx -y @kilocode/cli acp`
 - [Kimi](Kimi.md): built-in `kimi -> kimi acp`
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli-chat acp`
+- [Mux](Mux.md): built-in `mux -> npx -y mux acp`
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
 - [Qoder](Qoder.md): built-in `qoder -> qodercli --acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`

--- a/agents/README.md
+++ b/agents/README.md
@@ -15,7 +15,7 @@ Built-in agents:
 - `kilocode -> npx -y @kilocode/cli acp`
 - `kimi -> kimi acp`
 - `kiro -> kiro-cli-chat acp`
-- `mux -> npx -y mux acp`
+- `mux -> npx -y mux@^0.27.0 acp`
 - `opencode -> npx -y opencode-ai acp`
 - `qoder -> qodercli --acp`
 - `qwen -> qwen --acp`
@@ -34,7 +34,7 @@ Harness-specific docs in this directory:
 - [Kilocode](Kilocode.md): built-in `kilocode -> npx -y @kilocode/cli acp`
 - [Kimi](Kimi.md): built-in `kimi -> kimi acp`
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli-chat acp`
-- [Mux](Mux.md): built-in `mux -> npx -y mux acp`
+- [Mux](Mux.md): built-in `mux -> npx -y mux@^0.27.0 acp`
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
 - [Qoder](Qoder.md): built-in `qoder -> qodercli --acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,6 +24,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `kilocode`   | `npx -y @kilocode/cli acp`                     | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | `kimi acp`                                     | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | `kiro-cli-chat acp`                            | [Kiro CLI](https://kiro.dev)                                                                                    |
+| `mux`        | `npx -y mux acp`                               | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                       | [OpenCode](https://opencode.ai)                                                                                 |
 | `qoder`      | `qodercli --acp`                               | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | `qwen --acp`                                   | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
@@ -165,6 +166,16 @@ Configure model/provider settings through fast-agent environment variables, fast
 - Built-in name: `kiro`
 - Default command: `kiro-cli-chat acp`
 - Upstream: [kiro.dev](https://kiro.dev)
+
+### Mux
+
+- Built-in name: `mux`
+- Default command: `npx -y mux acp`
+- Upstream: https://mux.coder.com/integrations/acp
+
+`acpx mux` starts coder/mux through its ACP stdio bridge (`mux acp`). `mux acp` auto-starts an in-process mux server, so a separate `mux server` is not required.
+
+Configure at least one model provider before prompting (for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`); see https://mux.coder.com/config/providers. To target a remote mux server, override the command with `mux acp --server-url <url> --auth-token <token>` (or set `MUX_SERVER_URL` / `MUX_SERVER_AUTH_TOKEN`).
 
 ### OpenCode
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -24,7 +24,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `kilocode`   | `npx -y @kilocode/cli acp`                     | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | `kimi acp`                                     | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | `kiro-cli-chat acp`                            | [Kiro CLI](https://kiro.dev)                                                                                    |
-| `mux`        | `npx -y mux acp`                               | [Mux](https://mux.coder.com)                                                                                    |
+| `mux`        | `npx -y mux@^0.27.0 acp`                       | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                       | [OpenCode](https://opencode.ai)                                                                                 |
 | `qoder`      | `qodercli --acp`                               | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | `qwen --acp`                                   | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
@@ -170,12 +170,12 @@ Configure model/provider settings through fast-agent environment variables, fast
 ### Mux
 
 - Built-in name: `mux`
-- Default command: `npx -y mux acp`
+- Default command: `npx -y mux@^0.27.0 acp`
 - Upstream: https://mux.coder.com/integrations/acp
 
 `acpx mux` starts coder/mux through its ACP stdio bridge (`mux acp`). `mux acp` auto-starts an in-process mux server, so a separate `mux server` is not required.
 
-Configure at least one model provider before prompting (for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`); see https://mux.coder.com/config/providers. To target a remote mux server, override the command with `mux acp --server-url <url> --auth-token <token>` (or set `MUX_SERVER_URL` / `MUX_SERVER_AUTH_TOKEN`).
+Configure at least one model provider before prompting (for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`); see https://mux.coder.com/config/providers. When using direct provider keys, make sure mux route priority includes `direct` before providers you have not authenticated. To target a remote mux server, override the command with `mux acp --server-url <url> --auth-token <token>` (or set `MUX_SERVER_URL` / `MUX_SERVER_AUTH_TOKEN`).
 
 ### OpenCode
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ Some older Corepack builds bundled with supported Node.js versions have stale
 package-signing keys and fail while preparing current pnpm releases. Installing
 pnpm with npm avoids that bootstrap failure.
 
-`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`) are auto-fetched with `npx` on first use. The `fast-agent` built-in uses `uvx fast-agent-mcp acp`, so it requires `uvx` on `PATH`.
+`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`, `mux`) are auto-fetched with `npx` on first use. The `fast-agent` built-in uses `uvx fast-agent-mcp acp`, so it requires `uvx` on `PATH`.
 
 ## Global install (recommended)
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -92,7 +92,7 @@ Friendly agent names resolve to commands:
 - `kilocode` -> `npx -y @kilocode/cli acp`
 - `kimi` -> `kimi acp`
 - `kiro` -> `kiro-cli-chat acp`
-- `mux` -> `npx -y mux acp`
+- `mux` -> `npx -y mux@^0.27.0 acp`
 - `opencode` -> `npx -y opencode-ai acp`
 - `qoder` -> `qodercli --acp`
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -92,6 +92,7 @@ Friendly agent names resolve to commands:
 - `kilocode` -> `npx -y @kilocode/cli acp`
 - `kimi` -> `kimi acp`
 - `kiro` -> `kiro-cli-chat acp`
+- `mux` -> `npx -y mux acp`
 - `opencode` -> `npx -y opencode-ai acp`
 - `qoder` -> `qodercli --acp`
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -6,7 +6,7 @@ const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.26",
   codex: "^0.0.44",
   claude: "^0.37.0",
-  mux: "^0.26.0",
+  mux: "^0.27.0",
 } as const;
 
 type BuiltInAgentPackageSpec = {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -6,6 +6,7 @@ const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.26",
   codex: "^0.0.44",
   claude: "^0.37.0",
+  mux: "^0.26.0",
 } as const;
 
 type BuiltInAgentPackageSpec = {
@@ -49,6 +50,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   kilocode: "npx -y @kilocode/cli acp",
   kimi: "kimi acp",
   kiro: "kiro-cli-chat acp",
+  mux: `npx -y mux@${ACP_ADAPTER_PACKAGE_RANGES.mux} acp`,
   opencode: "npx -y opencode-ai acp",
   qoder: "qodercli --acp",
   qwen: "qwen --acp",

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -54,6 +54,11 @@ test("fast-agent built-in runs the ACP entrypoint through uvx", () => {
   assert.equal(resolveAgentCommand("fast-agent"), "uvx fast-agent-mcp acp");
 });
 
+test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
+  assert.equal(AGENT_REGISTRY.mux, "npx -y mux@^0.26.0 acp");
+  assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.26.0 acp");
+});
+
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {
   const agents = listBuiltInAgents();
   assert.deepEqual(agents, Object.keys(AGENT_REGISTRY));
@@ -73,6 +78,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
     "kilocode",
     "kimi",
     "kiro",
+    "mux",
     "opencode",
     "qoder",
     "qwen",

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -55,8 +55,8 @@ test("fast-agent built-in runs the ACP entrypoint through uvx", () => {
 });
 
 test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
-  assert.equal(AGENT_REGISTRY.mux, "npx -y mux@^0.26.0 acp");
-  assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.26.0 acp");
+  assert.equal(AGENT_REGISTRY.mux, "npx -y mux@^0.27.0 acp");
+  assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.27.0 acp");
 });
 
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {


### PR DESCRIPTION
Replaces contributor PR https://github.com/openclaw/acpx/pull/365 while preserving @ThomasK33's implementation and commit credit. Local writes to `coder/acpx:feat/mux-builtin-agent` were denied over both HTTPS and SSH despite `maintainerCanModify=true`, so this maintainer branch carries the same contributor commit plus a narrow maintainer fixup.

Changes:
- Add `mux` as a built-in adapter using `npx -y mux@^0.27.0 acp`.
- Document mux ACP setup and direct-provider routing.
- Add registry coverage and changelog credit for @ThomasK33.

Primary-source checks:
- `npm view mux@0.27.0` confirms the `mux` bin and published package metadata.
- `npx -y mux@0.27.0 acp --help` confirms the ACP stdio command and `--server-url` / `--auth-token` options.

Live proof:
- Built artifact command: `node dist/cli.js --verbose --cwd <real_git_workspace> --approve-all --timeout 420 --format text mux exec <prompt>`.
- Isolated HOME, realpathed temp Git repo on `main` with initial commit.
- 1Password-sourced Anthropic key shape only: prefix `sk-ant`, length 108.
- mux config route priority set to `direct` for direct Anthropic auth.
- acpx spawned `npx -y mux@^0.27.0 acp`, mux started its in-process server, and the final response was exactly `ACPX-MUX-365-OK` with exit 0.

Local validation:
- `fnm exec --using=22.22.3 pnpm run build:test`
- `fnm exec --using=22.22.3 node --test dist-test/test/agent-registry.test.js`
- `fnm exec --using=22.22.3 pnpm run test:coverage` after one transient full-check test failure
- `fnm exec --using=22.22.3 pnpm run mutate`
- `fnm exec --using=22.22.3 pnpm run check` passed on replay
- `$autoreview --mode local` clean
