### PR TITLE
fix(session-store): recover from corrupt session file in public FileSessionStore.load()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Repo: https://github.com/openclaw/acpx
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
 - CLI/Claude: let Claude Code adjudicate model selectors missing from a stale advertised model list on later persistent turns, and preserve the adapter-reported current model after model switches. Thanks @oakif.
 - Client/ACP: advertise scoped Devin/Windsurf-compatible client metadata and handle Devin extension requests/notifications without noisy method-not-found logs. Thanks @LivioGama.
+- Runtime/sessions: treat corrupt public file-session records as missing while preserving genuine filesystem errors. Thanks @KrasimirKralev.
 
 ## 2026.5.23 (v0.10.0)
 

--- a/src/runtime/public/file-session-store.ts
+++ b/src/runtime/public/file-session-store.ts
@@ -26,14 +26,24 @@ class FileSessionStore implements AcpSessionStore {
 
   async load(sessionId: string): Promise<AcpSessionRecord | undefined> {
     await this.ensureDir();
+    let payload: string;
     try {
-      const payload = await fs.readFile(this.filePath(sessionId), "utf8");
-      return parseSessionRecord(JSON.parse(payload)) ?? undefined;
+      payload = await fs.readFile(this.filePath(sessionId), "utf8");
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return undefined;
       }
       throw error;
+    }
+    // A present-but-corrupt session file is "no usable record" per the contract
+    // (load -> AcpSessionRecord | undefined). Treat unparseable/ill-shaped JSON as
+    // a recoverable miss, matching every internal reader (e.g.
+    // src/session/persistence/repository.ts), instead of throwing a raw SyntaxError
+    // out of the public store. Genuine I/O faults still surface from the read above.
+    try {
+      return parseSessionRecord(JSON.parse(payload)) ?? undefined;
+    } catch {
+      return undefined;
     }
   }
 

--- a/src/runtime/public/file-session-store.ts
+++ b/src/runtime/public/file-session-store.ts
@@ -35,16 +35,13 @@ class FileSessionStore implements AcpSessionStore {
       }
       throw error;
     }
-    // A present-but-corrupt session file is "no usable record" per the contract
-    // (load -> AcpSessionRecord | undefined). Treat unparseable/ill-shaped JSON as
-    // a recoverable miss, matching every internal reader (e.g.
-    // src/session/persistence/repository.ts), instead of throwing a raw SyntaxError
-    // out of the public store. Genuine I/O faults still surface from the read above.
+    let parsed: unknown;
     try {
-      return parseSessionRecord(JSON.parse(payload)) ?? undefined;
+      parsed = JSON.parse(payload);
     } catch {
       return undefined;
     }
+    return parseSessionRecord(parsed) ?? undefined;
   }
 
   async save(record: AcpSessionRecord): Promise<void> {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -234,6 +234,34 @@ test("createFileSessionStore persists records inside the provided state director
   );
 });
 
+test("createFileSessionStore.load() returns undefined for a corrupt session file (#378)", async (t) => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-runtime-store-corrupt-"));
+  t.after(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  const store = createFileSessionStore({ stateDir });
+  const sessionId = "agent:codex:acp:corrupt";
+  const record = createSessionRecord({ acpxRecordId: sessionId, acpSessionId: "sid-corrupt" });
+  await store.save(record);
+
+  const sessionFile = path.join(stateDir, "sessions", `${encodeURIComponent(sessionId)}.json`);
+
+  // Truncated JSON (e.g. a SIGKILL/power-loss mid-write before the atomic rename, or
+  // a half-flushed external write). Pre-fix, JSON.parse threw a SyntaxError straight
+  // out of the public load(); every internal reader already recovers from this.
+  await fs.writeFile(sessionFile, '{"schema":"acpx.session.v1","acpx', "utf8");
+  assert.equal(await store.load(sessionId), undefined);
+
+  // Structurally-valid JSON of the wrong shape is also "no usable record".
+  await fs.writeFile(sessionFile, '{"not":"a session record"}', "utf8");
+  assert.equal(await store.load(sessionId), undefined);
+
+  // A rewritten valid record still loads — recovery does not mask good data.
+  await store.save(record);
+  assert.equal((await store.load(sessionId))?.acpSessionId, "sid-corrupt");
+});
+
 test("doctor reports backend unavailable probe failures and agent registry honors overrides", async () => {
   const registry = createAgentRegistry({
     overrides: {


### PR DESCRIPTION
## Summary

- **Problem:** the public `AcpSessionStore` file store (`createFileSessionStore` → `FileSessionStore.load()`) catches only `ENOENT` and re-throws everything else, so a present-but-corrupt/truncated session JSON file surfaces a raw `SyntaxError` straight out of `load()`.
- **Why it matters:** every **internal** session reader in the same package (e.g. `src/session/persistence/repository.ts`, `src/session/persistence/index.ts`) already treats an unparseable session file as a recoverable miss and returns `undefined`/skips it. The public API was the lone outlier — an embedder adopting the shipped file store gets an unrecoverable crash exactly where the CLI itself silently recovers.
- **What changed:** split the read from the parse in `load()`. Genuine I/O faults (non-`ENOENT`) still throw; `ENOENT` **and** corrupt/ill-shaped content now return `undefined` — the contract's documented "no usable record" signal (`load(): Promise<AcpSessionRecord | undefined>`). One method, +14/−2.
- **What did NOT change (scope boundary):** `save()` is untouched (it already writes atomically via temp-file + rename); no contract/type change (`undefined` was always the documented miss signal); genuine filesystem errors (EACCES, EISDIR, …) still propagate — only corrupt *content* is treated as recoverable, matching the internal readers.

## Linked context

- Closes #378

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `FileSessionStore.load()` threw a raw `SyntaxError` on a corrupt session file instead of returning `undefined`.
- **Real environment tested:** Linux (Node v22.20.0), acpx built from source (`pnpm build && pnpm build:test`), run with `node --test` against the compiled `dist-test/`.
- **Exact steps or command run after this patch:** `node --test dist-test/test/runtime.test.js`
- **Evidence after fix:** a new regression test writes a real corrupt session file to disk and calls the public `load()`:

  ```
  $ node --test dist-test/test/runtime.test.js
  ok 2 - createFileSessionStore persists records inside the provided state directory
  ok 3 - createFileSessionStore.load() returns undefined for a corrupt session file (#378)
  # tests 9
  # pass 9
  # fail 0
  ```

  Negative control (proves the test guards the regression): reverting `load()` to the pre-fix throwing version makes the new test fail with exactly the reported error —

  ```
  not ok 1 - createFileSessionStore.load() returns undefined for a corrupt session file (#378)
    name: 'SyntaxError'
  ```

- **Observed result after fix:** with the fix, the corrupt-file (truncated JSON) and wrong-shape JSON cases both return `undefined`, a subsequently-rewritten valid record still loads, and the full `runtime.test.js` suite is 9/9. `pnpm typecheck` (tsgo) and `oxlint --type-aware` on the changed files are clean.
- **What was not tested:** real power-loss was not physically simulated — the test writes a deterministically truncated/ill-shaped file to the exact key→path the store derives, which reproduces the same `JSON.parse` failure mode. Repo-wide `format:check` was not run from this environment (line-ending drift on a Windows mount); the two changed files are LF and pass the committed pre-commit hook (oxfmt + oxlint).
- **Proof limitations or environment constraints:** none beyond the above.
