### PR TITLE
docs: describe prompt response usage persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Runtime/status: persist token usage reported on successful prompt responses,
+  including adapters that only provide a sparse `usage_update`.
+
 ## 2026.6.23 (v0.11.1)
 
 ### Changes

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -99,10 +99,9 @@ export type AcpRuntimeUsageCost = {
 };
 
 /**
- * Per-turn token breakdown. Sourced from `UsageUpdate._meta.usage` on
- * adapters that populate it (Claude Code today; Codex and others may
- * omit it). All fields optional — consumers should treat missing
- * fields as "unknown", not "zero".
+ * Per-turn token breakdown. Sourced from final prompt response usage or
+ * `UsageUpdate._meta.usage` on adapters that populate it. All fields optional —
+ * consumers should treat missing fields as "unknown", not "zero".
  */
 export type AcpRuntimeUsageBreakdown = {
   inputTokens?: number;


### PR DESCRIPTION
Follow-up to #407 / #406.

Updates the public runtime contract and Unreleased changelog to document that persisted token breakdowns can come from successful prompt responses as well as `usage_update._meta.usage`.

Validation: format, typecheck, lint, build, and 824 tests pass; autoreview clean.