### PR TITLE
chore(release): prepare acpx 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Repo: https://github.com/openclaw/acpx
 
-## Unreleased
+## 2026.6.23 (v0.11.2)
 
 ### Changes
 
@@ -14,6 +14,14 @@ Repo: https://github.com/openclaw/acpx
 
 - Runtime/status: persist token usage reported on successful prompt responses,
   including adapters that only provide a sparse `usage_update`.
+
+## Unreleased
+
+### Changes
+
+### Breaking
+
+### Fixes
 
 ## 2026.6.23 (v0.11.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acpx",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Headless CLI client for the Agent Client Protocol (ACP) — talk to coding agents from the command line",
   "keywords": [
     "acp",


### PR DESCRIPTION
Release acpx 0.11.2 with the merged prompt-response token usage persistence fix from #407 and its public contract/changelog follow-up from #409.

Validation: format, typecheck, lint, build, viewer typecheck/build, 824 tests, and autoreview pass. Hosted CI is the final release gate.