### PR TITLE
ci: smooth conformance blacksmith runs

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: conformance-nightly-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: 24
@@ -96,6 +96,7 @@ jobs:
     continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.strict_real_adapters == 'true') }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - id: pi


### PR DESCRIPTION
## What changed
- cancel superseded Conformance Nightly runs for the same ref
- cap the optional real-adapter Blacksmith matrix to one concurrent runner

## Why
The org shares GitHub's runner-registration budget. ACPX is not a current load source, but this keeps the nightly/manual conformance workflow from contributing burst fanout during org-wide CI spikes.

## Evidence
- org workflow scan found the Blacksmith conformance workflow missing cancellation and matrix `max-parallel`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/conformance-nightly.yml`
- `git diff --check`
