### PR TITLE
chore(release): prepare acpx 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+### Breaking
+
+### Fixes
+
+## 2026.6.23 (v0.11.1)
+
+### Changes
+
 - Runtime/embedding: preserve per-agent environment variables across ACP session
   creation, queue handoff, persistence, and reconnects. Thanks @zhangguiping-xydt.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acpx",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Headless CLI client for the Agent Client Protocol (ACP) — talk to coding agents from the command line",
   "keywords": [
     "acp",


### PR DESCRIPTION
## Summary
- bump package version from 0.11.0 to 0.11.1
- promote the current Unreleased fixes and per-agent environment change into the 2026.6.23 release section
- leave Unreleased empty for follow-up work

## Validation
- `pnpm run check:docs` passed
- `pnpm run format:check`, `typecheck`, `lint`, `build`, `viewer:typecheck`, and `viewer:build` passed
- 822 tests passed during `pnpm run check`
- local coverage command reaches the known Node 26/yargs ESM loader failure after tests; release CI runs Node 24/22
- autoreview branch mode: clean, no accepted/actionable findings

This is a release-preparation PR. Tagging and publishing happen after merge.