### PR TITLE
feat(cli): support external MCP config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Repo: https://github.com/openclaw/acpx
 - ACP/models: call the current SDK `session/set_model` method for legacy model
   metadata instead of the generic extension fallback.
 - CLI/config: add `--mcp-config` for session-scoped MCP servers without writing
-  a project config file. Fixes #387.
+  a project config file. Live persistent sessions reject MCP config changes until
+  closed. Fixes #387.
 
 ## 2026.6.17 (v0.11.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Repo: https://github.com/openclaw/acpx
   and release/CI checks found by `clawpatch`.
 - ACP/models: call the current SDK `session/set_model` method for legacy model
   metadata instead of the generic extension fallback.
-- ACP/Cursor: normalize a bare model name to a unique advertised bracketed
-  Cursor model id, while keeping ambiguous values rejected. Fixes #385.
+- CLI/config: add `--mcp-config` for session-scoped MCP servers without writing
+  a project config file. Fixes #387.
 
 ## 2026.6.17 (v0.11.0)
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ real GitHub PRs if you run it against a live repository.
 
 CLI flags always win over config values.
 
+Use `--mcp-config <path>` to load only the `mcpServers` array from an external JSON file without
+writing a project config file. Relative paths resolve from `--cwd`.
+
 Supported keys:
 
 ```json

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,6 +45,7 @@ acpx [global_options] <agent> sessions [list | new [--name <name>] | ensure [--n
 
 The global `--mcp-config <path>` option loads an external JSON file's `mcpServers` array for the
 invocation, replacing project/global MCP configuration. Relative paths resolve from `--cwd`.
+For a persistent session, close the existing session before switching its MCP config.
 
 `<agent>` can be:
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -43,6 +43,9 @@ acpx [global_options] <agent> status [-s <name>]
 acpx [global_options] <agent> sessions [list | new [--name <name>] | ensure [--name <name>] | close [name] | show [name] | history [name] [--limit <count>] | export [name] --output <path> | import <archive> [--name <name>] [--cwd <dir>]]
 ```
 
+The global `--mcp-config <path>` option loads an external JSON file's `mcpServers` array for the
+invocation, replacing project/global MCP configuration. Relative paths resolve from `--cwd`.
+
 `<agent>` can be:
 
 - built-in friendly name from [the README](https://github.com/openclaw/acpx/blob/main/README.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -77,6 +77,9 @@ the project/global `mcpServers` value for that invocation. Relative paths resolv
 acpx --cwd /workspace --mcp-config /run/job-mcp.json codex 'use the configured tools'
 ```
 
+An existing persistent session cannot switch MCP configurations while its queue owner is live.
+Close that session first, then retry with the new `--mcp-config` file.
+
 ## The `agents` map
 
 Custom agents and overrides live here:

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,13 @@ acpx config init
   "ttl": 300,
   "timeout": null,
   "format": "text",
+  "mcpServers": [
+    {
+      "name": "local-tools",
+      "type": "stdio",
+      "command": "./bin/mcp-server"
+    }
+  ],
   "agents": {
     "my-custom": { "command": "./bin/my-acp-server", "args": ["acp"] }
   },
@@ -56,10 +63,19 @@ acpx config init
 | `ttl`                       | integer          | `300`             | Queue owner idle TTL in seconds. `0` disables idle shutdown.                                       |
 | `timeout`                   | number \| `null` | `null`            | Default `--timeout` in seconds (decimal allowed).                                                  |
 | `format`                    | enum             | `"text"`          | Default `--format`.                                                                                |
+| `mcpServers`                | array            | `[]`              | MCP servers sent to new and loaded ACP sessions. Project values replace global values.             |
 | `agents`                    | object           | `{}`              | Override or add agent commands (see below).                                                        |
 | `auth`                      | object           | `{}`              | ACP auth-method credential map (see below).                                                        |
 
 CLI flags always override these values. For example, `--approve-all` wins over `defaultPermissions: "deny-all"`.
+
+Use `--mcp-config <path>` when MCP servers belong to a session or automation job rather than the
+working tree. The file must contain the same top-level `mcpServers` array shown above; it replaces
+the project/global `mcpServers` value for that invocation. Relative paths resolve from `--cwd`.
+
+```bash
+acpx --cwd /workspace --mcp-config /run/job-mcp.json codex 'use the configured tools'
+```
 
 ## The `agents` map
 

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -61,6 +61,7 @@ const TOP_LEVEL_VERSION_VALUE_FLAG_VALUES = [
   "--prompt-retries",
   "--timeout",
   "--ttl",
+  "--mcp-config",
 ] as const;
 
 const TOP_LEVEL_VERSION_VALUE_FLAGS = new Set<string>(TOP_LEVEL_VERSION_VALUE_FLAG_VALUES);
@@ -198,6 +199,41 @@ function detectInitialCwd(argv: string[]): string {
   }
 
   return process.cwd();
+}
+
+function detectMcpConfigPath(argv: string[], cwd: string): string | undefined {
+  for (let index = 0; index < argv.length; index += 1) {
+    const scan = scanMcpConfigToken(argv[index], argv[index + 1], cwd);
+    if (scan.stop) {
+      return scan.path;
+    }
+    if (scan.skipNext) {
+      index += 1;
+    }
+  }
+  return undefined;
+}
+
+function scanMcpConfigToken(
+  token: string,
+  nextToken: string | undefined,
+  cwd: string,
+): { path?: string; skipNext?: boolean; stop?: boolean } {
+  if (token === "--" || !token.startsWith("-") || token === "-") {
+    return { stop: true };
+  }
+  if (token === "--mcp-config") {
+    return { path: resolveMcpConfigPath(nextToken, cwd), stop: true };
+  }
+  if (token.startsWith("--mcp-config=")) {
+    return { path: resolveMcpConfigPath(token.slice("--mcp-config=".length), cwd), stop: true };
+  }
+  return { skipNext: TOP_LEVEL_VERSION_VALUE_FLAGS.has(token) };
+}
+
+function resolveMcpConfigPath(value: string | undefined, cwd: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed !== "--" ? path.resolve(cwd, trimmed) : undefined;
 }
 
 function isCwdFlagToken(token: string): boolean {
@@ -489,7 +525,10 @@ export async function main(argv: string[] = process.argv): Promise<void> {
 
   await maybeHandleSkillflag(normalizedArgv);
 
-  const config = await loadResolvedConfig(detectInitialCwd(rawArgs));
+  const initialCwd = detectInitialCwd(rawArgs);
+  const config = await loadResolvedConfig(initialCwd, {
+    mcpConfigPath: detectMcpConfigPath(rawArgs, initialCwd),
+  });
   const requestedJsonStrict = detectJsonStrict(rawArgs);
   const requestedOutputFormat = detectRequestedOutputFormat(rawArgs, config.format);
   const requestedOutputPolicy = {

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -336,6 +336,8 @@ export async function handlePrompt(
     sessionId: record.acpxRecordId,
     prompt,
     mcpServers: config.mcpServers,
+    mcpConfigPath: config.mcpConfigPath,
+    mcpConfigFingerprint: config.mcpConfigFingerprint,
     permissionMode,
     nonInteractivePermissions: globalFlags.nonInteractivePermissions,
     permissionPolicy,

--- a/src/cli/config-command.ts
+++ b/src/cli/config-command.ts
@@ -9,6 +9,7 @@ async function handleConfigShow(command: Command, config: ResolvedAcpxConfig): P
     paths: {
       global: config.globalPath,
       project: config.projectPath,
+      ...(config.mcpConfigPath ? { mcp: config.mcpConfigPath } : {}),
     },
     loaded: {
       global: config.hasGlobalConfig,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -383,7 +384,9 @@ export async function loadResolvedConfig(
     globalPath,
     projectPath,
     mcpConfigPath: explicitMcp.path,
-    mcpConfigFingerprint: explicitMcp.path ? JSON.stringify(mcpServers) : undefined,
+    mcpConfigFingerprint: explicitMcp.path
+      ? createHash("sha256").update(JSON.stringify(mcpServers)).digest("hex")
+      : undefined,
     hasGlobalConfig: globalResult.exists,
     hasProjectConfig: projectResult.exists,
   };

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -46,13 +46,24 @@ export type ResolvedAcpxConfig = {
   mcpServers: McpServer[];
   globalPath: string;
   projectPath: string;
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
   hasGlobalConfig: boolean;
   hasProjectConfig: boolean;
+};
+
+export type LoadResolvedConfigOptions = {
+  mcpConfigPath?: string;
 };
 
 type ConfigFileLoadResult = {
   config?: ConfigFileShape;
   exists: boolean;
+};
+
+type ExplicitMcpConfig = {
+  path?: string;
+  config?: ConfigFileShape;
 };
 
 const DEFAULT_TIMEOUT_MS = undefined;
@@ -287,6 +298,25 @@ async function readConfigFile(filePath: string): Promise<ConfigFileLoadResult> {
   }
 }
 
+async function loadExplicitMcpConfig(
+  cwd: string,
+  configuredPath: string | undefined,
+): Promise<ExplicitMcpConfig> {
+  if (!configuredPath) {
+    return {};
+  }
+
+  const resolvedPath = path.resolve(cwd, configuredPath);
+  const result = await readConfigFile(resolvedPath);
+  if (!result.exists) {
+    throw new Error(`MCP config file not found: ${resolvedPath}`);
+  }
+  return {
+    path: resolvedPath,
+    config: result.config,
+  };
+}
+
 function mergeAgents(
   globalAgents: Record<string, string> | undefined,
   projectAgents: Record<string, string> | undefined,
@@ -307,13 +337,17 @@ function mergeAuth(
   };
 }
 
-export async function loadResolvedConfig(cwd: string): Promise<ResolvedAcpxConfig> {
+export async function loadResolvedConfig(
+  cwd: string,
+  options: LoadResolvedConfigOptions = {},
+): Promise<ResolvedAcpxConfig> {
   const globalPath = defaultGlobalConfigPath();
   const projectPath = projectConfigPath(cwd);
 
-  const [globalResult, projectResult] = await Promise.all([
+  const [globalResult, projectResult, explicitMcp] = await Promise.all([
     readConfigFile(globalPath),
     readConfigFile(projectPath),
+    loadExplicitMcpConfig(cwd, options.mcpConfigPath),
   ]);
 
   const globalConfig = globalResult.config;
@@ -330,7 +364,14 @@ export async function loadResolvedConfig(cwd: string): Promise<ResolvedAcpxConfi
     parseAuth(projectConfig?.auth, projectPath),
   );
 
-  const mcpServers = resolveMcpServers(projectConfig, projectPath, globalConfig, globalPath);
+  const mcpServers = resolveMcpServers(
+    projectConfig,
+    projectPath,
+    globalConfig,
+    globalPath,
+    explicitMcp.config,
+    explicitMcp.path,
+  );
   const disableExec = resolveDisableExec(projectConfig, projectPath, globalConfig, globalPath);
 
   return {
@@ -341,6 +382,8 @@ export async function loadResolvedConfig(cwd: string): Promise<ResolvedAcpxConfi
     mcpServers,
     globalPath,
     projectPath,
+    mcpConfigPath: explicitMcp.path,
+    mcpConfigFingerprint: explicitMcp.path ? JSON.stringify(mcpServers) : undefined,
     hasGlobalConfig: globalResult.exists,
     hasProjectConfig: projectResult.exists,
   };
@@ -499,7 +542,12 @@ function resolveMcpServers(
   projectPath: string,
   globalConfig: ConfigFileShape | undefined,
   globalPath: string,
+  mcpConfig: ConfigFileShape | undefined,
+  mcpConfigPath: string | undefined,
 ): McpServer[] {
+  if (mcpConfigPath) {
+    return parseMcpServers(mcpConfig?.mcpServers, mcpConfigPath);
+  }
   if (hasConfigKey(projectConfig, "mcpServers")) {
     return parseMcpServers(projectConfig?.mcpServers, projectPath);
   }

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -341,6 +341,10 @@ export function addGlobalFlags(command: Command): Command {
       "Queue owner idle TTL before shutdown (0 = keep alive forever) (default: 300)",
       parseTtlSeconds,
     )
+    .option(
+      "--mcp-config <path>",
+      "Load MCP servers from a JSON config file instead of project/global mcpServers",
+    )
     .option("--verbose", "Enable verbose debug logs");
 }
 

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -301,6 +301,8 @@ export type SubmitToQueueOwnerOptions = {
   sessionId: string;
   message: string;
   prompt?: PromptInput;
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
   permissionMode: PermissionMode;
   resumePolicy?: SessionResumePolicy;
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
@@ -668,11 +670,25 @@ async function submitCloseSessionToQueueOwner(
   return response.closed;
 }
 
+function queueOwnerMcpConfigMatches(
+  owner: QueueOwnerRecord,
+  options: SubmitToQueueOwnerOptions,
+): boolean {
+  return (
+    owner.mcpConfigPath === options.mcpConfigPath &&
+    owner.mcpConfigFingerprint === options.mcpConfigFingerprint
+  );
+}
+
 export async function trySubmitToRunningOwner(
   options: SubmitToQueueOwnerOptions,
 ): Promise<SessionSendOutcome | undefined> {
   const owner = await readQueueOwnerRecord(options.sessionId);
   if (!owner) {
+    return undefined;
+  }
+  if (!queueOwnerMcpConfigMatches(owner, options)) {
+    await terminateQueueOwnerForSession(options.sessionId);
     return undefined;
   }
 

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -17,6 +17,7 @@ import type {
 import { probeQueueOwnerHealth, type QueueOwnerHealth } from "./ipc-health.js";
 import { connectToQueueOwner } from "./ipc-transport.js";
 import {
+  ensureOwnerIsUsable,
   type QueueOwnerRecord,
   readQueueOwnerRecord,
   terminateQueueOwnerForSession,
@@ -702,6 +703,9 @@ export async function trySubmitToRunningOwner(
 ): Promise<SessionSendOutcome | undefined> {
   const owner = await readQueueOwnerRecord(options.sessionId);
   if (!owner) {
+    return undefined;
+  }
+  if (!(await ensureOwnerIsUsable(options.sessionId, owner))) {
     return undefined;
   }
   assertQueueOwnerMcpConfigMatches(owner, options);

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -680,6 +680,23 @@ function queueOwnerMcpConfigMatches(
   );
 }
 
+function assertQueueOwnerMcpConfigMatches(
+  owner: QueueOwnerRecord,
+  options: SubmitToQueueOwnerOptions,
+): void {
+  if (queueOwnerMcpConfigMatches(owner, options)) {
+    return;
+  }
+  throw new QueueConnectionError(
+    "Session queue owner uses a different MCP config; close the session before retrying",
+    {
+      detailCode: "QUEUE_MCP_CONFIG_CONFLICT",
+      origin: "queue",
+      retryable: false,
+    },
+  );
+}
+
 export async function trySubmitToRunningOwner(
   options: SubmitToQueueOwnerOptions,
 ): Promise<SessionSendOutcome | undefined> {
@@ -687,10 +704,7 @@ export async function trySubmitToRunningOwner(
   if (!owner) {
     return undefined;
   }
-  if (!queueOwnerMcpConfigMatches(owner, options)) {
-    await terminateQueueOwnerForSession(options.sessionId);
-    return undefined;
-  }
+  assertQueueOwnerMcpConfigMatches(owner, options);
 
   let submitted: SessionSendOutcome | undefined;
   try {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -17,6 +17,8 @@ export type QueueOwnerRecord = {
   heartbeatAt: string;
   ownerGeneration: number;
   queueDepth: number;
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
 };
 
 export type QueueOwnerLease = {
@@ -25,6 +27,8 @@ export type QueueOwnerLease = {
   socketPath: string;
   createdAt: string;
   ownerGeneration: number;
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
 };
 
 export type QueueOwnerStatus = {
@@ -55,6 +59,10 @@ function parseQueueOwnerRecord(raw: unknown): QueueOwnerRecord | null {
     heartbeatAt: record.heartbeatAt,
     ownerGeneration: record.ownerGeneration,
     queueDepth: record.queueDepth,
+    ...(typeof record.mcpConfigPath === "string" ? { mcpConfigPath: record.mcpConfigPath } : {}),
+    ...(typeof record.mcpConfigFingerprint === "string"
+      ? { mcpConfigFingerprint: record.mcpConfigFingerprint }
+      : {}),
   };
 }
 
@@ -249,12 +257,22 @@ export async function readQueueOwnerStatus(
 
 export async function tryAcquireQueueOwnerLease(
   sessionId: string,
+  mcpConfigOrNowIsoFactory?:
+    | string
+    | {
+        path?: string;
+        fingerprint?: string;
+      }
+    | (() => string),
   nowIsoFactory: () => string = nowIso,
 ): Promise<QueueOwnerLease | undefined> {
+  const { mcpConfigPath, clock } = resolveLeaseArguments(mcpConfigOrNowIsoFactory, nowIsoFactory);
+  const mcpConfigFingerprint = readMcpConfigFingerprint(mcpConfigOrNowIsoFactory);
+  const mcpConfigMetadata = createMcpConfigMetadata(mcpConfigPath, mcpConfigFingerprint);
   await ensureQueueDir();
   const lockPath = queueLockFilePath(sessionId);
   const socketPath = queueSocketPath(sessionId);
-  const createdAt = nowIsoFactory();
+  const createdAt = clock();
   const ownerGeneration = createOwnerGeneration();
   const payload = JSON.stringify(
     {
@@ -265,6 +283,7 @@ export async function tryAcquireQueueOwnerLease(
       heartbeatAt: createdAt,
       ownerGeneration,
       queueDepth: 0,
+      ...mcpConfigMetadata,
     },
     null,
     2,
@@ -284,23 +303,76 @@ export async function tryAcquireQueueOwnerLease(
       socketPath,
       createdAt,
       ownerGeneration,
+      ...mcpConfigMetadata,
     };
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw error;
-    }
+    return await handleLeaseCollision(sessionId, error);
+  }
+}
 
-    const owner = await readQueueOwnerRecord(sessionId);
-    if (!owner) {
-      await cleanupStaleQueueOwner(sessionId, owner);
-      return undefined;
-    }
+function readMcpConfigFingerprint(
+  mcpConfigOrNowIsoFactory:
+    | string
+    | {
+        path?: string;
+        fingerprint?: string;
+      }
+    | (() => string)
+    | undefined,
+): string | undefined {
+  return typeof mcpConfigOrNowIsoFactory === "object"
+    ? mcpConfigOrNowIsoFactory?.fingerprint
+    : undefined;
+}
 
-    if (!isProcessAlive(owner.pid) || isQueueOwnerHeartbeatStale(owner)) {
-      await retireStaleQueueOwner(sessionId, owner);
-    }
+function createMcpConfigMetadata(
+  mcpConfigPath: string | undefined,
+  mcpConfigFingerprint: string | undefined,
+): { mcpConfigPath?: string; mcpConfigFingerprint?: string } {
+  return {
+    ...(mcpConfigPath ? { mcpConfigPath } : {}),
+    ...(mcpConfigFingerprint ? { mcpConfigFingerprint } : {}),
+  };
+}
+
+async function handleLeaseCollision(sessionId: string, error: unknown): Promise<undefined> {
+  if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+    throw error;
+  }
+
+  const owner = await readQueueOwnerRecord(sessionId);
+  if (!owner) {
+    await cleanupStaleQueueOwner(sessionId, owner);
     return undefined;
   }
+
+  if (!isProcessAlive(owner.pid) || isQueueOwnerHeartbeatStale(owner)) {
+    await retireStaleQueueOwner(sessionId, owner);
+  }
+  return undefined;
+}
+
+function resolveLeaseArguments(
+  mcpConfigOrNowIsoFactory:
+    | string
+    | {
+        path?: string;
+        fingerprint?: string;
+      }
+    | (() => string)
+    | undefined,
+  nowIsoFactory: () => string,
+): { mcpConfigPath: string | undefined; clock: () => string } {
+  if (typeof mcpConfigOrNowIsoFactory === "string") {
+    return { mcpConfigPath: mcpConfigOrNowIsoFactory, clock: nowIsoFactory };
+  }
+  if (typeof mcpConfigOrNowIsoFactory === "function") {
+    return { mcpConfigPath: undefined, clock: mcpConfigOrNowIsoFactory };
+  }
+  if (mcpConfigOrNowIsoFactory) {
+    return { mcpConfigPath: mcpConfigOrNowIsoFactory.path, clock: nowIsoFactory };
+  }
+  return { mcpConfigPath: undefined, clock: nowIsoFactory };
 }
 
 export async function refreshQueueOwnerLease(
@@ -319,6 +391,8 @@ export async function refreshQueueOwnerLease(
       heartbeatAt: nowIsoFactory(),
       ownerGeneration: lease.ownerGeneration,
       queueDepth: Math.max(0, Math.round(options.queueDepth)),
+      ...(lease.mcpConfigPath ? { mcpConfigPath: lease.mcpConfigPath } : {}),
+      ...(lease.mcpConfigFingerprint ? { mcpConfigFingerprint: lease.mcpConfigFingerprint } : {}),
     },
     null,
     2,

--- a/src/cli/queue/owner-env.ts
+++ b/src/cli/queue/owner-env.ts
@@ -57,6 +57,12 @@ function assignQueueOwnerTransportOptions(
   if (parsedMcpServers) {
     options.mcpServers = parsedMcpServers;
   }
+  if (typeof record.mcpConfigPath === "string" && record.mcpConfigPath.length > 0) {
+    options.mcpConfigPath = record.mcpConfigPath;
+  }
+  if (typeof record.mcpConfigFingerprint === "string" && record.mcpConfigFingerprint.length > 0) {
+    options.mcpConfigFingerprint = record.mcpConfigFingerprint;
+  }
 
   if (record.authCredentials && typeof record.authCredentials === "object") {
     const entries = Object.entries(record.authCredentials as UnknownRecord).filter(

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -82,6 +82,8 @@ export type SessionSendOptions = {
   prompt: PromptInput;
   resumePolicy?: SessionResumePolicy;
   mcpServers?: McpServer[];
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
   permissionMode: PermissionMode;
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   permissionPolicy?: PermissionPolicy;

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -16,6 +16,8 @@ const QUEUE_OWNER_PAYLOAD_ENV = "ACPX_QUEUE_OWNER_PAYLOAD";
 export type QueueOwnerRuntimeOptions = {
   sessionId: string;
   mcpServers?: McpServer[];
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
   permissionMode: PermissionMode;
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
@@ -32,6 +34,8 @@ export type QueueOwnerRuntimeOptions = {
 type SessionSendLike = {
   sessionId: string;
   mcpServers?: McpServer[];
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
   permissionMode: PermissionMode;
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
@@ -157,6 +161,8 @@ export function queueOwnerRuntimeOptionsFromSend(
   return {
     sessionId: options.sessionId,
     mcpServers: options.mcpServers,
+    ...(options.mcpConfigPath ? { mcpConfigPath: options.mcpConfigPath } : {}),
+    ...(options.mcpConfigFingerprint ? { mcpConfigFingerprint: options.mcpConfigFingerprint } : {}),
     permissionMode: options.permissionMode,
     nonInteractivePermissions: options.nonInteractivePermissions,
     authCredentials: options.authCredentials,

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -52,6 +52,8 @@ async function submitToRunningOwner(
     sessionId: options.sessionId,
     message: promptToDisplayText(options.prompt),
     prompt: options.prompt,
+    mcpConfigPath: options.mcpConfigPath,
+    mcpConfigFingerprint: options.mcpConfigFingerprint,
     permissionMode: options.permissionMode,
     nonInteractivePermissions: options.nonInteractivePermissions,
     permissionPolicy: options.permissionPolicy,
@@ -197,7 +199,10 @@ async function writeQueueOwnerLifecycleSnapshot(
 }
 
 export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): Promise<void> {
-  const lease = await tryAcquireQueueOwnerLease(options.sessionId);
+  const lease = await tryAcquireQueueOwnerLease(options.sessionId, {
+    path: options.mcpConfigPath,
+    fingerprint: options.mcpConfigFingerprint,
+  });
   if (!lease) {
     return;
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -134,6 +134,68 @@ test("loadResolvedConfig rejects invalid mcpServers config", async () => {
   });
 });
 
+test("loadResolvedConfig uses an explicit MCP config path without project config", async () => {
+  await withTempEnv(async ({ homeDir }) => {
+    const cwd = path.join(homeDir, "workspace");
+    const mcpConfigPath = path.join(homeDir, "job", "mcp.json");
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir(path.dirname(mcpConfigPath), { recursive: true });
+    await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(homeDir, ".acpx", "config.json"),
+      `${JSON.stringify(
+        {
+          mcpServers: [{ name: "global", type: "http", url: "https://global.example/mcp" }],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      mcpConfigPath,
+      `${JSON.stringify(
+        {
+          mcpServers: [{ name: "job", type: "stdio", command: "./bin/job-mcp" }],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const config = await loadResolvedConfig(cwd, {
+      mcpConfigPath: path.relative(cwd, mcpConfigPath),
+    });
+    assert.deepEqual(config.mcpServers, [
+      {
+        name: "job",
+        command: "./bin/job-mcp",
+        args: [],
+        env: [],
+        _meta: undefined,
+      },
+    ]);
+    assert.equal(config.mcpConfigPath, mcpConfigPath);
+  });
+});
+
+test("loadResolvedConfig rejects a missing explicit MCP config path", async () => {
+  await withTempEnv(async ({ homeDir }) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    await assert.rejects(
+      () =>
+        loadResolvedConfig(cwd, {
+          mcpConfigPath: "missing-mcp.json",
+        }),
+      /MCP config file not found: .*missing-mcp\.json/,
+    );
+  });
+});
+
 test("initGlobalConfigFile creates the config once and then reports existing file", async () => {
   await withTempEnv(async ({ homeDir }) => {
     const first = await initGlobalConfigFile();

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -178,6 +178,8 @@ test("loadResolvedConfig uses an explicit MCP config path without project config
       },
     ]);
     assert.equal(config.mcpConfigPath, mcpConfigPath);
+    assert.match(config.mcpConfigFingerprint ?? "", /^[a-f0-9]{64}$/);
+    assert(!/job-mcp/.test(config.mcpConfigFingerprint ?? ""));
   });
 });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -179,7 +179,7 @@ test("loadResolvedConfig uses an explicit MCP config path without project config
     ]);
     assert.equal(config.mcpConfigPath, mcpConfigPath);
     assert.match(config.mcpConfigFingerprint ?? "", /^[a-f0-9]{64}$/);
-    assert(!/job-mcp/.test(config.mcpConfigFingerprint ?? ""));
+    assert.equal((config.mcpConfigFingerprint ?? "").includes("job-mcp"), false);
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2236,6 +2236,97 @@ test("integration: configured mcpServers are sent to session/new and session/loa
   });
 });
 
+test("integration: --mcp-config loads session-scoped MCP servers", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-mcp-config-cwd-"));
+    const mcpConfigPath = path.join(homeDir, "job-mcp.json");
+    await fs.writeFile(
+      mcpConfigPath,
+      `${JSON.stringify(
+        {
+          mcpServers: [
+            {
+              name: "job-stdio",
+              type: "stdio",
+              command: "./bin/job-mcp",
+              args: ["--serve"],
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          MOCK_AGENT_COMMAND,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--mcp-config",
+          mcpConfigPath,
+          "--format",
+          "json",
+          "exec",
+          "echo mcp-config",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+      const messages = parseJsonRpcOutputLines(result.stdout);
+      const newSessionRequest = messages.find(
+        (message) => message.method === "session/new" && extractJsonRpcId(message) !== undefined,
+      );
+      assert(newSessionRequest, `expected session/new request in output:\n${result.stdout}`);
+      assert.deepEqual(
+        (newSessionRequest.params as { mcpServers?: unknown } | undefined)?.mcpServers,
+        [
+          {
+            name: "job-stdio",
+            command: "./bin/job-mcp",
+            args: ["--serve"],
+            env: [],
+          },
+        ],
+      );
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: prompt text after the command does not trigger --mcp-config loading", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-mcp-config-prompt-cwd-"));
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          MOCK_AGENT_COMMAND,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "exec",
+          "--",
+          "--mcp-config",
+          "missing-mcp.json",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /unrecognized prompt: --mcp-config missing-mcp\.json/);
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: prompt reconnect uses session/resume when advertised", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -751,7 +751,7 @@ test("trySubmitToRunningOwner clears stale owner lock on protocol mismatch", asy
   });
 });
 
-test("trySubmitToRunningOwner restarts an owner when MCP config contents change", async () => {
+test("trySubmitToRunningOwner rejects MCP config changes for a live owner", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "submit-mcp-config-owner-mismatch";
     const keeper = await startKeeperProcess();
@@ -766,18 +766,27 @@ test("trySubmitToRunningOwner restarts an owner when MCP config contents change"
     });
 
     try {
-      const outcome = await trySubmitToRunningOwner({
-        sessionId,
-        message: "hello",
-        mcpConfigPath: "/tmp/job-mcp.json",
-        mcpConfigFingerprint: "fingerprint-v2",
-        permissionMode: "approve-reads",
-        outputFormatter: NOOP_OUTPUT_FORMATTER,
-        waitForCompletion: true,
-      });
-      assert.equal(outcome, undefined);
-      await assert.rejects(fs.access(lockPath));
-      assert.equal(keeper.exitCode == null && keeper.signalCode == null, false);
+      await assert.rejects(
+        async () =>
+          await trySubmitToRunningOwner({
+            sessionId,
+            message: "hello",
+            mcpConfigPath: "/tmp/job-mcp.json",
+            mcpConfigFingerprint: "fingerprint-v2",
+            permissionMode: "approve-reads",
+            outputFormatter: NOOP_OUTPUT_FORMATTER,
+            waitForCompletion: true,
+          }),
+        (error: unknown) => {
+          assert(error instanceof QueueConnectionError);
+          assert.equal(error.detailCode, "QUEUE_MCP_CONFIG_CONFLICT");
+          assert.equal(error.retryable, false);
+          return true;
+        },
+      );
+      await fs.access(lockPath);
+      assert.equal(keeper.exitCode, null);
+      assert.equal(keeper.signalCode, null);
     } finally {
       await cleanupOwnerArtifacts({ socketPath, lockPath });
       stopProcess(keeper);

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -750,3 +750,37 @@ test("trySubmitToRunningOwner clears stale owner lock on protocol mismatch", asy
     }
   });
 });
+
+test("trySubmitToRunningOwner restarts an owner when MCP config contents change", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "submit-mcp-config-owner-mismatch";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+      mcpConfigPath: "/tmp/job-mcp.json",
+      mcpConfigFingerprint: "fingerprint-v1",
+    });
+
+    try {
+      const outcome = await trySubmitToRunningOwner({
+        sessionId,
+        message: "hello",
+        mcpConfigPath: "/tmp/job-mcp.json",
+        mcpConfigFingerprint: "fingerprint-v2",
+        permissionMode: "approve-reads",
+        outputFormatter: NOOP_OUTPUT_FORMATTER,
+        waitForCompletion: true,
+      });
+      assert.equal(outcome, undefined);
+      await assert.rejects(fs.access(lockPath));
+      assert.equal(keeper.exitCode == null && keeper.signalCode == null, false);
+    } finally {
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -793,3 +793,38 @@ test("trySubmitToRunningOwner rejects MCP config changes for a live owner", asyn
     }
   });
 });
+
+test("trySubmitToRunningOwner recovers stale owners before MCP conflict checks", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "submit-stale-mcp-config-owner";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+      mcpConfigPath: "/tmp/old-mcp.json",
+      mcpConfigFingerprint: "fingerprint-v1",
+      heartbeatAt: "2000-01-01T00:00:00.000Z",
+    });
+
+    try {
+      const outcome = await trySubmitToRunningOwner({
+        sessionId,
+        message: "hello",
+        mcpConfigPath: "/tmp/new-mcp.json",
+        mcpConfigFingerprint: "fingerprint-v2",
+        permissionMode: "approve-reads",
+        outputFormatter: NOOP_OUTPUT_FORMATTER,
+        waitForCompletion: true,
+      });
+      assert.equal(outcome, undefined);
+      await assert.rejects(fs.access(lockPath));
+      assert.equal(keeper.exitCode == null && keeper.signalCode == null, false);
+    } finally {
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -61,6 +61,43 @@ test("tryAcquireQueueOwnerLease creates a lease that can be refreshed and releas
   });
 });
 
+test("tryAcquireQueueOwnerLease persists MCP config path metadata", async () => {
+  await withTempHome(async () => {
+    const lease = await tryAcquireQueueOwnerLease("lease-mcp-config", {
+      path: "/tmp/job-mcp.json",
+      fingerprint: "fingerprint-v1",
+    });
+    assert(lease);
+    assert.equal(lease.mcpConfigPath, "/tmp/job-mcp.json");
+    assert.equal(lease.mcpConfigFingerprint, "fingerprint-v1");
+
+    const record = await readQueueOwnerRecord("lease-mcp-config");
+    assert(record);
+    assert.equal(record.mcpConfigPath, "/tmp/job-mcp.json");
+    assert.equal(record.mcpConfigFingerprint, "fingerprint-v1");
+
+    await refreshQueueOwnerLease(lease, { queueDepth: 2 });
+    const refreshed = await readQueueOwnerRecord("lease-mcp-config");
+    assert(refreshed);
+    assert.equal(refreshed.mcpConfigPath, "/tmp/job-mcp.json");
+    assert.equal(refreshed.mcpConfigFingerprint, "fingerprint-v1");
+
+    await releaseQueueOwnerLease(lease);
+  });
+});
+
+test("tryAcquireQueueOwnerLease preserves the legacy clock callback argument", async () => {
+  await withTempHome(async () => {
+    const lease = await tryAcquireQueueOwnerLease(
+      "lease-clock-callback",
+      () => "2026-03-26T00:00:00.000Z",
+    );
+    assert(lease);
+    assert.equal(lease.createdAt, "2026-03-26T00:00:00.000Z");
+    await releaseQueueOwnerLease(lease);
+  });
+});
+
 test("tryAcquireQueueOwnerLease assigns collision-resistant owner generations", async () => {
   await withTempHome(async () => {
     const originalDateNow = Date.now;

--- a/test/queue-owner-env.test.ts
+++ b/test/queue-owner-env.test.ts
@@ -12,6 +12,8 @@ describe("parseQueueOwnerPayload", () => {
       JSON.stringify({
         sessionId: "session-1",
         permissionMode: "approve-reads",
+        mcpConfigPath: "/tmp/job-mcp.json",
+        mcpConfigFingerprint: "fingerprint-v1",
         mcpServers: [
           {
             name: "linear-http",
@@ -38,6 +40,8 @@ describe("parseQueueOwnerPayload", () => {
     );
     assert.equal(parsed.sessionId, "session-1");
     assert.equal(parsed.permissionMode, "approve-reads");
+    assert.equal(parsed.mcpConfigPath, "/tmp/job-mcp.json");
+    assert.equal(parsed.mcpConfigFingerprint, "fingerprint-v1");
     assert.equal(parsed.ttlMs, 1234);
     assert.equal(parsed.maxQueueDepth, 7);
     assert.equal(parsed.terminal, false);

--- a/test/queue-test-helpers.ts
+++ b/test/queue-test-helpers.ts
@@ -56,6 +56,8 @@ export async function writeQueueOwnerLock(options: {
   socketPath: string;
   ownerGeneration?: number;
   queueDepth?: number;
+  mcpConfigPath?: string;
+  mcpConfigFingerprint?: string;
   createdAt?: string;
   heartbeatAt?: string;
 }): Promise<void> {
@@ -74,6 +76,10 @@ export async function writeQueueOwnerLock(options: {
       ownerGeneration:
         options.ownerGeneration ?? Date.now() * 1_000 + Math.floor(Math.random() * 1_000),
       queueDepth: options.queueDepth ?? 0,
+      ...(options.mcpConfigPath ? { mcpConfigPath: options.mcpConfigPath } : {}),
+      ...(options.mcpConfigFingerprint
+        ? { mcpConfigFingerprint: options.mcpConfigFingerprint }
+        : {}),
     })}\n`,
     "utf8",
   );


### PR DESCRIPTION
Fixes #387

Adds a global `--mcp-config <path>` option for loading session-scoped MCP servers without writing `<cwd>/.acpxrc.json`. The config replaces project/global `mcpServers` for that invocation and resolves relative paths from `--cwd`.

Persistent queue owners carry a path plus SHA-256 MCP fingerprint; live owners reject config changes without killing in-flight work, while stale owners are cleaned up before retry.

Validation:
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run check:docs`
- `pnpm run build:test`
- focused queue/config/integration tests
- autoreview clean
- `pnpm run check`: 799/799 tests pass; local Node 26 package-bin smoke still fails in upstream `yargs` with `require is not defined in ES module scope`.