### PR TITLE
fix(claude): isolate ACP sessions from user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- CLI/Claude: isolate built-in Claude ACP sessions from user settings by default so globally enabled channel and daemon plugins cannot interfere with a spawned session. Set `ACPX_CLAUDE_INCLUDE_USER_SETTINGS=1` to restore user settings deliberately. Fixes #361.
 - ACP/models: support SDK 0.25 model config options while preserving `session/set_model` compatibility for adapters that explicitly advertise legacy model metadata.
 - CLI/Claude: let Claude Code adjudicate model selectors missing from a stale advertised model list on later persistent turns, and preserve the adapter-reported current model after model switches. Thanks @oakif.
 - Client/ACP: advertise scoped Devin/Windsurf-compatible client metadata and handle Devin extension requests/notifications without noisy method-not-found logs. Thanks @LivioGama.

--- a/agents/Claude.md
+++ b/agents/Claude.md
@@ -4,3 +4,13 @@
 - Default command: `npx -y @agentclientprotocol/claude-agent-acp`
 - Upstream: https://github.com/agentclientprotocol/claude-agent-acp
 - ACPX pins the built-in package range so fresh installs pick up Claude model and ACP adapter fixes without depending on a global adapter binary.
+
+## Settings isolation
+
+Built-in `acpx claude` sessions load Claude project and local settings, but not
+user settings. This prevents globally enabled channel and daemon plugins from
+claiming singleton external resources in an ACP-spawned session.
+
+Set `ACPX_CLAUDE_INCLUDE_USER_SETTINGS=1` only when the spawned session needs
+the user's global Claude settings and no such plugin conflict exists. Ambient
+credentials and other environment variables are still inherited normally.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -607,7 +607,10 @@ Per-tool policy:
 
 ## Environment variables
 
-No `acpx`-specific environment variables are currently defined.
+`ACPX_CLAUDE_INCLUDE_USER_SETTINGS=1` makes built-in `claude` sessions include
+Claude Code user settings. By default, they load only project and local settings
+to avoid globally enabled channel or daemon plugins interfering with spawned ACP
+sessions.
 
 Related runtime behavior:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -124,7 +124,12 @@ finds a matching `ACPX_AUTH_*` environment variable or `auth` config value.
 
 ## Environment variables
 
-`acpx` does not define new env vars beyond `ACPX_AUTH_*`. Other ACP-relevant behavior:
+`ACPX_CLAUDE_INCLUDE_USER_SETTINGS=1` makes built-in `claude` sessions include
+Claude Code user settings. By default, they load only project and local settings
+to avoid globally enabled channel or daemon plugins interfering with spawned ACP
+sessions.
+
+Other ACP-relevant behavior:
 
 - Session storage path is derived from the OS home directory (`~/.acpx/sessions`).
 - Child adapter processes inherit the current environment by default.

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -286,6 +286,16 @@ acpx --append-system-prompt "Always explain trade-offs before recommending a fix
 
 The override is forwarded via ACP `_meta.systemPrompt` (or `_meta.systemPrompt.append`) on `session/new` and stored in `session_options.system_prompt`. Subsequent `prompt`/`ensure` calls in the same scope keep the override unless you explicitly create a new session. Non-Claude adapters ignore the field, so the same flag is safe inside cross-agent scripts.
 
+## Claude settings isolation
+
+Built-in `acpx claude` sessions load Claude project and local settings, but not
+user settings. This prevents globally enabled channel and daemon plugins from
+claiming singleton external resources in an ACP-spawned session.
+
+Set `ACPX_CLAUDE_INCLUDE_USER_SETTINGS=1` only when the spawned session needs
+the user's global Claude settings and no such plugin conflict exists. Ambient
+credentials and other environment variables are still inherited normally.
+
 ## Sessions cleanup
 
 Closed session records accumulate on disk by default. Use `sessions prune` to enforce retention:

--- a/src/acp/agent-command.ts
+++ b/src/acp/agent-command.ts
@@ -16,6 +16,7 @@ const CLAUDE_ACP_SESSION_CREATE_TIMEOUT_MS = 60_000;
 const GEMINI_VERSION_TIMEOUT_MS = 2_000;
 const GEMINI_ACP_FLAG_VERSION = [0, 33, 0] as const;
 const COPILOT_HELP_TIMEOUT_MS = 2_000;
+const CLAUDE_CODE_DEFAULT_SETTING_SOURCES = ["project", "local"] as const;
 
 type GeminiVersion = {
   raw: string;
@@ -294,26 +295,35 @@ export async function ensureCopilotAcpSupport(command: string): Promise<void> {
 
 export function buildClaudeCodeOptionsMeta(
   options: AcpClientOptions["sessionOptions"],
+  isolateUserSettings = false,
 ): Record<string, unknown> | undefined {
-  if (!options) {
-    return undefined;
-  }
-
   const claudeCodeOptions: Record<string, unknown> = {};
-  assignClaudeCodeOptions(claudeCodeOptions, options);
+  if (isolateUserSettings) {
+    claudeCodeOptions.settingSources = resolveClaudeCodeSettingSources();
+  }
+  if (options) {
+    assignClaudeCodeOptions(claudeCodeOptions, options);
+  }
 
   const meta: Record<string, unknown> = {};
   if (Object.keys(claudeCodeOptions).length > 0) {
     meta.claudeCode = { options: claudeCodeOptions };
   }
 
-  assignClaudeCodeSystemPrompt(meta, options.systemPrompt);
+  assignClaudeCodeSystemPrompt(meta, options?.systemPrompt);
 
   if (Object.keys(meta).length === 0) {
     return undefined;
   }
 
   return meta;
+}
+
+export function resolveClaudeCodeSettingSources(env: NodeJS.ProcessEnv = process.env): string[] {
+  if (env.ACPX_CLAUDE_INCLUDE_USER_SETTINGS?.trim() === "1") {
+    return ["user", ...CLAUDE_CODE_DEFAULT_SETTING_SOURCES];
+  }
+  return [...CLAUDE_CODE_DEFAULT_SETTING_SOURCES];
 }
 
 function assignClaudeCodeOptions(
@@ -333,7 +343,7 @@ function assignClaudeCodeOptions(
 
 function assignClaudeCodeSystemPrompt(
   target: Record<string, unknown>,
-  systemPrompt: NonNullable<AcpClientOptions["sessionOptions"]>["systemPrompt"],
+  systemPrompt: NonNullable<AcpClientOptions["sessionOptions"]>["systemPrompt"] | undefined,
 ): void {
   if (typeof systemPrompt === "string" && systemPrompt.length > 0) {
     target.systemPrompt = systemPrompt;

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -78,6 +78,7 @@ import {
   resolveAgentCloseAfterStdinEndMs,
   resolveClaudeAcpSessionCreateTimeoutMs,
   resolveClaudeCodeExecutable,
+  resolveClaudeCodeSettingSources,
   resolveGeminiAcpStartupTimeoutMs,
   resolveGeminiCommandArgs,
   shouldIgnoreNonJsonAgentOutputLine,
@@ -116,6 +117,7 @@ export {
   buildAgentSpawnOptions,
   buildQoderAcpCommandArgs,
   resolveAgentCloseAfterStdinEndMs,
+  resolveClaudeCodeSettingSources,
   shouldIgnoreNonJsonAgentOutputLine,
 };
 
@@ -902,7 +904,7 @@ export class AcpClient {
         connection.newSession({
           cwd: sessionCwd,
           mcpServers: this.options.mcpServers ?? [],
-          _meta: buildClaudeCodeOptionsMeta(this.options.sessionOptions),
+          _meta: buildClaudeCodeOptionsMeta(this.options.sessionOptions, claudeAcp),
         }),
       );
       result = claudeAcp

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -7,6 +7,7 @@ import {
   AcpClient,
   buildAgentSpawnOptions,
   buildQoderAcpCommandArgs,
+  resolveClaudeCodeSettingSources,
   resolveAgentCloseAfterStdinEndMs,
   shouldIgnoreNonJsonAgentOutputLine,
 } from "../src/acp/client.js";
@@ -685,6 +686,47 @@ test("AcpClient createSession forwards claudeCode options in _meta", async () =>
       },
     },
   });
+});
+
+test("AcpClient creates built-in Claude sessions without user settings by default", async () => {
+  const cwd = path.resolve("/tmp/acpx-client-claude-settings");
+  const client = makeClient({
+    agentCommand: "npx -y @agentclientprotocol/claude-agent-acp",
+  });
+
+  let capturedParams: Record<string, unknown> | undefined;
+  asInternals(client).connection = {
+    newSession: async (params: Record<string, unknown>) => {
+      capturedParams = params;
+      return { sessionId: "session-claude-settings" };
+    },
+  };
+
+  await client.createSession("/tmp/acpx-client-claude-settings");
+  assert.deepEqual(capturedParams, {
+    cwd,
+    mcpServers: [],
+    _meta: {
+      claudeCode: {
+        options: {
+          settingSources: ["project", "local"],
+        },
+      },
+    },
+  });
+});
+
+test("resolveClaudeCodeSettingSources includes user settings only when explicitly enabled", () => {
+  assert.deepEqual(resolveClaudeCodeSettingSources({}), ["project", "local"]);
+  assert.deepEqual(resolveClaudeCodeSettingSources({ ACPX_CLAUDE_INCLUDE_USER_SETTINGS: "1" }), [
+    "user",
+    "project",
+    "local",
+  ]);
+  assert.deepEqual(resolveClaudeCodeSettingSources({ ACPX_CLAUDE_INCLUDE_USER_SETTINGS: "true" }), [
+    "project",
+    "local",
+  ]);
 });
 
 test("AcpClient createSession forwards systemPrompt string in _meta", async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1025,6 +1025,7 @@ test("integration: exec forwards model, allowed-tools, and max-turns in session/
             model: "sonnet",
             allowedTools: ["Read", "Grep"],
             maxTurns: 7,
+            settingSources: ["project", "local"],
           },
         },
       });


### PR DESCRIPTION
## Summary

- creates built-in Claude ACP sessions with `settingSources: ["project", "local"]`
- adds `ACPX_CLAUDE_INCLUDE_USER_SETTINGS=1` as an explicit opt-in for user settings
- documents the behavior in the Claude agent guide, CLI/config docs, and agent skill

## Root cause

The Claude ACP adapter loads user settings by default. A globally enabled Telegram plugin can then start inside an `acpx`-spawned session and contend with an existing bot poller.

## Validation

- `PATH=<Node 24 bin>:$PATH pnpm run check`
- `pnpm run check:docs`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Fixes #361.