### PR TITLE
fix(output): surface a structured stderr line on error in quiet mode

### DIFF
--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -1146,7 +1146,7 @@ class QuietOutputFormatter implements OutputFormatter {
     }
   }
 
-  onError(_params: {
+  onError(params: {
     code: OutputErrorCode;
     detailCode?: string;
     origin?: OutputErrorOrigin;
@@ -1155,7 +1155,8 @@ class QuietOutputFormatter implements OutputFormatter {
     acp?: OutputErrorAcpPayload;
     timestamp?: string;
   }): void {
-    // no-op in quiet mode
+    const qualifier = params.detailCode ? `${params.code} ${params.detailCode}` : params.code;
+    this.stderr.write(`[acpx] error: ${qualifier} ${params.message}\n`);
   }
 
   onPermissionEscalation(_event: PermissionEscalationEvent): void {

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -1156,7 +1156,7 @@ class QuietOutputFormatter implements OutputFormatter {
     timestamp?: string;
   }): void {
     const qualifier = params.detailCode ? `${params.code} ${params.detailCode}` : params.code;
-    this.stderr.write(`[acpx] error: ${qualifier} ${params.message}\n`);
+    this.stderr.write(`[acpx] error: ${qualifier} ${params.message.replace(/\n/g, " ")}\n`);
   }
 
   onPermissionEscalation(_event: PermissionEscalationEvent): void {

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -1156,7 +1156,7 @@ class QuietOutputFormatter implements OutputFormatter {
     timestamp?: string;
   }): void {
     const qualifier = params.detailCode ? `${params.code} ${params.detailCode}` : params.code;
-    this.stderr.write(`[acpx] error: ${qualifier} ${params.message.replace(/\n/g, " ")}\n`);
+    this.stderr.write(`[acpx] error: ${qualifier} ${params.message.replace(/\r\n?|\n/g, " ")}\n`);
   }
 
   onPermissionEscalation(_event: PermissionEscalationEvent): void {

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -160,7 +160,13 @@ function emitQueueOwnerError(
     });
     formatter.flush();
   }
-  return queueConnectionErrorFromOwner(message, queueErrorAlreadyEmitted);
+  // If we just emitted via the formatter, mark the error as already-emitted so
+  // that the top-level emitRequestedError handler (cli-core.ts) does not emit
+  // the same error a second time on stderr.  Without this, quiet mode (where
+  // queueErrorAlreadyEmitted === false) results in two stderr lines: one
+  // structured "[acpx] error: …" from the formatter and one raw line from the
+  // catch handler.
+  return queueConnectionErrorFromOwner(message, queueErrorAlreadyEmitted || shouldEmitInFormatter);
 }
 
 function parseQueueOwnerResponseLine(

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -590,3 +590,38 @@ test("quiet formatter emits final usage and cost metadata to stderr", () => {
     "[acpx] tokens: input=17030 output=4 cache_read=12 cache_write=3 total=17049\n[acpx] cost: 0.051276 USD\n",
   );
 });
+
+test("quiet formatter emits structured error line to stderr on onError (never swallows errors)", () => {
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    detailCode: "QUEUE_RUNTIME_PROMPT_FAILED",
+    origin: "queue",
+    message: "rate limit exceeded",
+  });
+
+  // stdout must remain empty — the quiet contract only covers stdout
+  assert.equal(stdout.toString(), "");
+  // stderr must contain exactly one structured line, parseable by machines
+  assert.equal(
+    stderr.toString(),
+    "[acpx] error: RUNTIME QUEUE_RUNTIME_PROMPT_FAILED rate limit exceeded\n",
+  );
+});
+
+test("quiet formatter onError line uses code when detailCode is absent", () => {
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "NO_SESSION",
+    message: "session not found",
+  });
+
+  assert.equal(stdout.toString(), "");
+  assert.equal(stderr.toString(), "[acpx] error: NO_SESSION session not found\n");
+});

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -625,3 +625,26 @@ test("quiet formatter onError line uses code when detailCode is absent", () => {
   assert.equal(stdout.toString(), "");
   assert.equal(stderr.toString(), "[acpx] error: NO_SESSION session not found\n");
 });
+
+test("quiet formatter onError collapses multi-line message to a single stderr line", () => {
+  // A message containing \n would break a line-by-line parser reading stderr.
+  // The formatter must squash all newlines before interpolation.
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    message: "line one\nline two\nline three",
+  });
+
+  assert.equal(stdout.toString(), "");
+  const stderrStr = stderr.toString();
+  // Exactly one non-empty line in the output.
+  assert.equal(
+    stderrStr.split("\n").filter(Boolean).length,
+    1,
+    "stderr must be a single line when the message contains embedded newlines",
+  );
+  assert.equal(stderrStr, "[acpx] error: RUNTIME line one line two line three\n");
+});

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -648,3 +648,25 @@ test("quiet formatter onError collapses multi-line message to a single stderr li
   );
   assert.equal(stderrStr, "[acpx] error: RUNTIME line one line two line three\n");
 });
+
+test("quiet formatter onError collapses CRLF line endings in message to a single stderr line", () => {
+  // Windows-style \r\n line endings must be collapsed the same way as \n.
+  // A lone \r (old Mac style) is also normalised.
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    message: "line one\r\nline two\r\nline three",
+  });
+
+  assert.equal(stdout.toString(), "");
+  const stderrStr = stderr.toString();
+  assert.equal(
+    stderrStr.split("\n").filter(Boolean).length,
+    1,
+    "stderr must be a single line when the message contains embedded CRLF newlines",
+  );
+  assert.equal(stderrStr, "[acpx] error: RUNTIME line one line two line three\n");
+});

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -828,3 +828,104 @@ test("trySubmitToRunningOwner recovers stale owners before MCP conflict checks",
     }
   });
 });
+
+test("trySubmitToRunningOwner in quiet mode marks error as outputAlreadyEmitted after formatter emits", async () => {
+  // Regression test for double-emission in quiet mode.
+  //
+  // When errorEmissionPolicy.queueErrorAlreadyEmitted === false (quiet mode),
+  // emitQueueOwnerError() calls formatter.onError() to emit the structured
+  // error line, then must return a QueueConnectionError with
+  // outputAlreadyEmitted === true so that the top-level emitRequestedError
+  // handler in cli-core.ts does not emit the same error a second time on
+  // stderr.  Without the fix, two stderr lines would appear: one structured
+  // "[acpx] error: …" from the formatter and one raw line from the catch.
+  await withTempHome(async (homeDir) => {
+    const sessionId = "quiet-double-emit-session";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+    });
+
+    const server = createSingleRequestServer((socket, request) => {
+      assert.equal(request.type, "submit_prompt");
+      socket.write(
+        `${JSON.stringify({
+          type: "accepted",
+          requestId: request.requestId,
+        })}\n`,
+      );
+      socket.write(
+        `${JSON.stringify({
+          type: "error",
+          requestId: request.requestId,
+          code: "RUNTIME",
+          detailCode: "QUEUE_RUNTIME_PROMPT_FAILED",
+          origin: "queue",
+          retryable: false,
+          message: "prompt failed in queue owner",
+        })}\n`,
+      );
+      socket.end();
+    });
+
+    await listenServer(server, socketPath);
+
+    const onErrorCalls: string[] = [];
+    const spyFormatter: OutputFormatter = {
+      setContext() {
+        // no-op
+      },
+      onAcpMessage() {
+        // no-op
+      },
+      onError(params) {
+        onErrorCalls.push(params.code);
+      },
+      onPermissionEscalation() {
+        // no-op
+      },
+      flush() {
+        // no-op
+      },
+    };
+
+    try {
+      await assert.rejects(
+        async () =>
+          await trySubmitToRunningOwner({
+            sessionId,
+            message: "hello",
+            permissionMode: "approve-reads",
+            outputFormatter: spyFormatter,
+            // quiet mode: the formatter is responsible for emitting errors;
+            // the queue owner has NOT already emitted them.
+            errorEmissionPolicy: { queueErrorAlreadyEmitted: false },
+            waitForCompletion: true,
+          }),
+        (error: unknown) => {
+          assert(error instanceof QueueConnectionError, "expected QueueConnectionError");
+          // After the fix: formatter emitted once → error must be marked so
+          // the top-level handler does not emit a second time.
+          assert.equal(
+            error.outputAlreadyEmitted,
+            true,
+            "QueueConnectionError must carry outputAlreadyEmitted=true when formatter already emitted",
+          );
+          return true;
+        },
+      );
+
+      // The formatter's onError must have been called exactly once.
+      assert.equal(onErrorCalls.length, 1, "formatter.onError must be called exactly once");
+      assert.equal(onErrorCalls[0], "RUNTIME");
+    } finally {
+      await closeServer(server);
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});


### PR DESCRIPTION
> Sibling to #424 (queue-owner orphan fix). Independent — touches only `output.ts` / `ipc.ts`, no file overlap with #424; either can land first.


## Problem

`QuietOutputFormatter.onError` is a no-op, so in `--format quiet` a failing
prompt is **silently swallowed**: a programmatic caller sees a non-zero exit with
empty stdout *and* empty stderr — indistinguishable from a bridge crash or a
provider blip. There is no signal at all that the prompt failed or why.

## Change

Emit exactly one structured line on **stderr** when a prompt fails in quiet mode:

```
[acpx] error: <code> [<detailCode>] <message collapsed to one line>
```

- **stdout / NDJSON is untouched.** This is stderr-only — the `--format json` /
  `--json-strict` contract is not modified and no synthetic event is added to the
  JSON-RPC stream. (Deliberately different from #327, which added a terminal
  envelope to the stdout stream.)
- The message is collapsed to a single line (`/\r\n?|\n/g`) so it stays
  grep/parse-friendly.
- On the queue IPC path, the error is marked `outputAlreadyEmitted` once the
  formatter has written it, so the top-level handler doesn't print a second raw
  line (no double emission).

## Precedent

Follows the spirit of #274 (quiet usage metadata): quiet carries structured
diagnostics on the side channel without polluting the data stream.

## On the contract change

I'm treating quiet as "no stdout data unless there is success output", not "no
diagnostics ever". This does change quiet's behavior from "fully silent" to
"silent on stdout, one diagnostic line on stderr for errors". If you'd rather
keep quiet strictly silent by default, I'm happy to:
- put it behind an opt-in flag (e.g. `--error-format=line`), or
- pursue dedicated exit codes (rate_limit / quota / internal / timeout) instead.

Flagging explicitly so the contract decision stays yours.

## Tests

`test/output.test.ts` (+ `test/queue-ipc-errors.test.ts`): structured line shape,
`\r\n` / bare `\r` / `\n` normalization, and no double-emission on the quiet IPC
path. All green off `main`.
