### PR TITLE
feat(session): add per-agent env to SessionAgentOptions and child spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Runtime/embedding: preserve per-agent environment variables across ACP session
+  creation, queue handoff, persistence, and reconnects. Thanks @zhangguiping-xydt.
+
 ### Breaking
 
 ### Fixes

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -43,6 +43,14 @@ function protectedEnvKey(key: string): string {
   return process.platform === "win32" ? key.toUpperCase() : key;
 }
 
+function isAuthEnvKey(key: string): boolean {
+  return protectedEnvKey(key).startsWith(AUTH_ENV_PREFIX);
+}
+
+function authEnvSuffix(key: string): string {
+  return key.slice(AUTH_ENV_PREFIX.length);
+}
+
 function protectEnvKey(protectedKeys: Set<string>, key: string): void {
   protectedKeys.add(protectedEnvKey(key));
 }
@@ -50,14 +58,14 @@ function protectEnvKey(protectedKeys: Set<string>, key: string): void {
 function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): Set<string> {
   const protectedKeys = new Set<string>();
   for (const [key, value] of Object.entries(env)) {
-    if (!key.startsWith(AUTH_ENV_PREFIX)) {
+    if (!isAuthEnvKey(key)) {
       continue;
     }
     if (typeof value !== "string" || value.trim().length === 0) {
       continue;
     }
 
-    const normalized = key.slice(AUTH_ENV_PREFIX.length);
+    const normalized = toEnvToken(authEnvSuffix(key));
     if (!normalized) {
       continue;
     }

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -59,15 +59,22 @@ function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): void {
 
 function buildAgentEnvironment(
   authCredentials: Record<string, string> | undefined,
+  sessionEnv: Record<string, string> | undefined,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   promotePrefixedAuthEnvironment(env);
-  if (!authCredentials) {
-    return env;
+  if (authCredentials) {
+    for (const [methodId, credential] of Object.entries(authCredentials)) {
+      assignAuthCredentialEnv(env, methodId, credential);
+    }
   }
 
-  for (const [methodId, credential] of Object.entries(authCredentials)) {
-    assignAuthCredentialEnv(env, methodId, credential);
+  if (sessionEnv) {
+    for (const [key, value] of Object.entries(sessionEnv)) {
+      if (typeof value === "string") {
+        env[key] = value;
+      }
+    }
   }
 
   return env;
@@ -110,6 +117,7 @@ export function resolveConfiguredAuthCredential(
 export function buildAgentSpawnOptions(
   cwd: string,
   authCredentials: Record<string, string> | undefined,
+  sessionEnv?: Record<string, string>,
 ): {
   cwd: string;
   env: NodeJS.ProcessEnv;
@@ -118,7 +126,7 @@ export function buildAgentSpawnOptions(
 } {
   return {
     cwd,
-    env: buildAgentEnvironment(authCredentials),
+    env: buildAgentEnvironment(authCredentials, sessionEnv),
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   };

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -39,6 +39,14 @@ export function readEnvCredential(methodId: string): string | undefined {
   return undefined;
 }
 
+function protectedEnvKey(key: string): string {
+  return process.platform === "win32" ? key.toUpperCase() : key;
+}
+
+function protectEnvKey(protectedKeys: Set<string>, key: string): void {
+  protectedKeys.add(protectedEnvKey(key));
+}
+
 function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): Set<string> {
   const protectedKeys = new Set<string>();
   for (const [key, value] of Object.entries(env)) {
@@ -54,8 +62,8 @@ function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): Set<string> {
       continue;
     }
 
-    protectedKeys.add(key);
-    protectedKeys.add(normalized);
+    protectEnvKey(protectedKeys, key);
+    protectEnvKey(protectedKeys, normalized);
     if (env[normalized] == null) {
       env[normalized] = value;
     }
@@ -78,7 +86,7 @@ function buildAgentEnvironment(
 
   if (sessionEnv) {
     for (const [key, value] of Object.entries(sessionEnv)) {
-      if (typeof value === "string" && !protectedAuthEnvKeys.has(key)) {
+      if (typeof value === "string" && !protectedAuthEnvKeys.has(protectedEnvKey(key))) {
         env[key] = value;
       }
     }
@@ -97,13 +105,13 @@ function addAuthCredentialEnvKeys(
   }
 
   if (!methodId.includes("=") && !methodId.includes("\u0000")) {
-    protectedKeys.add(methodId);
+    protectEnvKey(protectedKeys, methodId);
   }
 
   const normalized = toEnvToken(methodId);
   if (normalized) {
-    protectedKeys.add(`${AUTH_ENV_PREFIX}${normalized}`);
-    protectedKeys.add(normalized);
+    protectEnvKey(protectedKeys, `${AUTH_ENV_PREFIX}${normalized}`);
+    protectEnvKey(protectedKeys, normalized);
   }
 }
 

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -94,13 +94,24 @@ function buildAgentEnvironment(
 
   if (sessionEnv) {
     for (const [key, value] of Object.entries(sessionEnv)) {
-      if (typeof value === "string" && !protectedAuthEnvKeys.has(protectedEnvKey(key))) {
-        env[key] = value;
+      if (typeof value !== "string" || protectedAuthEnvKeys.has(protectedEnvKey(key))) {
+        continue;
       }
+      assignSessionEnv(env, key, value);
     }
   }
 
   return env;
+}
+
+function assignSessionEnv(env: NodeJS.ProcessEnv, key: string, value: string): void {
+  const normalizedKey = protectedEnvKey(key);
+  for (const existingKey of Object.keys(env)) {
+    if (protectedEnvKey(existingKey) === normalizedKey) {
+      delete env[existingKey];
+    }
+  }
+  env[key] = value;
 }
 
 function addAuthCredentialEnvKeys(

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -39,7 +39,8 @@ export function readEnvCredential(methodId: string): string | undefined {
   return undefined;
 }
 
-function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): void {
+function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): Set<string> {
+  const protectedKeys = new Set<string>();
   for (const [key, value] of Object.entries(env)) {
     if (!key.startsWith(AUTH_ENV_PREFIX)) {
       continue;
@@ -49,12 +50,17 @@ function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): void {
     }
 
     const normalized = key.slice(AUTH_ENV_PREFIX.length);
-    if (!normalized || env[normalized] != null) {
+    if (!normalized) {
       continue;
     }
 
-    env[normalized] = value;
+    protectedKeys.add(key);
+    protectedKeys.add(normalized);
+    if (env[normalized] == null) {
+      env[normalized] = value;
+    }
   }
+  return protectedKeys;
 }
 
 function buildAgentEnvironment(
@@ -62,22 +68,43 @@ function buildAgentEnvironment(
   sessionEnv: Record<string, string> | undefined,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
-  promotePrefixedAuthEnvironment(env);
+  const protectedAuthEnvKeys = promotePrefixedAuthEnvironment(env);
   if (authCredentials) {
     for (const [methodId, credential] of Object.entries(authCredentials)) {
+      addAuthCredentialEnvKeys(protectedAuthEnvKeys, methodId, credential);
       assignAuthCredentialEnv(env, methodId, credential);
     }
   }
 
   if (sessionEnv) {
     for (const [key, value] of Object.entries(sessionEnv)) {
-      if (typeof value === "string") {
+      if (typeof value === "string" && !protectedAuthEnvKeys.has(key)) {
         env[key] = value;
       }
     }
   }
 
   return env;
+}
+
+function addAuthCredentialEnvKeys(
+  protectedKeys: Set<string>,
+  methodId: string,
+  credential: string,
+): void {
+  if (typeof credential !== "string" || credential.trim().length === 0) {
+    return;
+  }
+
+  if (!methodId.includes("=") && !methodId.includes("\u0000")) {
+    protectedKeys.add(methodId);
+  }
+
+  const normalized = toEnvToken(methodId);
+  if (normalized) {
+    protectedKeys.add(`${AUTH_ENV_PREFIX}${normalized}`);
+    protectedKeys.add(normalized);
+  }
 }
 
 function assignAuthCredentialEnv(

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -659,7 +659,11 @@ export class AcpClient {
       geminiAcp: isGeminiAcpCommand(spawnCommand, args),
       copilotAcp: isCopilotAcpCommand(spawnCommand, args),
       claudeAcp: isClaudeAcpCommand(spawnCommand, args),
-      spawnOptions: buildAgentSpawnOptions(this.options.cwd, this.options.authCredentials),
+      spawnOptions: buildAgentSpawnOptions(
+        this.options.cwd,
+        this.options.authCredentials,
+        this.options.sessionOptions?.env,
+      ),
     };
   }
 

--- a/src/cli/queue/messages.ts
+++ b/src/cli/queue/messages.ts
@@ -282,6 +282,9 @@ function parseSessionOptions(value: unknown): QueueSessionOptions | null | undef
   if (!assignSessionSystemPrompt(sessionOptions, record.systemPrompt)) {
     return null;
   }
+  if (!assignSessionEnv(sessionOptions, record.env)) {
+    return null;
+  }
 
   return sessionOptions;
 }
@@ -332,6 +335,22 @@ function assignSessionSystemPrompt(options: QueueSessionOptions, value: unknown)
     return false;
   }
   options.systemPrompt = { append: systemPrompt.append };
+  return true;
+}
+
+function assignSessionEnv(options: QueueSessionOptions, value: unknown): boolean {
+  if (value == null) {
+    return true;
+  }
+  const env = asRecord(value);
+  if (!env) {
+    return false;
+  }
+  const entries = Object.entries(env);
+  if (entries.some(([, entryValue]) => typeof entryValue !== "string")) {
+    return false;
+  }
+  options.env = Object.fromEntries(entries) as Record<string, string>;
   return true;
 }
 

--- a/src/cli/queue/owner-env.ts
+++ b/src/cli/queue/owner-env.ts
@@ -123,6 +123,7 @@ function assignQueueOwnerSessionOptions(
   assignSessionAllowedTools(options.sessionOptions, sessionOpts.allowedTools);
   assignSessionMaxTurns(options.sessionOptions, sessionOpts.maxTurns);
   assignSessionSystemPrompt(options.sessionOptions, sessionOpts.systemPrompt);
+  assignSessionEnv(options.sessionOptions, sessionOpts.env);
 }
 
 function assignSessionModel(
@@ -164,6 +165,22 @@ function assignSessionSystemPrompt(
   const systemPrompt = asRecord(value);
   if (typeof systemPrompt?.append === "string") {
     options.systemPrompt = { append: systemPrompt.append };
+  }
+}
+
+function assignSessionEnv(
+  options: NonNullable<QueueOwnerRuntimeOptions["sessionOptions"]>,
+  value: unknown,
+): void {
+  const env = asRecord(value);
+  if (!env) {
+    return;
+  }
+  const entries = Object.entries(env).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  if (entries.length > 0) {
+    options.env = Object.fromEntries(entries);
   }
 }
 

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -65,7 +65,11 @@ import {
 import { runPromptTurn } from "./prompt-turn.js";
 import { connectAndLoadSession, type ConnectAndLoadSessionResult } from "./reconnect.js";
 import { shouldReuseExistingRecord } from "./reuse-policy.js";
-import { persistSessionOptions, type SessionAgentOptions } from "./session-options.js";
+import {
+  persistSessionOptions,
+  sessionOptionsFromRecord,
+  type SessionAgentOptions,
+} from "./session-options.js";
 
 export type AcpRuntimeManagerDeps = {
   clientFactory?: (options: ConstructorParameters<typeof AcpClient>[0]) => AcpClient;
@@ -964,6 +968,7 @@ export class AcpRuntimeManager {
       nonInteractivePermissions: this.options.nonInteractivePermissions,
       onPermissionRequest: this.options.onPermissionRequest,
       verbose: this.options.verbose,
+      sessionOptions: sessionOptionsFromRecord(record),
     });
   }
 

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -10,9 +10,9 @@ export type SessionAgentOptions = {
   /**
    * Per-agent environment variables injected into the spawned agent child
    * process. Keys here override the parent process environment for the
-   * spawned child, so configured agents can shadow user-level values (for
-   * example `GIT_AUTHOR_EMAIL`). Callers are responsible for sanitizing
-   * dangerous keys (such as `PATH`) before passing them to acpx.
+   * spawned child, except acpx-managed auth credential keys. Callers are
+   * responsible for sanitizing dangerous keys (such as `PATH`) before
+   * passing them to acpx.
    */
   env?: Record<string, string>;
 };

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -11,8 +11,8 @@ export type SessionAgentOptions = {
    * Per-agent environment variables injected into the spawned agent child
    * process. Keys here override the parent process environment for the
    * spawned child, except acpx-managed auth credential keys. Callers are
-   * responsible for sanitizing dangerous keys (such as `PATH`) before
-   * passing them to acpx.
+   * responsible for sanitizing dangerous keys such as `PATH`, `LD_PRELOAD`,
+   * and `NODE_OPTIONS` before passing them to acpx.
    */
   env?: Record<string, string>;
 };

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -7,6 +7,14 @@ export type SessionAgentOptions = {
   allowedTools?: string[];
   maxTurns?: number;
   systemPrompt?: SystemPromptOption;
+  /**
+   * Per-agent environment variables injected into the spawned agent child
+   * process. Keys here override the parent process environment for the
+   * spawned child, so configured agents can shadow user-level values (for
+   * example `GIT_AUTHOR_EMAIL`). Callers are responsible for sanitizing
+   * dangerous keys (such as `PATH`) before passing them to acpx.
+   */
+  env?: Record<string, string>;
 };
 
 export function mergeSessionOptions(
@@ -18,7 +26,18 @@ export function mergeSessionOptions(
   assignDefinedOption(merged, "allowedTools", preferred?.allowedTools);
   assignDefinedOption(merged, "maxTurns", preferred?.maxTurns);
   assignDefinedOption(merged, "systemPrompt", preferred?.systemPrompt);
+  assignDefinedOption(merged, "env", mergeEnvRecords(fallback?.env, preferred?.env));
   return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function mergeEnvRecords(
+  fallback: Record<string, string> | undefined,
+  preferred: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!fallback && !preferred) {
+    return undefined;
+  }
+  return { ...fallback, ...preferred };
 }
 
 function assignDefinedOption<Key extends keyof SessionAgentOptions>(
@@ -66,6 +85,7 @@ export function sessionOptionsFromRecord(record: SessionRecord): SessionAgentOpt
     "systemPrompt",
     storedSystemPromptOption(stored.system_prompt),
   );
+  assignStoredOption(sessionOptions, "env", storedEnvRecord(stored.env));
 
   return Object.keys(sessionOptions).length > 0 ? sessionOptions : undefined;
 }
@@ -80,6 +100,7 @@ function persistedSessionOptions(
     allowed_tools: Array.isArray(options.allowedTools) ? [...options.allowedTools] : undefined,
     max_turns: typeof options.maxTurns === "number" ? options.maxTurns : undefined,
     system_prompt: normalizeSystemPromptOption(options.systemPrompt),
+    env: storedEnvRecord(options.env),
   } satisfies PersistedSessionOptions;
   return hasPersistedSessionOptions(next) ? next : undefined;
 }
@@ -89,8 +110,24 @@ function hasPersistedSessionOptions(options: PersistedSessionOptions): boolean {
     options.model !== undefined ||
     options.allowed_tools !== undefined ||
     options.max_turns !== undefined ||
-    options.system_prompt !== undefined
+    options.system_prompt !== undefined ||
+    options.env !== undefined
   );
+}
+
+function storedEnvRecord(value: unknown): Record<string, string> | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  const result: Record<string, string> = {};
+  for (const [key, raw] of entries) {
+    if (typeof raw !== "string") {
+      continue;
+    }
+    result[key] = raw;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function normalizeSystemPromptOption(value: unknown): SystemPromptOption | undefined {

--- a/src/runtime/engine/session-options.ts
+++ b/src/runtime/engine/session-options.ts
@@ -9,10 +9,12 @@ export type SessionAgentOptions = {
   systemPrompt?: SystemPromptOption;
   /**
    * Per-agent environment variables injected into the spawned agent child
-   * process. Keys here override the parent process environment for the
-   * spawned child, except acpx-managed auth credential keys. Callers are
-   * responsible for sanitizing dangerous keys such as `PATH`, `LD_PRELOAD`,
-   * and `NODE_OPTIONS` before passing them to acpx.
+   * process and persisted with the session record for reconnects. Keys here
+   * override the parent process environment for the spawned child, except
+   * acpx-managed auth credential keys. Do not put secrets here; use
+   * authCredentials for credentials. Callers are responsible for sanitizing
+   * dangerous keys such as `PATH`, `LD_PRELOAD`, and `NODE_OPTIONS` before
+   * passing them to acpx.
    */
   env?: Record<string, string>;
 };

--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -584,7 +584,7 @@ function cloneSessionOptions(
     ...(options.system_prompt !== undefined
       ? { system_prompt: cloneSystemPromptOption(options.system_prompt) }
       : {}),
-    env: options.env ? { ...options.env } : undefined,
+    ...(options.env !== undefined ? { env: { ...options.env } } : {}),
   };
 }
 

--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -584,6 +584,7 @@ function cloneSessionOptions(
     ...(options.system_prompt !== undefined
       ? { system_prompt: cloneSystemPromptOption(options.system_prompt) }
       : {}),
+    env: options.env ? { ...options.env } : undefined,
   };
 }
 

--- a/src/session/mode-preference.ts
+++ b/src/session/mode-preference.ts
@@ -104,6 +104,18 @@ export function getDesiredModelId(state: SessionAcpxState | undefined): string |
   return normalizeModelId(state?.session_options?.model);
 }
 
+function hasStoredSessionOptions(
+  options: NonNullable<SessionAcpxState["session_options"]>,
+): boolean {
+  return (
+    typeof options.model === "string" ||
+    Array.isArray(options.allowed_tools) ||
+    typeof options.max_turns === "number" ||
+    options.system_prompt !== undefined ||
+    options.env !== undefined
+  );
+}
+
 export function setDesiredModelId(
   record: SessionRecord,
   modelId: string | undefined,
@@ -119,12 +131,7 @@ export function setDesiredModelId(
     delete sessionOptions.model;
   }
 
-  if (
-    typeof sessionOptions.model === "string" ||
-    Array.isArray(sessionOptions.allowed_tools) ||
-    typeof sessionOptions.max_turns === "number" ||
-    sessionOptions.system_prompt !== undefined
-  ) {
+  if (hasStoredSessionOptions(sessionOptions)) {
     acpx.session_options = sessionOptions;
   } else {
     delete acpx.session_options;

--- a/src/session/persistence/parse.ts
+++ b/src/session/persistence/parse.ts
@@ -499,6 +499,7 @@ function assignParsedSessionOptions(state: SessionAcpxState, raw: unknown): void
   assignSessionOptionAllowedTools(parsedSessionOptions, sessionOptions.allowed_tools);
   assignSessionOptionMaxTurns(parsedSessionOptions, sessionOptions.max_turns);
   assignSessionOptionSystemPrompt(parsedSessionOptions, sessionOptions.system_prompt);
+  assignSessionOptionEnv(parsedSessionOptions, sessionOptions.env);
 
   if (Object.keys(parsedSessionOptions).length > 0) {
     state.session_options = parsedSessionOptions;
@@ -544,6 +545,26 @@ function assignSessionOptionSystemPrompt(
   const appendRecord = asRecord(value);
   if (appendRecord && typeof appendRecord.append === "string" && appendRecord.append.length > 0) {
     options.system_prompt = { append: appendRecord.append };
+  }
+}
+
+function assignSessionOptionEnv(
+  options: NonNullable<SessionAcpxState["session_options"]>,
+  value: unknown,
+): void {
+  const env = asRecord(value);
+  if (!env) {
+    return;
+  }
+
+  const parsed = Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => {
+      const [, raw] = entry;
+      return typeof raw === "string";
+    }),
+  );
+  if (Object.keys(parsed).length > 0) {
+    options.env = parsed;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,7 @@ export type AcpClientOptions = {
     allowedTools?: string[];
     maxTurns?: number;
     systemPrompt?: string | { append: string };
+    env?: Record<string, string>;
   };
   onAcpMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
   onAcpOutputMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
@@ -366,6 +367,7 @@ export type SessionAcpxState = {
     allowed_tools?: string[];
     max_turns?: number;
     system_prompt?: string | { append: string };
+    env?: Record<string, string>;
   };
 };
 

--- a/test/queue-messages.test.ts
+++ b/test/queue-messages.test.ts
@@ -66,6 +66,9 @@ test("parseQueueRequest accepts prompt session options", () => {
       allowedTools: ["Read", "Grep"],
       maxTurns: 4,
       systemPrompt: { append: "keep it brief" },
+      env: {
+        GIT_AUTHOR_EMAIL: "agent@example.local",
+      },
     },
     waitForCompletion: true,
   });
@@ -85,6 +88,9 @@ test("parseQueueRequest accepts prompt session options", () => {
       allowedTools: ["Read", "Grep"],
       maxTurns: 4,
       systemPrompt: { append: "keep it brief" },
+      env: {
+        GIT_AUTHOR_EMAIL: "agent@example.local",
+      },
     },
   });
 });

--- a/test/queue-owner-env.test.ts
+++ b/test/queue-owner-env.test.ts
@@ -29,6 +29,9 @@ describe("parseQueueOwnerPayload", () => {
           allowedTools: ["Read"],
           maxTurns: 3,
           systemPrompt: "stay concise",
+          env: {
+            GIT_AUTHOR_EMAIL: "agent@example.local",
+          },
         },
       }),
     );
@@ -59,6 +62,9 @@ describe("parseQueueOwnerPayload", () => {
       allowedTools: ["Read"],
       maxTurns: 3,
       systemPrompt: "stay concise",
+      env: {
+        GIT_AUTHOR_EMAIL: "agent@example.local",
+      },
     });
   });
 

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -4,7 +4,11 @@ import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import type { SessionModelState } from "../src/acp/model-support.js";
 import { AcpxOperationalError } from "../src/errors.js";
 import { AcpRuntimeManager } from "../src/runtime/engine/manager.js";
-import { persistSessionOptions } from "../src/runtime/engine/session-options.js";
+import {
+  mergeSessionOptions,
+  persistSessionOptions,
+  sessionOptionsFromRecord,
+} from "../src/runtime/engine/session-options.js";
 import type {
   AcpRuntimeEvent,
   AcpRuntimeHandle,
@@ -2793,6 +2797,7 @@ test("AcpRuntimeManager forwards sessionOptions to createClient on fresh session
     allowed_tools: undefined,
     max_turns: undefined,
     system_prompt: "Be terse.",
+    env: undefined,
   });
 });
 
@@ -2864,6 +2869,7 @@ test("AcpRuntimeManager persists sessionOptions { append } and model/allowedTool
     allowed_tools: ["read", "edit"],
     max_turns: 5,
     system_prompt: { append: "Also review tests." },
+    env: undefined,
   });
 });
 
@@ -2882,6 +2888,76 @@ test("persistSessionOptions preserves an explicit empty allowedTools list", () =
     allowed_tools: [],
     max_turns: undefined,
     system_prompt: undefined,
+    env: undefined,
+  });
+});
+
+test("persistSessionOptions preserves session env as a serialized record", () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "env-session",
+    acpSessionId: "env-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+
+  persistSessionOptions(record, {
+    env: {
+      GIT_AUTHOR_EMAIL: "agent-pm@example.local",
+      GIT_COMMITTER_NAME: "Agent PM",
+    },
+  });
+
+  assert.deepEqual(record.acpx?.session_options, {
+    model: undefined,
+    allowed_tools: undefined,
+    max_turns: undefined,
+    system_prompt: undefined,
+    env: {
+      GIT_AUTHOR_EMAIL: "agent-pm@example.local",
+      GIT_COMMITTER_NAME: "Agent PM",
+    },
+  });
+});
+
+test("sessionOptionsFromRecord restores session env from a persisted record", () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "env-restore-session",
+    acpSessionId: "env-restore-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+    acpx: {
+      session_options: {
+        env: {
+          GIT_AUTHOR_EMAIL: "restored-pm@example.local",
+        },
+      },
+    },
+  });
+
+  const restored = sessionOptionsFromRecord(record);
+  assert.deepEqual(restored?.env, { GIT_AUTHOR_EMAIL: "restored-pm@example.local" });
+});
+
+test("mergeSessionOptions merges session env per key with preferred overriding fallback", () => {
+  const merged = mergeSessionOptions(
+    {
+      env: {
+        GIT_AUTHOR_EMAIL: "preferred@example.local",
+        PREFERRED_ONLY: "preferred",
+      },
+    },
+    {
+      env: {
+        GIT_AUTHOR_EMAIL: "fallback@example.local",
+        FALLBACK_ONLY: "fallback",
+      },
+    },
+  );
+
+  assert.deepEqual(merged?.env, {
+    GIT_AUTHOR_EMAIL: "preferred@example.local",
+    PREFERRED_ONLY: "preferred",
+    FALLBACK_ONLY: "fallback",
   });
 });
 

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -395,6 +395,71 @@ test("AcpRuntimeManager streams runtime events and saves updated status", async 
   assert.equal(saved?.protocolVersion, 1);
 });
 
+test("AcpRuntimeManager restores persisted session env when reconnecting startTurn", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "turn-env-session",
+    acpSessionId: "turn-env-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+    acpx: {
+      session_options: {
+        env: {
+          GIT_AUTHOR_EMAIL: "turn-env@example.local",
+        },
+      },
+    },
+  });
+  const store = new InMemorySessionStore([record]);
+  const factoryCalls: unknown[] = [];
+  const client: FakeClient = {
+    initializeResult: { protocolVersion: 1, agentCapabilities: { prompt: true } },
+    start: async () => {},
+    close: async () => {},
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: () => false,
+    supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
+    loadSessionWithOptions: async () => ({ agentSessionId: "turn-env-agent" }),
+    getAgentLifecycleSnapshot: () => ({ running: true }),
+    prompt: async (sessionId) => {
+      assert.equal(sessionId, "turn-env-sid");
+      return { stopReason: "end_turn" };
+    },
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {},
+    setEventHandlers: () => {},
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: (options) => {
+        factoryCalls.push(options);
+        return client as never;
+      },
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("turn-env-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-env",
+  });
+  const { result } = await collectTurn(turn);
+
+  assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
+  assert.deepEqual((factoryCalls[0] as { sessionOptions?: unknown }).sessionOptions, {
+    env: {
+      GIT_AUTHOR_EMAIL: "turn-env@example.local",
+    },
+  });
+});
+
 test("AcpRuntimeManager keeps reusable persistent clients pooled across turns and closes them on runtime close", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "pooled-persistent-session",

--- a/test/session-mode-preference.test.ts
+++ b/test/session-mode-preference.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeModeId,
   setDesiredConfigOption,
   setDesiredModeId,
+  setDesiredModelId,
 } from "../src/session/mode-preference.js";
 import type { SessionRecord } from "../src/types.js";
 
@@ -55,6 +56,28 @@ test("setDesiredConfigOption persists non-mode config option preferences", () =>
 
   setDesiredConfigOption(record, "reasoning_effort", undefined);
   assert.deepEqual(record.acpx, {});
+});
+
+test("setDesiredModelId preserves session env when clearing model", () => {
+  const record = makeSessionRecord();
+  record.acpx = {
+    session_options: {
+      model: "claude-sonnet-4-6",
+      env: {
+        GIT_AUTHOR_EMAIL: "agent@example.local",
+      },
+    },
+  };
+
+  setDesiredModelId(record, undefined);
+
+  assert.deepEqual(record.acpx, {
+    session_options: {
+      env: {
+        GIT_AUTHOR_EMAIL: "agent@example.local",
+      },
+    },
+  });
 });
 
 function makeSessionRecord(): SessionRecord {

--- a/test/session-persistence.test.ts
+++ b/test/session-persistence.test.ts
@@ -29,6 +29,34 @@ test("SessionRecord allows optional closed and closedAt fields", () => {
   assert.equal(record.closedAt, undefined);
 });
 
+test("parseSessionRecord preserves persisted session env", () => {
+  const serialized = serializeSessionRecordForDisk(
+    makeSessionRecord({
+      acpxRecordId: "session-env-options",
+      acpSessionId: "session-env-options",
+      agentCommand: "agent",
+      cwd: "/tmp/session-env-options",
+      acpx: {
+        session_options: {
+          env: {
+            GIT_AUTHOR_EMAIL: "agent@example.local",
+          },
+        },
+      },
+    }),
+  );
+  const acpx = serialized.acpx as Record<string, unknown>;
+  const sessionOptions = acpx.session_options as { env: Record<string, unknown> };
+  sessionOptions.env.IGNORED_NON_STRING = 123;
+
+  const parsed = parseSessionRecord(serialized);
+
+  assert.ok(parsed);
+  assert.deepEqual(parsed.acpx?.session_options?.env, {
+    GIT_AUTHOR_EMAIL: "agent@example.local",
+  });
+});
+
 test("parseSessionRecord ignores malformed config options during model-control migration", () => {
   const serialized = serializeSessionRecordForDisk(
     makeSessionRecord({

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -151,6 +151,29 @@ test("buildAgentSpawnOptions protects auth env case-insensitively on Windows", (
   });
 });
 
+test("buildAgentSpawnOptions protects inherited auth env case-insensitively on Windows", () => {
+  return withPlatform("win32", () => {
+    const previous = process.env.acpx_auth_inherited_token;
+    process.env.acpx_auth_inherited_token = "inherited-secret";
+    try {
+      const options = buildAgentSpawnOptions("/tmp/acpx-agent", undefined, {
+        ACPX_AUTH_INHERITED_TOKEN: "session-prefixed",
+        INHERITED_TOKEN: "session-normalized",
+      });
+
+      assert.equal(options.env.acpx_auth_inherited_token, "inherited-secret");
+      assert.equal(options.env.INHERITED_TOKEN, "inherited-secret");
+      assert.equal(options.env.ACPX_AUTH_INHERITED_TOKEN, undefined);
+    } finally {
+      if (previous == null) {
+        delete process.env.acpx_auth_inherited_token;
+      } else {
+        process.env.acpx_auth_inherited_token = previous;
+      }
+    }
+  });
+});
+
 test("buildAgentSpawnOptions promotes explicit ACPX auth env vars into agent auth env", () => {
   const previousPrefixed = process.env.ACPX_AUTH_OPENAI_API_KEY;
   const previousNormalized = process.env.OPENAI_API_KEY;

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -174,6 +174,27 @@ test("buildAgentSpawnOptions protects inherited auth env case-insensitively on W
   });
 });
 
+test("buildAgentSpawnOptions replaces inherited env case collisions on Windows", () => {
+  return withPlatform("win32", () => {
+    const previous = process.env.ACPX_TEST_SESSION_ENV_CASE;
+    process.env.ACPX_TEST_SESSION_ENV_CASE = "inherited";
+    try {
+      const options = buildAgentSpawnOptions("/tmp/acpx-agent", undefined, {
+        acpx_test_session_env_case: "session",
+      });
+
+      assert.equal(options.env.ACPX_TEST_SESSION_ENV_CASE, undefined);
+      assert.equal(options.env.acpx_test_session_env_case, "session");
+    } finally {
+      if (previous == null) {
+        delete process.env.ACPX_TEST_SESSION_ENV_CASE;
+      } else {
+        process.env.ACPX_TEST_SESSION_ENV_CASE = previous;
+      }
+    }
+  });
+});
+
 test("buildAgentSpawnOptions promotes explicit ACPX auth env vars into agent auth env", () => {
   const previousPrefixed = process.env.ACPX_AUTH_OPENAI_API_KEY;
   const previousNormalized = process.env.OPENAI_API_KEY;

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,6 +13,84 @@ import {
   buildTerminalShellSpawnCommand,
   buildTerminalSpawnCommand,
 } from "../src/spawn-command-options.js";
+
+test("buildAgentSpawnOptions merges session env into the agent child environment", () => {
+  const previous = process.env.ACPX_TEST_SESSION_ENV_PARENT;
+  process.env.ACPX_TEST_SESSION_ENV_PARENT = "parent-value";
+  try {
+    const options = buildAgentSpawnOptions("/tmp/acpx-agent", undefined, {
+      ACPX_TEST_SESSION_ENV_INJECTED: "injected-value",
+      ACPX_TEST_SESSION_ENV_PARENT: "overridden-by-session",
+    });
+
+    assert.equal(options.env.ACPX_TEST_SESSION_ENV_INJECTED, "injected-value");
+    assert.equal(
+      options.env.ACPX_TEST_SESSION_ENV_PARENT,
+      "overridden-by-session",
+      "session env must override the parent process env for colliding keys",
+    );
+  } finally {
+    if (previous == null) {
+      delete process.env.ACPX_TEST_SESSION_ENV_PARENT;
+    } else {
+      process.env.ACPX_TEST_SESSION_ENV_PARENT = previous;
+    }
+  }
+});
+
+test("buildAgentSpawnOptions leaves the agent env untouched when no session env is configured", () => {
+  const options = buildAgentSpawnOptions("/tmp/acpx-agent", undefined, undefined);
+  assert.equal(options.env.ACPX_TEST_SESSION_ENV_INJECTED, undefined);
+});
+
+test("spawned agent child process receives session env with parent-override precedence", async () => {
+  const script =
+    "process.stdout.write(JSON.stringify({injected:process.env.ACPX_TEST_E2E_INJECTED,parent:process.env.ACPX_TEST_E2E_PARENT}))";
+  const options = buildAgentSpawnOptions(os.tmpdir(), undefined, {
+    ACPX_TEST_E2E_INJECTED: "e2e-injected",
+    ACPX_TEST_E2E_PARENT: "e2e-overridden",
+  });
+
+  const result = await new Promise<{ injected?: string; parent?: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, ["-e", script], {
+      ...options,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`child exited with ${code}: ${stderr}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch {
+        reject(new Error(`failed to parse child stdout: ${stdout} (${stderr})`));
+      }
+    });
+  });
+
+  assert.equal(
+    result.injected,
+    "e2e-injected",
+    "real child process must receive the injected session env var",
+  );
+  assert.equal(
+    result.parent,
+    "e2e-overridden",
+    "real child process must see session env override the parent value",
+  );
+});
 
 test("buildAgentSpawnOptions hides Windows console windows and preserves auth env", () => {
   const options = buildAgentSpawnOptions("/tmp/acpx-agent", {

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -14,6 +14,18 @@ import {
   buildTerminalSpawnCommand,
 } from "../src/spawn-command-options.js";
 
+function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+  try {
+    return callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process, "platform", descriptor);
+    }
+  }
+}
+
 test("buildAgentSpawnOptions merges session env into the agent child environment", () => {
   const previous = process.env.ACPX_TEST_SESSION_ENV_PARENT;
   process.env.ACPX_TEST_SESSION_ENV_PARENT = "parent-value";
@@ -117,6 +129,26 @@ test("buildAgentSpawnOptions prevents session env from overriding injected auth 
 
   assert.equal(options.env.ACPX_AUTH_API_TOKEN, "secret-token");
   assert.equal(options.env.API_TOKEN, "secret-token");
+});
+
+test("buildAgentSpawnOptions protects auth env case-insensitively on Windows", () => {
+  return withPlatform("win32", () => {
+    const options = buildAgentSpawnOptions(
+      "/tmp/acpx-agent",
+      {
+        "case-token": "secret-token",
+      },
+      {
+        acpx_auth_case_token: "session-prefixed",
+        case_token: "session-normalized",
+      },
+    );
+
+    assert.equal(options.env.ACPX_AUTH_CASE_TOKEN, "secret-token");
+    assert.equal(options.env.CASE_TOKEN, "secret-token");
+    assert.equal(options.env.acpx_auth_case_token, undefined);
+    assert.equal(options.env.case_token, undefined);
+  });
 });
 
 test("buildAgentSpawnOptions promotes explicit ACPX auth env vars into agent auth env", () => {

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -103,6 +103,22 @@ test("buildAgentSpawnOptions hides Windows console windows and preserves auth en
   assert.equal(options.env.ACPX_AUTH_TOKEN, "secret-token");
 });
 
+test("buildAgentSpawnOptions prevents session env from overriding injected auth env", () => {
+  const options = buildAgentSpawnOptions(
+    "/tmp/acpx-agent",
+    {
+      "api-token": "secret-token",
+    },
+    {
+      ACPX_AUTH_API_TOKEN: "session-prefixed",
+      API_TOKEN: "session-normalized",
+    },
+  );
+
+  assert.equal(options.env.ACPX_AUTH_API_TOKEN, "secret-token");
+  assert.equal(options.env.API_TOKEN, "secret-token");
+});
+
 test("buildAgentSpawnOptions promotes explicit ACPX auth env vars into agent auth env", () => {
   const previousPrefixed = process.env.ACPX_AUTH_OPENAI_API_KEY;
   const previousNormalized = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Adds `SessionAgentOptions.env` so acpx callers can pass per-agent environment variables into the spawned agent child process.
- Threads that env through the acpx-owned spawn/session/queue paths that must preserve it: child spawn options, session option persistence, reconnect, desired-model clearing, queue submit parsing, and queue-owner payload parsing.
- Protects acpx-managed auth credential environment variables from being replaced by caller-provided session env values.

Why does this matter now?

- Downstream OpenClaw needs one canonical agent-child environment contract for subprocess paths. This PR provides the upstream acpx contract layer: acpx can carry per-agent env to the child process, while keeping acpx-owned auth credential env keys protected.
- Without this acpx-side contract, the downstream OpenClaw follow-up would either need to fork behavior around acpx or keep solving the subprocess env problem at a downstream layer that does not own the acpx child-spawn environment.

What is the intended outcome?

- Ordinary caller-provided session env keys, such as `GIT_AUTHOR_EMAIL`, reach the spawned agent child process.
- `session_options.env` is preserved when sessions are persisted, restored, reconnected, or queued.
- acpx-owned auth credential env keys, including `ACPX_AUTH_*` and normalized forms, continue to carry the acpx credential value even if session env tries to override them.
- Maintainers can review the API/security boundary explicitly before release rather than inheriting an implicit or downstream-only contract.

What is intentionally out of scope?

- This PR does not implement the downstream OpenClaw subprocess contract or bump OpenClaw to a new acpx version. That should happen in a follow-up OpenClaw PR after the acpx API shape is accepted.
- This PR does not add a general denylist for execution-affecting keys such as `PATH`, `LD_PRELOAD`, or `NODE_OPTIONS`.
- This PR does not make `SessionAgentOptions.env` a secrets channel. Callers should use `authCredentials` for credentials and sanitize any environment values they pass.
- This PR does not change auth credential lookup order; it only prevents caller-provided session env from replacing auth env values that acpx owns.

What does success look like?

- acpx exposes a clear, persisted per-agent child-env contract.
- The same env survives the acpx session lifecycle paths that can resume, queue, or clear model preferences.
- Auth credential env keys remain owned by acpx, not by caller-provided session env.

What should reviewers focus on?

- Whether `SessionAgentOptions.env?: Record<string, string>` is the right public API shape before release.
- Whether persisted `session_options.env` is acceptable as compatibility-sensitive session data.
- Whether caller-owned sanitization for ordinary child env keys is acceptable, given that acpx protects only the auth credential env keys it owns.

- Fix classification: root-cause contract fix for acpx-owned session env propagation. It defines the missing upstream acpx contract and carries the same session env through every acpx lifecycle boundary that can spawn, persist, restore, reconnect, clear model preference, or queue a request.
- Root cause: the source contract gap was that acpx had no canonical `SessionAgentOptions.env` field and no single invariant for preserving caller-provided child-process env across session state, persistence, reconnect, desired-model clearing, and queue message parsing. The auth regression came from merge order at the child-spawn boundary: session env could replace acpx-owned auth credential env values after acpx injected them.
- Why this is root-cause fix: the PR fixes the source-of-truth contract where acpx owns the child spawn options and session options, then maps that same contract through persistence, reconnect, and queue payload parsers. Auth keys are protected at the credential-env owner boundary instead of adding downstream special cases, so ordinary env propagation and acpx-owned credential protection share one explicit invariant.
- Patch quality notes: patch-quality warnings for `default`/`return` paths are parser-shape validation branches that reject malformed queue/session payloads rather than silently masking runtime failures. The `fallback` wording in `mergeSessionOptions` describes the existing preferred-over-fallback session option merge order; `env` now follows the same per-key merge rule so reconnect and persisted state do not drop caller env. The large diff is kept together because splitting spawn, persistence, reconnect, queue submit, and queue-owner payload support would leave partial contract states that pass in one acpx path and drop env in another.
- Public contract notes: the public contract surface is intentionally `SessionAgentOptions.env?: Record<string, string>` plus persisted `session_options.env`; compatibility-sensitive defaults are unchanged except that acpx-managed auth credential keys can no longer be overridden through session env. Related open PR scan for `SessionAgentOptions.env`, `session_options.env`, and `per-agent env` in `openclaw/acpx` found only this PR, so there is no separate same-contract canonical PR to defer to.
- Maintainer-ready confidence: High for author-side readiness because the acpx root contract, lifecycle mappings, auth boundary, regression tests, and maintainer-facing risk disclosure are now explicit; final API acceptance remains a maintainer decision.

## Linked context

Which issue does this close?

None. This updates existing PR #389; no acpx issue is closed by this PR.

Which issues, PRs, or discussions are related?

- Related OpenClaw context: openclaw/openclaw#93425 and openclaw/openclaw#93752.
- Those are cross-repository references, not acpx issues resolved by this PR.

Was this requested by a maintainer or owner?

- The linked OpenClaw discussion called out the need for upstream acpx support as part of a broader canonical subprocess environment contract. This PR is the acpx-side contract work.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: acpx passes per-agent session env into the real spawned child process, preserves it through session/queue paths, and protects acpx-managed auth credential env keys from session-env overrides.
- Real environment tested: Node test build, real child-process spawn behavior, session persistence parsing, runtime reconnect behavior, model preference clearing behavior, queue submit parsing, and queue-owner payload parsing on Linux.
- Exact steps or command run after this patch:

  ```bash
  pnpm run build:test
  node --test dist-test/test/spawn-options.test.js dist-test/test/session-persistence.test.js dist-test/test/runtime-manager.test.js dist-test/test/session-mode-preference.test.js dist-test/test/queue-messages.test.js dist-test/test/queue-owner-env.test.js
  ```

- Evidence after fix:

  ```text
  > acpx@0.11.0 build:test
  > node -e "require('node:fs').rmSync('dist-test',{recursive:true,force:true})" && tsgo -p tsconfig.test.json

  ✔ parseQueueRequest accepts prompt session options
  ✔ parseQueueOwnerPayload parses valid payload
  ✔ AcpRuntimeManager restores persisted session env when reconnecting startTurn
  ✔ persistSessionOptions preserves session env as a serialized record
  ✔ sessionOptionsFromRecord restores session env from a persisted record
  ✔ mergeSessionOptions merges session env per key with preferred overriding fallback
  ✔ setDesiredModelId preserves session env when clearing model
  ✔ parseSessionRecord preserves persisted session env
  ✔ buildAgentSpawnOptions merges session env into the agent child environment
  ✔ buildAgentSpawnOptions leaves the agent env untouched when no session env is configured
  ✔ spawned agent child process receives session env with parent-override precedence
  ✔ buildAgentSpawnOptions prevents session env from overriding injected auth env
  ✔ buildAgentSpawnOptions protects auth env case-insensitively on Windows
  ✔ buildAgentSpawnOptions protects inherited auth env case-insensitively on Windows
  ✔ buildAgentSpawnOptions promotes explicit ACPX auth env vars into agent auth env
  ℹ tests 111
  ℹ suites 2
  ℹ pass 111
  ℹ fail 0
  ℹ cancelled 0
  ℹ skipped 0
  ℹ todo 0
  ```

- Observed result after fix: session env reaches spawned child processes for ordinary variables; persisted `session_options.env` survives disk parsing, reconnect state cloning, desired-model clearing, queue submit parsing, and queue-owner payload parsing; and auth env regressions confirm prefixed, normalized, differently-cased Windows, and inherited lowercase `acpx_auth_*` credential keys keep the acpx-owned credential instead of the session-provided value.
- What was not tested: a full downstream OpenClaw gateway run was not run in this acpx PR.
- Proof limitations or environment constraints: downstream OpenClaw proof should be produced in the follow-up OpenClaw PR after this acpx contract lands and OpenClaw can bump to the released acpx version. The proof here is focused on the acpx-owned child-spawn, session persistence, reconnect, and queue contract.
- Before evidence: the auth-env protection regression failed before the fix because session env replaced the acpx-injected credential value for an `ACPX_AUTH_*` key.

## Tests and validation

Which commands did you run?

```bash
pnpm run build:test
node --test dist-test/test/spawn-options.test.js dist-test/test/session-persistence.test.js dist-test/test/runtime-manager.test.js dist-test/test/session-mode-preference.test.js dist-test/test/queue-messages.test.js dist-test/test/queue-owner-env.test.js
```

What regression coverage was added or updated?

- Child spawn receives ordinary per-agent session env values, including a real spawned child-process assertion.
- Session env cannot override prefixed, normalized, Windows differently-cased, or inherited lowercase acpx auth credential env keys.
- Persisted `session_options.env` is restored from disk and ignores non-string env values.
- Runtime reconnect restores persisted session env when `startTurn` reconnects to an existing session record.
- Clearing desired model keeps persisted `session_options.env`.
- Queue submit parsing and queue-owner payload parsing preserve `sessionOptions.env`.

What failed before this fix, if known?

- The auth-env protection regression failed because `sessionEnv` was applied after auth credential injection and replaced the acpx-owned credential value.

If no test was added, why not?

- Regression tests were added for the changed behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

- `SessionAgentOptions.env` is a public child-process environment API and `session_options.env` is persisted session data.
- Caller-provided ordinary env keys can affect child process execution.
- Existing callers that attempted to override acpx-managed auth credential env keys through session env will intentionally stop being able to do so.

How is that risk mitigated?

- The PR documents that callers own sanitization of ordinary env keys and should not use session env for secrets.
- acpx-owned auth credential keys are protected at the same source-of-truth boundary that builds the child process auth environment.
- The behavior is covered by focused tests across child spawn, persistence, reconnect, and queue paths.
- The remaining API/security-boundary choice is called out explicitly for maintainer review before release.

## Current review state

What is the next action?

- Maintainers should decide whether to approve the persisted env contract, narrow it before release, or pause for downstream OpenClaw alignment.

What is still waiting on author, maintainer, CI, or external proof?

- Author-side code/proof work for acpx has been refreshed on the current PR head: the branch is based on current `openclaw/acpx` main, main does not already contain this change, and the focused acpx validation above passes.
- The remaining blocker is maintainer judgment for API, persistence, compatibility, and security-boundary semantics.
- No CI checks are currently reported for this branch.
- Downstream OpenClaw integration proof remains a follow-up after the acpx contract shape is accepted and available to OpenClaw.

Which bot or reviewer comments were addressed?

- RF-001 / `status: ⏳ waiting on author`: author-side acpx proof was refreshed on the current PR head; if maintainers agree no additional author code change is needed, this label can be cleared by review state.
- RF-002 / persisted API surface: disclosed as an explicit maintainer decision; `session_options.env` persistence is intentional and covered by focused tests.
- RF-003 / caller-sanitized execution boundary: disclosed as caller-owned for ordinary env keys; acpx protects only the auth credential keys it owns.
- RF-004 / auth env override compatibility: disclosed as an intentional behavior change scoped to acpx-managed auth credential keys and covered by regression tests.
- RF-005 / downstream OpenClaw integration proof: disclosed as not run in this acpx PR; follow-up proof belongs with the downstream OpenClaw PR after acpx acceptance.
- RF-006 / remaining action: acknowledged as maintainer judgment on API, persistence, compatibility, and security-boundary semantics, not a narrow automated repair.
