### PR TITLE
fix(queue): don't orphan the agent bridge when the queue owner is terminated

### DIFF
--- a/src/cli/queue/ipc-server.ts
+++ b/src/cli/queue/ipc-server.ts
@@ -122,6 +122,7 @@ export class SessionQueueOwner {
   private readonly onQueueDepthChanged?: (queueDepth: number) => void;
   private readonly pending: QueueTask[] = [];
   private readonly waiters: Array<(task: QueueTask | undefined) => void> = [];
+  private readonly activeSockets = new Set<net.Socket>();
   private closed = false;
 
   private constructor(
@@ -194,6 +195,18 @@ export class SessionQueueOwner {
       task.close();
     }
     this.emitQueueDepth();
+
+    // Destroy tracked sockets so server.close() can resolve promptly even
+    // when a client is still connected (e.g. in waitForCompletion).  Without
+    // this, server.close() waits for all existing connections to drain;
+    // a connected client would block the drain past the external SIGKILL grace,
+    // letting terminateProcess() kill the owner before the bridge was killed.
+    // Clients already handle unexpected disconnects gracefully (the error is
+    // caught on the client side and converted to a retryable error).
+    for (const socket of this.activeSockets) {
+      socket.destroy();
+    }
+    this.activeSockets.clear();
 
     await new Promise<void>((resolve) => {
       this.server.close(() => resolve());
@@ -508,6 +521,11 @@ export class SessionQueueOwner {
 
   private handleConnection(socket: net.Socket): void {
     socket.setEncoding("utf8");
+
+    this.activeSockets.add(socket);
+    socket.once("close", () => {
+      this.activeSockets.delete(socket);
+    });
 
     if (this.closed) {
       writeQueueMessage(

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -5,7 +5,14 @@ import { queueBaseDir, queueLockFilePath, queueSocketBaseDir, queueSocketPath } 
 
 export { isProcessAlive } from "../../process-liveness.js";
 
-const PROCESS_EXIT_GRACE_MS = 1_500;
+// Budget for graceful SIGTERM shutdown of a queue-owner process.
+// The owner runs AcpClient.close() during shutdown:
+//   stdin-close grace (100 ms) + SIGTERM wait (1 500 ms) + SIGKILL wait (1 000 ms) = 2 600 ms worst case.
+// We add ~1 400 ms of headroom for event-loop latency and process startup overhead → 4 000 ms.
+// If the owner does not exit within this window we escalate to SIGKILL.
+const PROCESS_SIGTERM_GRACE_MS = 4_000;
+// After SIGKILL the OS terminates the process almost immediately; 1 500 ms is generous.
+const PROCESS_SIGKILL_GRACE_MS = 1_500;
 const PROCESS_POLL_MS = 50;
 const QUEUE_OWNER_STALE_HEARTBEAT_MS = 15_000;
 
@@ -203,7 +210,7 @@ export async function terminateProcess(pid: number): Promise<boolean> {
     return false;
   }
 
-  if (await waitForProcessExit(pid, PROCESS_EXIT_GRACE_MS)) {
+  if (await waitForProcessExit(pid, PROCESS_SIGTERM_GRACE_MS)) {
     return true;
   }
 
@@ -213,7 +220,7 @@ export async function terminateProcess(pid: number): Promise<boolean> {
     return false;
   }
 
-  await waitForProcessExit(pid, PROCESS_EXIT_GRACE_MS);
+  await waitForProcessExit(pid, PROCESS_SIGKILL_GRACE_MS);
   return true;
 }
 

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -255,23 +255,25 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     }
   };
 
-  // Idempotent shutdown: safe to invoke from both the signal handler (via
-  // withInterrupt's onInterrupt callback) and the finally block below.
-  let closeStarted = false;
-  const doShutdown = async (): Promise<void> => {
-    if (closeStarted) {
-      return;
+  // Shared-promise shutdown: both the signal handler (withInterrupt's
+  // onInterrupt callback) and the finally block below call doShutdown().
+  // Using a shared promise means the second caller awaits the SAME cleanup
+  // instead of returning immediately, so runSessionQueueOwner never returns
+  // before releaseQueueOwnerLease has executed.
+  let shutdownPromise: Promise<void> | null = null;
+  const doShutdown = (): Promise<void> => {
+    if (!shutdownPromise) {
+      shutdownPromise = closeQueueOwnerRuntime({
+        lease,
+        owner,
+        heartbeatTimer,
+        turnController,
+        sharedClient,
+        sessionId: options.sessionId,
+        verbose: options.verbose,
+      });
     }
-    closeStarted = true;
-    await closeQueueOwnerRuntime({
-      lease,
-      owner,
-      heartbeatTimer,
-      turnController,
-      sharedClient,
-      sessionId: options.sessionId,
-      verbose: options.verbose,
-    });
+    return shutdownPromise;
   };
 
   try {

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -174,10 +174,21 @@ async function closeQueueOwnerRuntime(params: {
     clearInterval(params.heartbeatTimer);
   }
   params.turnController.beginClosing();
-  await params.owner?.close();
+  // Kill the bridge first — invariant: the bridge must never outlive the owner.
+  // The old order (owner.close() then sharedClient.close()) was wrong:
+  // owner.close() calls server.close() which waits for all active client
+  // sockets to drain.  A client in waitForCompletion that stayed connected
+  // would block the drain past the external 4 s SIGKILL grace period, so
+  // terminateProcess() would SIGKILL the owner before sharedClient.close()
+  // (which calls terminateAgentProcess) had a chance to run — orphaning the
+  // bridge.  By closing the bridge first we guarantee it is killed regardless
+  // of how long the IPC-server drain takes.
   await params.sharedClient.close().catch(() => {
     // best effort while queue owner is shutting down
   });
+  // SessionQueueOwner.close() now also destroys tracked client sockets so
+  // server.close() resolves promptly even when a client is still connected.
+  await params.owner?.close();
   await writeQueueOwnerLifecycleSnapshot(params.sessionId, params.sharedClient);
   await releaseQueueOwnerLease(params.lease);
   if (params.verbose) {

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -1,6 +1,6 @@
 import { AcpClient } from "../../acp/client.js";
 import { formatErrorMessage } from "../../acp/error-normalization.js";
-import { withTimeout } from "../../async-control.js";
+import { InterruptedError, withInterrupt, withTimeout } from "../../async-control.js";
 import { checkpointPerfMetricsCapture } from "../../perf-metrics-capture.js";
 import { setPerfGauge } from "../../perf-metrics.js";
 import { promptToDisplayText } from "../../prompt-content.js";
@@ -255,88 +255,14 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     }
   };
 
-  try {
-    owner = await SessionQueueOwner.start(
-      lease,
-      {
-        cancelPrompt: async () => {
-          const accepted = await turnController.requestCancel();
-          if (!accepted) {
-            return false;
-          }
-          await applyPendingCancel();
-          return true;
-        },
-        closeSession: async (timeoutMs?: number) => await closeActiveBackendSession(timeoutMs),
-        setSessionMode: async (modeId: string, timeoutMs?: number) => {
-          await turnController.setSessionMode(modeId, timeoutMs);
-        },
-        setSessionModel: async (modelId: string, timeoutMs?: number) =>
-          await turnController.setSessionModel(modelId, timeoutMs),
-        setSessionConfigOption: async (configId: string, value: string, timeoutMs?: number) => {
-          return await turnController.setSessionConfigOption(configId, value, timeoutMs);
-        },
-      },
-      {
-        maxQueueDepth,
-        onQueueDepthChanged: (queueDepth) => {
-          setPerfGauge("queue.owner.depth", queueDepth);
-          void refreshQueueOwnerLease(lease, { queueDepth }).catch(() => {
-            // best effort heartbeat refresh while owner is live
-          });
-        },
-      },
-    );
-
-    logQueueOwnerReady({
-      sessionId: options.sessionId,
-      ttlMs,
-      maxQueueDepth,
-      verbose: options.verbose,
-    });
-    await refreshQueueOwnerLease(lease, { queueDepth: owner.queueDepth() }).catch(() => {
-      // best effort initial heartbeat
-    });
-    heartbeatTimer = setInterval(() => {
-      void refreshQueueOwnerLease(lease, { queueDepth: owner?.queueDepth() ?? 0 }).catch(() => {
-        // best effort heartbeat
-      });
-    }, QUEUE_OWNER_HEARTBEAT_INTERVAL_MS);
-
-    let isFirstTask = true;
-    while (true) {
-      const pollTimeoutMs = isFirstTask ? initialTaskPollTimeoutMs : taskPollTimeoutMs;
-      const task = await owner.nextTask(pollTimeoutMs);
-      if (!task) {
-        break;
-      }
-      isFirstTask = false;
-
-      await runPromptTurn(async () => {
-        try {
-          await runQueuedTask(options.sessionId, task, {
-            sharedClient,
-            verbose: options.verbose,
-            mcpServers: options.mcpServers,
-            nonInteractivePermissions: options.nonInteractivePermissions,
-            authCredentials: options.authCredentials,
-            authPolicy: options.authPolicy,
-            suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
-            promptRetries: task.promptRetries ?? 0,
-            sessionOptions: options.sessionOptions,
-            onClientAvailable: setActiveController,
-            onClientClosed: clearActiveController,
-            onPromptActive: async () => {
-              turnController.markPromptActive();
-              await applyPendingCancel();
-            },
-          });
-        } finally {
-          checkpointPerfMetricsCapture();
-        }
-      });
+  // Idempotent shutdown: safe to invoke from both the signal handler (via
+  // withInterrupt's onInterrupt callback) and the finally block below.
+  let closeStarted = false;
+  const doShutdown = async (): Promise<void> => {
+    if (closeStarted) {
+      return;
     }
-  } finally {
+    closeStarted = true;
     await closeQueueOwnerRuntime({
       lease,
       owner,
@@ -346,6 +272,107 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
       sessionId: options.sessionId,
       verbose: options.verbose,
     });
+  };
+
+  try {
+    // withInterrupt installs SIGTERM/SIGINT/SIGHUP handlers and calls
+    // doShutdown when any of them fires, before rejecting with
+    // InterruptedError.  Without this, a SIGTERM from lease-store's
+    // terminateProcess() would kill the Node process immediately,
+    // bypassing the finally block and leaving the bridge adapter orphaned.
+    await withInterrupt(async () => {
+      owner = await SessionQueueOwner.start(
+        lease,
+        {
+          cancelPrompt: async () => {
+            const accepted = await turnController.requestCancel();
+            if (!accepted) {
+              return false;
+            }
+            await applyPendingCancel();
+            return true;
+          },
+          closeSession: async (timeoutMs?: number) => await closeActiveBackendSession(timeoutMs),
+          setSessionMode: async (modeId: string, timeoutMs?: number) => {
+            await turnController.setSessionMode(modeId, timeoutMs);
+          },
+          setSessionModel: async (modelId: string, timeoutMs?: number) =>
+            await turnController.setSessionModel(modelId, timeoutMs),
+          setSessionConfigOption: async (configId: string, value: string, timeoutMs?: number) => {
+            return await turnController.setSessionConfigOption(configId, value, timeoutMs);
+          },
+        },
+        {
+          maxQueueDepth,
+          onQueueDepthChanged: (queueDepth) => {
+            setPerfGauge("queue.owner.depth", queueDepth);
+            void refreshQueueOwnerLease(lease, { queueDepth }).catch(() => {
+              // best effort heartbeat refresh while owner is live
+            });
+          },
+        },
+      );
+
+      logQueueOwnerReady({
+        sessionId: options.sessionId,
+        ttlMs,
+        maxQueueDepth,
+        verbose: options.verbose,
+      });
+      await refreshQueueOwnerLease(lease, { queueDepth: owner.queueDepth() }).catch(() => {
+        // best effort initial heartbeat
+      });
+      heartbeatTimer = setInterval(() => {
+        void refreshQueueOwnerLease(lease, { queueDepth: owner?.queueDepth() ?? 0 }).catch(() => {
+          // best effort heartbeat
+        });
+      }, QUEUE_OWNER_HEARTBEAT_INTERVAL_MS);
+
+      let isFirstTask = true;
+      while (true) {
+        const pollTimeoutMs = isFirstTask ? initialTaskPollTimeoutMs : taskPollTimeoutMs;
+        const task = await owner.nextTask(pollTimeoutMs);
+        if (!task) {
+          break;
+        }
+        isFirstTask = false;
+
+        await runPromptTurn(async () => {
+          try {
+            await runQueuedTask(options.sessionId, task, {
+              sharedClient,
+              verbose: options.verbose,
+              mcpServers: options.mcpServers,
+              nonInteractivePermissions: options.nonInteractivePermissions,
+              authCredentials: options.authCredentials,
+              authPolicy: options.authPolicy,
+              suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
+              promptRetries: task.promptRetries ?? 0,
+              sessionOptions: options.sessionOptions,
+              onClientAvailable: setActiveController,
+              onClientClosed: clearActiveController,
+              onPromptActive: async () => {
+                turnController.markPromptActive();
+                await applyPendingCancel();
+              },
+            });
+          } finally {
+            checkpointPerfMetricsCapture();
+          }
+        });
+      }
+    }, doShutdown);
+  } catch (error) {
+    if (!(error instanceof InterruptedError)) {
+      throw error;
+    }
+    // SIGTERM/SIGINT/SIGHUP received — graceful shutdown already completed
+    // by doShutdown() inside withInterrupt's onInterrupt callback.
+  } finally {
+    // Idempotent: if doShutdown() already ran via the signal path, this is
+    // a no-op.  If the main loop exited normally or with an error, this
+    // ensures cleanup still happens.
+    await doShutdown();
   }
 }
 

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -67,6 +67,8 @@ type MockAgentOptions = {
   replayLoadSessionUpdates: boolean;
   loadReplayText: string;
   ignoreSigterm: boolean;
+  /** If set, the agent writes its PID to this path at startup (before ACP handshake). */
+  pidFile?: string;
 };
 
 type SessionState = {
@@ -375,6 +377,7 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let loadReplayText = "replayed load session update";
   let ignoreSigterm = false;
   let hangOnNewSession = false;
+  let pidFile: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -513,6 +516,12 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       continue;
     }
 
+    if (token === "--pid-file") {
+      pidFile = parseOptionValue(argv, index + 1, token);
+      index += 1;
+      continue;
+    }
+
     if (token === "--claude-agent-acp") {
       continue;
     }
@@ -578,6 +587,7 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     replayLoadSessionUpdates,
     loadReplayText,
     ignoreSigterm,
+    pidFile,
   };
 }
 
@@ -1458,6 +1468,12 @@ const output = Writable.toWeb(process.stdout);
 const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
 const stream = ndJsonStream(output, input);
 const mockAgentOptions = parseMockAgentOptions(process.argv.slice(2));
+
+// Write PID to a file before doing anything else so that the parent can track
+// this bridge process and verify it is dead after queue-owner shutdown.
+if (mockAgentOptions.pidFile) {
+  writeFileSync(mockAgentOptions.pidFile, `${process.pid}\n`, "utf8");
+}
 
 if (mockAgentOptions.ignoreSigterm) {
   process.on("SIGTERM", () => {

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
@@ -286,4 +288,81 @@ test("terminateProcess and terminateQueueOwnerForSession handle live and missing
       stopProcess(keeper);
     }
   });
+});
+
+test("terminateProcess waits long enough for a process that delays 2s before exiting on SIGTERM", async () => {
+  // Regression test for the SIGTERM grace-period mismatch.
+  //
+  // A queue-owner's AcpClient.close() can take up to ~2 600 ms (stdin-close
+  // 100 ms + SIGTERM wait 1 500 ms + SIGKILL wait 1 000 ms).  The old
+  // PROCESS_EXIT_GRACE_MS of 1 500 ms would SIGKILL the owner before it
+  // finished closing its bridge.  PROCESS_SIGTERM_GRACE_MS = 4 000 ms gives
+  // sufficient headroom.
+  //
+  // This test spawns a Node.js process that defers its exit by 2 000 ms after
+  // receiving SIGTERM and verifies that terminateProcess() returns true without
+  // needing to escalate to SIGKILL (i.e. the process exits on its own within
+  // the 4 s window).
+  if (process.platform === "win32") {
+    // SIGTERM semantics differ on Windows.
+    return;
+  }
+
+  // The child writes "ready\n" to stderr once its SIGTERM handler is installed.
+  // We wait for that line before sending SIGTERM to avoid the race where the
+  // signal arrives before the handler is registered.
+  const script = `
+    process.on('SIGTERM', () => {
+      setTimeout(() => process.exit(0), 2_000);
+    });
+    process.stderr.write('ready\\n');
+    // Keep the event loop alive until SIGTERM arrives.
+    setInterval(() => {}, 60_000);
+  `;
+
+  const child = spawn(process.execPath, ["-e", script], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+
+  // Wait for the "ready" signal before sending SIGTERM.
+  await new Promise<void>((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString();
+      if (buf.includes("ready")) {
+        child.stderr?.off("data", onData);
+        resolve();
+      }
+    };
+    child.stderr?.on("data", onData);
+    child.once("exit", () => reject(new Error("child exited before signalling ready")));
+  });
+
+  assert(child.pid, "child must have a pid");
+
+  try {
+    assert.equal(isProcessAlive(child.pid), true, "child must be alive before terminateProcess");
+    const result = await terminateProcess(child.pid);
+    assert.equal(result, true, "terminateProcess must return true");
+    assert.equal(isProcessAlive(child.pid), false, "process must be dead after terminateProcess");
+
+    // Wait for the ChildProcess object to pick up the close event so that
+    // exitCode / signalCode are populated.
+    if (child.exitCode == null && child.signalCode == null) {
+      await once(child, "close");
+    }
+
+    // The process should have exited with code 0 (clean exit via setTimeout),
+    // not killed by a signal, proving the 4 s SIGTERM grace was enough.
+    assert.equal(
+      child.signalCode,
+      null,
+      `process should have exited cleanly, not via signal ${child.signalCode}`,
+    );
+    assert.equal(child.exitCode, 0, "process must exit with code 0");
+  } finally {
+    if (child.exitCode == null && child.signalCode == null) {
+      child.kill("SIGKILL");
+    }
+  }
 });

--- a/test/queue-owner-lifecycle.test.ts
+++ b/test/queue-owner-lifecycle.test.ts
@@ -11,9 +11,12 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
+import readline from "node:readline";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
+import { isProcessAlive } from "../src/cli/queue/lease-store.js";
 import { queueLockFilePath, queueSocketPath } from "../src/cli/queue/paths.js";
 import { makeSessionRecord, withTempHome, writeSessionRecordFile } from "./runtime-test-helpers.js";
 
@@ -299,6 +302,146 @@ describe("queue owner lifecycle — graceful SIGTERM shutdown", () => {
           "lock file must be gone after graceful shutdown — shared shutdown promise was not awaited",
         );
       } finally {
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+});
+
+describe("queue owner lifecycle — bridge process death on SIGTERM", () => {
+  // Verifies that when the queue owner is SIGTERMed while a prompt is in
+  // flight, the agent bridge process (mock-agent) is also killed by the
+  // queue owner's graceful shutdown before it exits.
+  //
+  // This test catches the race that existed before the SIGTERM grace-period
+  // fix: terminateProcess() used a 1 500 ms SIGTERM grace, but AcpClient.close()
+  // can take up to ~2 600 ms.  With the old grace the queue owner could be
+  // SIGKILLed before it finished killing the bridge, leaving it orphaned.
+  it("kills the agent bridge when the queue owner receives SIGTERM mid-prompt", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-bridge-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      // PID file: mock-agent writes its PID here as soon as it starts, before
+      // the ACP handshake.  We poll for it to know the bridge is live.
+      const pidFilePath = path.join(homeDir, "mock-agent.pid");
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-bridge-test",
+        acpSessionId: "lifecycle-bridge-session",
+        // Pass --pid-file so the bridge records its PID at startup.
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --pid-file ${JSON.stringify(pidFilePath)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      let queueSocket: net.Socket | undefined;
+
+      try {
+        // Wait for the queue owner socket — signal handlers are live at this point.
+        await waitUntil(() => fileExists(socketPath));
+
+        // Connect to the queue-owner socket and submit a long-running prompt.
+        // "sleep 10000" keeps the bridge busy for 10 s so it is still alive
+        // when we send SIGTERM to the queue owner.
+        queueSocket = await new Promise<net.Socket>((resolve, reject) => {
+          const s = net.createConnection(socketPath);
+          s.setEncoding("utf8");
+          s.once("connect", () => resolve(s));
+          s.once("error", reject);
+        });
+
+        queueSocket.write(
+          `${JSON.stringify({
+            type: "submit_prompt",
+            requestId: "req-bridge-test",
+            message: "sleep 10000",
+            permissionMode: "approve-reads",
+            waitForCompletion: true,
+          })}\n`,
+        );
+
+        // Read the "accepted" acknowledgement.
+        const lines = readline.createInterface({ input: queueSocket });
+        const iter = lines[Symbol.asyncIterator]();
+        const acceptedRaw = await Promise.race([
+          iter.next(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout waiting for accepted")), 5_000),
+          ),
+        ]);
+        const accepted = JSON.parse((acceptedRaw as IteratorYieldResult<string>).value) as {
+          type: string;
+        };
+        assert.equal(accepted.type, "accepted", "queue owner must acknowledge the prompt");
+
+        // Close the readline and socket BEFORE sending SIGTERM.
+        // SessionQueueOwner.close() calls net.Server.close() which waits for
+        // all existing connections to drain before resolving.  Leaving this
+        // socket open would stall the queue-owner's graceful shutdown forever.
+        lines.close();
+        queueSocket.destroy();
+        queueSocket = undefined;
+
+        // Wait for the bridge to write its PID — this confirms the bridge
+        // process has been spawned and the ACP handshake has started.
+        await waitUntil(() => fileExists(pidFilePath), 8_000);
+
+        const bridgePidRaw = (await fs.readFile(pidFilePath, "utf8")).trim();
+        const bridgePid = Number(bridgePidRaw);
+        assert(
+          Number.isInteger(bridgePid) && bridgePid > 0,
+          "bridge PID must be a positive integer",
+        );
+        assert.equal(isProcessAlive(bridgePid), true, "bridge must be alive before SIGTERM");
+
+        // Signal the queue owner to shut down gracefully.
+        child.kill("SIGTERM");
+
+        const { code, signal } = await waitForProcessExit(child, 10_000);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `queue owner should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected queue owner exit code 0 (graceful); stderr=${stderr}`);
+
+        // After the queue owner exits, the bridge must also be dead.
+        // AcpClient.close() kills the bridge before releasing the lease.
+        assert.equal(
+          isProcessAlive(bridgePid),
+          false,
+          "bridge process must be dead after queue owner graceful shutdown — was it orphaned?",
+        );
+      } finally {
+        queueSocket?.destroy();
         if (child.exitCode == null && child.signalCode == null) {
           child.kill("SIGKILL");
         }

--- a/test/queue-owner-lifecycle.test.ts
+++ b/test/queue-owner-lifecycle.test.ts
@@ -36,7 +36,9 @@ async function waitUntil(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await condition()) {return;}
+    if (await condition()) {
+      return;
+    }
     await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
   }
   throw new Error(`Condition not met within ${timeoutMs}ms`);
@@ -59,6 +61,15 @@ function waitForProcessExit(
 }
 
 describe("queue owner lifecycle — graceful SIGTERM shutdown", () => {
+  // Implementation note: doShutdown() uses a shared Promise (not a boolean
+  // flag) so that both the signal handler (withInterrupt's onInterrupt
+  // callback) and the finally block await the SAME cleanup.  With a boolean
+  // flag the finally block would return immediately while cleanup was still
+  // in progress, causing runSessionQueueOwner to return before
+  // releaseQueueOwnerLease executed (floating promise / orphaned lock file).
+  // The tests below verify the lock file is gone synchronously after process
+  // exit, which only holds if both callers fully awaited cleanup.
+
   it("exits with code 0 and releases its lease when it receives SIGTERM", async () => {
     if (process.platform === "win32") {
       // SIGTERM semantics differ on Windows; skip this test.
@@ -200,6 +211,92 @@ describe("queue owner lifecycle — graceful SIGTERM shutdown", () => {
           await fileExists(lockPath),
           false,
           "lock file must be gone after graceful shutdown — lease was not released",
+        );
+      } finally {
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("releases lease even when doShutdown is invoked concurrently from signal and finally block", async () => {
+    // Regression test for the shared-promise fix.
+    //
+    // SIGTERM fires while the queue owner is in nextTask().  withInterrupt's
+    // onInterrupt callback calls doShutdown() (first invocation), which
+    // starts closeQueueOwnerRuntime().  The resulting InterruptedError is
+    // then caught, the finally block runs, and it calls doShutdown() again
+    // (second invocation).
+    //
+    // With the old boolean guard the second invocation returned immediately
+    // without awaiting the in-progress cleanup.  runSessionQueueOwner could
+    // therefore return before releaseQueueOwnerLease had run, leaving the
+    // lock file on disk.
+    //
+    // With the shared-promise fix both invocations await the same Promise,
+    // so the process only exits after cleanup is fully complete.
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-concurrent-shutdown-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-concurrent-shutdown-test",
+        acpSessionId: "lifecycle-concurrent-shutdown-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      try {
+        // Wait until the owner is inside nextTask() — signal handlers live.
+        await waitUntil(() => fileExists(socketPath));
+
+        assert.equal(await fileExists(lockPath), true, "lock file must exist before SIGTERM");
+
+        // Send SIGTERM — this triggers the concurrent doShutdown scenario.
+        child.kill("SIGTERM");
+
+        const { code, signal } = await waitForProcessExit(child);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `process should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected exit code 0 (graceful); stderr=${stderr}`);
+
+        // Lock file must be gone immediately after process exit — not
+        // eventually.  A floating cleanup promise would leave it on disk.
+        assert.equal(
+          await fileExists(lockPath),
+          false,
+          "lock file must be gone after graceful shutdown — shared shutdown promise was not awaited",
         );
       } finally {
         if (child.exitCode == null && child.signalCode == null) {

--- a/test/queue-owner-lifecycle.test.ts
+++ b/test/queue-owner-lifecycle.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests that the queue owner runtime shuts down gracefully on SIGTERM/SIGINT,
+ * so the codex-acp bridge adapter is never orphaned.
+ *
+ * See: src/cli/session/queue-owner-runtime.ts — the `runSessionQueueOwner`
+ * function previously had no signal handlers; SIGTERM from lease-store's
+ * terminateProcess() killed the Node process before the `finally` block could
+ * run closeQueueOwnerRuntime(), leaving bridge adapters orphaned.
+ */
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { queueLockFilePath, queueSocketPath } from "../src/cli/queue/paths.js";
+import { makeSessionRecord, withTempHome, writeSessionRecordFile } from "./runtime-test-helpers.js";
+
+const CLI_PATH = fileURLToPath(new URL("../src/cli.js", import.meta.url));
+const MOCK_AGENT_PATH = fileURLToPath(new URL("./mock-agent.js", import.meta.url));
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs = 6_000,
+  pollMs = 50,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) {return;}
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+function waitForProcessExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs = 8_000,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Queue owner process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe("queue owner lifecycle — graceful SIGTERM shutdown", () => {
+  it("exits with code 0 and releases its lease when it receives SIGTERM", async () => {
+    if (process.platform === "win32") {
+      // SIGTERM semantics differ on Windows; skip this test.
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-sigterm-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      // A minimal session record — the queue owner reads it during startup.
+      // The agent bridge is only spawned when the first prompt is run, so
+      // we just need any plausible agentCommand to pass startup validation.
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-sigterm-test",
+        acpSessionId: "lifecycle-sigterm-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      // The socket file is created inside withInterrupt's `run()` callback
+      // (by SessionQueueOwner.start()), which executes AFTER withInterrupt has
+      // installed SIGTERM/SIGINT/SIGHUP handlers.  Waiting for the socket
+      // avoids the race where the lock file exists but handlers aren't yet live.
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      // Queue owner payload — no ttlMs so it waits indefinitely for tasks.
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      try {
+        // Wait until the queue owner has created its Unix socket — at this
+        // point SessionQueueOwner.start() has returned, meaning withInterrupt
+        // has already installed the signal handlers and we're inside nextTask().
+        await waitUntil(() => fileExists(socketPath));
+
+        // Confirm the lock file is present before sending the signal.
+        assert.equal(await fileExists(lockPath), true, "lock file must exist before SIGTERM");
+
+        // Signal graceful shutdown.
+        child.kill("SIGTERM");
+
+        const { code, signal } = await waitForProcessExit(child);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        // Graceful shutdown: exit code 0, not killed by a signal.
+        assert.equal(
+          signal,
+          null,
+          `process should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected exit code 0 (graceful); stderr=${stderr}`);
+
+        // The lease must have been released: no orphaned lock file.
+        assert.equal(
+          await fileExists(lockPath),
+          false,
+          "lock file must be gone after graceful shutdown — lease was not released",
+        );
+      } finally {
+        // Safety net: kill the child if the test fails mid-way.
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("exits with code 0 and releases its lease when it receives SIGINT", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-sigint-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-sigint-test",
+        acpSessionId: "lifecycle-sigint-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      try {
+        // Wait for the socket — signal handlers are live at this point.
+        await waitUntil(() => fileExists(socketPath));
+
+        child.kill("SIGINT");
+
+        const { code, signal } = await waitForProcessExit(child);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `process should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected exit code 0 (graceful); stderr=${stderr}`);
+
+        assert.equal(
+          await fileExists(lockPath),
+          false,
+          "lock file must be gone after graceful shutdown — lease was not released",
+        );
+      } finally {
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+});

--- a/test/queue-owner-lifecycle.test.ts
+++ b/test/queue-owner-lifecycle.test.ts
@@ -400,10 +400,11 @@ describe("queue owner lifecycle — bridge process death on SIGTERM", () => {
         };
         assert.equal(accepted.type, "accepted", "queue owner must acknowledge the prompt");
 
-        // Close the readline and socket BEFORE sending SIGTERM.
-        // SessionQueueOwner.close() calls net.Server.close() which waits for
-        // all existing connections to drain before resolving.  Leaving this
-        // socket open would stall the queue-owner's graceful shutdown forever.
+        // Close the readline and socket before sending SIGTERM.
+        // (This was previously required to prevent a deadlock — server.close()
+        // waited for connected sockets to drain — but is now just one of two
+        // test scenarios; the companion test verifies the fix when the socket
+        // stays open.)
         lines.close();
         queueSocket.destroy();
         queueSocket = undefined;
@@ -440,6 +441,152 @@ describe("queue owner lifecycle — bridge process death on SIGTERM", () => {
           false,
           "bridge process must be dead after queue owner graceful shutdown — was it orphaned?",
         );
+      } finally {
+        queueSocket?.destroy();
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("kills the bridge and exits gracefully when a client socket stays open during SIGTERM", async () => {
+    // Regression test for the connected-client deadlock.
+    //
+    // Before the fix:
+    //   closeQueueOwnerRuntime called owner.close() first, which called
+    //   server.close().  server.close() waits for all existing connections to
+    //   drain.  A client in waitForCompletion that never closed its socket
+    //   kept the drain blocked past the external 4 s SIGKILL grace period;
+    //   terminateProcess() then SIGKILLed the owner before sharedClient.close()
+    //   ran — leaving the bridge orphaned.
+    //
+    // After the fix:
+    //   sharedClient.close() (kills bridge) runs BEFORE owner.close() (drains
+    //   IPC server), and SessionQueueOwner.close() destroys tracked sockets so
+    //   server.close() does not block even if the client socket is still open.
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-bridge-open-socket-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const pidFilePath = path.join(homeDir, "mock-agent-open.pid");
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-bridge-open-socket-test",
+        acpSessionId: "lifecycle-bridge-open-socket-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --pid-file ${JSON.stringify(pidFilePath)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      // This socket intentionally stays open (not destroyed before SIGTERM)
+      // to reproduce the deadlock that existed before the fix.
+      let queueSocket: net.Socket | undefined;
+
+      try {
+        await waitUntil(() => fileExists(socketPath));
+
+        queueSocket = await new Promise<net.Socket>((resolve, reject) => {
+          const s = net.createConnection(socketPath);
+          s.setEncoding("utf8");
+          s.once("connect", () => resolve(s));
+          s.once("error", reject);
+        });
+
+        queueSocket.write(
+          `${JSON.stringify({
+            type: "submit_prompt",
+            requestId: "req-open-socket-test",
+            message: "sleep 10000",
+            permissionMode: "approve-reads",
+            waitForCompletion: true,
+          })}\n`,
+        );
+
+        // Read the "accepted" acknowledgement.
+        const lines = readline.createInterface({ input: queueSocket });
+        const iter = lines[Symbol.asyncIterator]();
+        const acceptedRaw = await Promise.race([
+          iter.next(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout waiting for accepted")), 5_000),
+          ),
+        ]);
+        const accepted = JSON.parse((acceptedRaw as IteratorYieldResult<string>).value) as {
+          type: string;
+        };
+        assert.equal(accepted.type, "accepted", "queue owner must acknowledge the prompt");
+
+        // Deliberately do NOT close the readline or socket here.
+        // The fix must handle this — the socket remaining open must not block
+        // the bridge kill or prevent the owner from exiting within the grace period.
+
+        // Wait until the bridge has written its PID — ACP handshake started.
+        await waitUntil(() => fileExists(pidFilePath), 8_000);
+
+        const bridgePidRaw = (await fs.readFile(pidFilePath, "utf8")).trim();
+        const bridgePid = Number(bridgePidRaw);
+        assert(
+          Number.isInteger(bridgePid) && bridgePid > 0,
+          "bridge PID must be a positive integer",
+        );
+        assert.equal(isProcessAlive(bridgePid), true, "bridge must be alive before SIGTERM");
+
+        // Send SIGTERM — the external grace is 4 s (lease-store terminateProcess).
+        // The owner must exit before that deadline even though the client socket
+        // is still open.
+        child.kill("SIGTERM");
+
+        // Tight budget: the owner must finish within the 4 s external grace.
+        const { code, signal } = await waitForProcessExit(child, 8_000);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `queue owner should not have been killed by a signal — it likely stalled past the grace period; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected queue owner exit code 0 (graceful); stderr=${stderr}`);
+
+        // Bridge must be dead — it must not have been orphaned.
+        assert.equal(
+          isProcessAlive(bridgePid),
+          false,
+          "bridge process must be dead after queue owner graceful shutdown — was it orphaned? (connected-client deadlock regression)",
+        );
+
+        // Lock file must be released.
+        assert.equal(
+          await fileExists(lockPath),
+          false,
+          "lock file must be gone after graceful shutdown",
+        );
+
+        lines.close();
       } finally {
         queueSocket?.destroy();
         if (child.exitCode == null && child.signalCode == null) {


### PR DESCRIPTION

## Problem

When the queue owner process is terminated — SIGTERM from `terminateProcess`
in `lease-store`, or Ctrl-C/SIGINT — the `codex-acp` (or any) bridge adapter it
spawned can be left as an **orphaned child process**, accumulating across runs
until the agent app-server chokes and new sessions hang at `session/new`.

43013ea (which correctly preserves ACP session details and closes active owners)
addresses the **ACP session** lifecycle; the **OS-process** lifecycle of the
bridge is a separate issue, with three parts:

1. **No signal handler on the queue owner.** A SIGTERM killed the Node process
   immediately, bypassing the `finally` block, so `closeQueueOwnerRuntime()`
   (which kills the bridge via `sharedClient.close()`) never ran.
2. **Wrong shutdown order.** `owner.close()` (which `server.close()`s and waits
   for connected IPC client sockets to drain) ran *before* `sharedClient.close()`.
   A client parked in `waitForCompletion` kept its socket open, blocking the
   drain past the external SIGKILL grace — so the owner was SIGKILLed before it
   could kill the bridge.
3. **SIGTERM grace too short.** `terminateProcess` allowed 1.5 s, but a graceful
   `AcpClient.close()` needs ~2.6 s worst case (stdin-close 100 ms + SIGTERM
   1.5 s + SIGKILL 1 s).

## Fix

- Wrap the queue-owner main loop in `withInterrupt(...)`, installing
  SIGTERM/SIGINT/SIGHUP handlers that run graceful shutdown *before* the process
  exits.
- Share a single idempotent `shutdownPromise` between the signal path and the
  `finally` block, so `runSessionQueueOwner` never returns before
  `releaseQueueOwnerLease` completes.
- Reorder shutdown to **kill the bridge first**, then close the owner —
  invariant: *the bridge must never outlive the owner*. `SessionQueueOwner.close()`
  now also destroys tracked client sockets so `server.close()` resolves promptly
  even with a client still connected (clients already treat an unexpected
  disconnect as retryable).
- Raise the external SIGTERM grace to 4 s to cover the graceful-close budget with
  headroom.

**This does not touch `src/acp/*` or the semantics of `AcpClient.close()`** — it
is purely queue-owner / process-lifecycle. Plain `AcpClient.close()` stays
non-destructive and never sends `session/close`. (Deliberately scoped to avoid
the concern raised on #283.)

## Shutdown window

During bridge teardown the IPC server may briefly still accept a client against a
shutting-down session. Existing/late clients treat the disconnect as retryable;
this path is covered by a test. I can mark the owner closed earlier if you'd
prefer to reject immediately.

## Tests

`test/queue-owner-lifecycle.test.ts` (+ `test/queue-lease-store.test.ts`):
- exits 0 / releases lease on SIGTERM and SIGINT
- releases lease when `doShutdown` races between signal and finally
- kills the agent bridge when SIGTERMed mid-prompt
- **kills the bridge and exits gracefully when a client socket stays open during
  SIGTERM** (the exact orphan repro)

All green off `main`.
