### PR TITLE
fix(cursor): normalize unique advertised model aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Repo: https://github.com/openclaw/acpx
   and release/CI checks found by `clawpatch`.
 - ACP/models: call the current SDK `session/set_model` method for legacy model
   metadata instead of the generic extension fallback.
+- ACP/Cursor: normalize a bare model name to a unique advertised bracketed
+  Cursor model id, while keeping ambiguous values rejected. Fixes #385.
 
 ## 2026.6.17 (v0.11.0)
 

--- a/agents/Cursor.md
+++ b/agents/Cursor.md
@@ -4,6 +4,11 @@
 - Default command: `cursor-agent acp`
 - Upstream: https://cursor.com/docs/cli/acp
 
+Cursor can advertise model ids with bracketed settings (for example,
+`composer-2.5[fast=false]`). `acpx --model composer-2.5 cursor ...` accepts a bare
+model name only when Cursor advertises exactly one matching bracketed variant; use
+the full advertised id when multiple variants are available.
+
 If your Cursor install exposes ACP as `agent acp` instead of `cursor-agent acp`, override the built-in command in config:
 
 ```json

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -123,6 +123,10 @@ Behavior varies by adapter:
 - **Claude** consumes the value as session-creation metadata.
 - Other agents must advertise a model session config option or legacy `models` metadata. Config options use `session/set_config_option`; explicitly advertised legacy models use `session/set_model`.
 - Model ids must appear in the adapter's advertised values. Unknown ids are rejected.
+- Cursor may advertise model variants with bracketed settings such as
+  `composer-2.5[fast=false]`. When exactly one advertised Cursor id has the requested
+  bare model as its prefix, `acpx` forwards that advertised id automatically; ambiguous
+  variants remain rejected.
 
 For mid-session model switches, use `set model <id>` instead. See [Session control](session-control.md#set-key-value).
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -270,6 +270,9 @@ Behavior:
 - `--no-terminal`: do not advertise the ACP terminal capability — useful for review-only or sandboxed agent invocations
 - `--verbose`: verbose ACP/debug logs to stderr
 
+Cursor may advertise bracketed model ids such as `composer-2.5[fast=false]`. A bare Cursor
+model name is normalized only when exactly one advertised bracketed variant matches it.
+
 Permission flags are mutually exclusive.
 
 ## System prompt override (Claude)

--- a/src/acp/agent-command.ts
+++ b/src/acp/agent-command.ts
@@ -66,6 +66,11 @@ export function isQoderAcpCommand(command: string, args: readonly string[]): boo
   return basenameToken(command) === "qodercli" && args.includes("--acp");
 }
 
+export function isCursorAcpCommand(command: string, args: readonly string[]): boolean {
+  const commandToken = basenameToken(command);
+  return commandToken === "cursor-agent" || (commandToken === "agent" && args.includes("acp"));
+}
+
 export function isDevinAcpCommand(command: string, args: readonly string[]): boolean {
   return (
     basenameToken(command) === "devin" &&

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -104,6 +104,7 @@ import {
   modelStateFromConfigOptions,
   modelStateFromSessionResponse,
   RequestedModelUnsupportedError,
+  resolveRequestedModelId,
   type SessionModelState,
 } from "./model-support.js";
 import {
@@ -262,7 +263,8 @@ type SessionUpdateSuppressionState = {
 };
 
 type ModelControl = { kind: "config_option"; configId: string } | { kind: "legacy_set_model" };
-type ModelControlOverride = Pick<SessionModelState, "configId">;
+type ModelControlOverride = Pick<SessionModelState, "configId"> &
+  Partial<Pick<SessionModelState, "availableModels">>;
 
 export type AgentExitInfo = {
   exitCode: number | null;
@@ -1125,9 +1127,16 @@ export class AcpClient {
         `Cannot set model "${modelId}": the ACP session did not advertise a model config option or legacy session/set_model support.`,
       );
     }
+    const resolvedModelId = resolveRequestedModelId({
+      requestedModel: modelId,
+      models: controlOverride?.availableModels
+        ? { availableModels: controlOverride.availableModels }
+        : undefined,
+      agentCommand: this.options.agentCommand,
+    });
     return control.kind === "config_option"
-      ? await this.setSessionModelThroughConfig(sessionId, modelId, control.configId)
-      : await this.setSessionModelThroughLegacyMethod(sessionId, modelId);
+      ? await this.setSessionModelThroughConfig(sessionId, resolvedModelId, control.configId)
+      : await this.setSessionModelThroughLegacyMethod(sessionId, resolvedModelId);
   }
 
   private async setSessionModelThroughConfig(

--- a/src/acp/model-support.ts
+++ b/src/acp/model-support.ts
@@ -1,4 +1,4 @@
-import { isClaudeAcpCommand } from "./agent-command.js";
+import { isClaudeAcpCommand, isCursorAcpCommand } from "./agent-command.js";
 import { splitCommandLine } from "./client-process.js";
 
 export type SessionModelState = {
@@ -9,6 +9,8 @@ export type SessionModelState = {
     name: string;
   }>;
 };
+
+type AdvertisedModelIds = Pick<SessionModelState, "availableModels">;
 
 type LegacySessionModelResponse = {
   models?: {
@@ -161,6 +163,33 @@ export function formatAvailableModelIds(models: SessionModelState | undefined): 
   return ids.length > 0 ? ids.join(", ") : "none advertised";
 }
 
+export function resolveRequestedModelId(params: {
+  requestedModel: string;
+  models: AdvertisedModelIds | undefined;
+  agentCommand?: string;
+}): string {
+  if (!params.models || !isCursorAcpCommandForModelAlias(params.agentCommand)) {
+    return params.requestedModel;
+  }
+
+  if (params.models.availableModels.some((model) => model.modelId === params.requestedModel)) {
+    return params.requestedModel;
+  }
+
+  const candidates = params.models.availableModels
+    .map((model) => model.modelId)
+    .filter((modelId) => modelId.startsWith(`${params.requestedModel}[`));
+  return candidates.length === 1 ? candidates[0] : params.requestedModel;
+}
+
+function isCursorAcpCommandForModelAlias(agentCommand: string | undefined): boolean {
+  if (!agentCommand) {
+    return false;
+  }
+  const { command, args } = splitCommandLine(agentCommand);
+  return isCursorAcpCommand(command, args);
+}
+
 export function assertRequestedModelSupported(params: {
   requestedModel: string;
   models: SessionModelState | undefined;
@@ -179,6 +208,10 @@ export function assertRequestedModelSupported(params: {
 
   const advertised = new Set(params.models.availableModels.map((model) => model.modelId));
   if (!advertised.has(params.requestedModel)) {
+    const resolvedModel = resolveRequestedModelId(params);
+    if (resolvedModel !== params.requestedModel) {
+      return `Cursor ACP advertised "${resolvedModel}" for requested model "${params.requestedModel}"; using the advertised id.`;
+    }
     if (supportsLegacyClaudeCodeModelMetadata(params.agentCommand)) {
       return `requested model "${params.requestedModel}" was not in the Claude ACP advertised model list (${formatAvailableModelIds(params.models)}); forwarding it to Claude Code so the adapter can accept or reject it.`;
     }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -869,6 +869,23 @@ test("AcpClient setSessionModel honors an advertised custom config id", async ()
   assert.equal(capturedConfigId, "llm");
 });
 
+test("AcpClient normalizes a Cursor model alias to its unique advertised id", async () => {
+  const client = makeClient({ agentCommand: "cursor-agent acp" });
+  let capturedValue: string | undefined;
+  asInternals(client).connection = {
+    setSessionConfigOption: async (params: { value: string }) => {
+      capturedValue = params.value;
+      return { configOptions: [] };
+    },
+  };
+
+  await client.setSessionModel("session-456", "composer-2.5", {
+    configId: "model",
+    availableModels: [{ modelId: "composer-2.5[fast=false]", name: "Composer 2.5" }],
+  });
+  assert.equal(capturedValue, "composer-2.5[fast=false]");
+});
+
 test("AcpClient setSessionModel rejects sessions without advertised model control", async () => {
   const client = makeClient();
   asInternals(client).connection = {};

--- a/test/model-support.test.ts
+++ b/test/model-support.test.ts
@@ -39,3 +39,56 @@ test("non-Claude model validation rejects unadvertised selectors", () => {
     /did not advertise that model/,
   );
 });
+
+test("Cursor model validation accepts a unique advertised suffix variant", () => {
+  const warning = assertRequestedModelSupported({
+    requestedModel: "composer-2.5",
+    models: {
+      configId: "model",
+      currentModelId: "composer-2.5[fast=false]",
+      availableModels: [{ modelId: "composer-2.5[fast=false]", name: "Composer 2.5" }],
+    },
+    agentCommand: "cursor-agent acp",
+    context: "apply",
+  });
+
+  assert.match(warning ?? "", /advertised "composer-2\.5\[fast=false\]"/);
+});
+
+test("Cursor model validation keeps ambiguous suffix variants strict", () => {
+  assert.throws(
+    () =>
+      assertRequestedModelSupported({
+        requestedModel: "composer-2.5",
+        models: {
+          configId: "model",
+          currentModelId: "composer-2.5[fast=false]",
+          availableModels: [
+            { modelId: "composer-2.5[fast=false]", name: "Composer 2.5" },
+            { modelId: "composer-2.5[fast=true]", name: "Composer 2.5 Fast" },
+          ],
+        },
+        agentCommand: "cursor-agent acp",
+        context: "apply",
+      }),
+    /did not advertise that model/,
+  );
+});
+
+test("Cursor model resolution preserves an exact advertised id", () => {
+  const warning = assertRequestedModelSupported({
+    requestedModel: "composer-2.5",
+    models: {
+      configId: "model",
+      currentModelId: "composer-2.5",
+      availableModels: [
+        { modelId: "composer-2.5", name: "Composer 2.5" },
+        { modelId: "composer-2.5[fast=false]", name: "Composer 2.5 Fast" },
+      ],
+    },
+    agentCommand: "cursor-agent acp",
+    context: "apply",
+  });
+
+  assert.equal(warning, undefined);
+});


### PR DESCRIPTION
Fixes #385

Cursor ACP can advertise bracketed model variants such as `composer-2.5[fast=false]` while users request the bare model name. This keeps exact advertised ids unchanged, resolves only a unique Cursor bracketed variant, and keeps ambiguous values rejected.

Validation: targeted client/model tests, typecheck, lint, docs check, and autoreview pass. Full check ran 790/790 tests; the final package-bin smoke is blocked by the local Node 26/yargs ESM incompatibility.