### PR TITLE
fix(ci): pin pnpm to public npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
What Problem This Solves

Dependabot npm updates in openclaw/acpx were still failing during pnpm lockfile rewrites because the updater could resolve @types packages from npm.pkg.github.com and then report missing public versions there.

Why This Change Was Made

The existing dependabot.yml already pins Dependabot's registry to public npm. This adds the matching root .npmrc so the pnpm subprocess used by Dependabot resolves default and @types packages through registry.npmjs.org too.

User Impact

Daily Dependabot npm update runs should stop failing on public @types packages during lockfile updates.

Evidence

- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "yaml ok"'
- npm config --userconfig .npmrc get @types:registry
- git diff --check