### PR TITLE
feat: add Grok Build ACP agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Agents/built-ins: add Grok Build via `grok agent stdio`, including cached-login and `XAI_API_KEY` authentication selection. Thanks @TheAngryPit.
+
 ### Breaking
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Built-ins:
 | `copilot`    | native (`copilot --acp --stdio`)                                            | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-chat/use-copilot-chat-in-the-command-line) |
 | `droid`      | native (`droid exec --output-format acp`)                                   | [Factory Droid](https://www.factory.ai)                                                                         |
 | `fast-agent` | `uvx fast-agent-mcp acp`                                                    | [fast-agent](https://fast-agent.ai)                                                                             |
+| `grok-build` | native (`grok agent stdio`)                                                 | [Grok Build](https://docs.x.ai/build/overview)                                                                  |
 | `iflow`      | native (`iflow --experimental-acp`)                                         | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                              |
 | `kilocode`   | `npx -y @kilocode/cli acp`                                                  | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | native (`kimi acp`)                                                         | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |

--- a/agents/GrokBuild.md
+++ b/agents/GrokBuild.md
@@ -1,0 +1,29 @@
+# Grok Build
+
+- Built-in name: `grok-build`
+- Default command: `grok agent stdio`
+- Upstream: [xAI Grok Build](https://docs.x.ai/build/overview)
+
+`acpx grok-build` launches the installed `grok` CLI through its ACP stdio entrypoint. Install Grok Build and complete its normal authentication flow before using it through `acpx`.
+
+When Grok advertises `cached_token`, `acpx` asks the Grok ACP server to authenticate with its agent-managed cached login. For non-browser and automation environments where Grok advertises `xai.api_key`, `acpx grok-build` also accepts `XAI_API_KEY`.
+
+Examples:
+
+```bash
+acpx grok-build sessions new
+acpx grok-build 'review this branch'
+acpx grok-build exec 'summarize this repository'
+```
+
+If your Grok Build install exposes ACP through a different command, override the built-in in `~/.acpx/config.json`:
+
+```json
+{
+  "agents": {
+    "grok-build": {
+      "command": "grok agent stdio"
+    }
+  }
+}
+```

--- a/agents/README.md
+++ b/agents/README.md
@@ -26,12 +26,12 @@ Harness-specific docs in this directory:
 
 - [Codex](Codex.md): built-in `codex -> npx -y @agentclientprotocol/codex-acp`
 - [Claude](Claude.md): built-in `claude -> npx -y @agentclientprotocol/claude-agent-acp`
+- [Gemini](Gemini.md): built-in `gemini -> gemini --acp`
+- [Cursor](Cursor.md): built-in `cursor -> cursor-agent acp`
 - [Copilot](Copilot.md): built-in `copilot -> copilot --acp --stdio`
 - [Droid](Droid.md): built-in `droid -> droid exec --output-format acp` with `factory-droid` and `factorydroid` aliases
 - [fast-agent](FastAgent.md): built-in `fast-agent -> uvx fast-agent-mcp acp`
 - [Grok Build](GrokBuild.md): built-in `grok-build -> grok agent stdio`
-- [Cursor](Cursor.md): built-in `cursor -> cursor-agent acp`
-- [Gemini](Gemini.md): built-in `gemini -> gemini --acp`
 - [iFlow](Iflow.md): built-in `iflow -> iflow --experimental-acp`
 - [Kilocode](Kilocode.md): built-in `kilocode -> npx -y @kilocode/cli acp`
 - [Kimi](Kimi.md): built-in `kimi -> kimi acp`

--- a/agents/README.md
+++ b/agents/README.md
@@ -11,6 +11,7 @@ Built-in agents:
 - `copilot -> copilot --acp --stdio`
 - `droid -> droid exec --output-format acp` (`factory-droid` and `factorydroid` also resolve to `droid`)
 - `fast-agent -> uvx fast-agent-mcp acp`
+- `grok-build -> grok agent stdio`
 - `iflow -> iflow --experimental-acp`
 - `kilocode -> npx -y @kilocode/cli acp`
 - `kimi -> kimi acp`
@@ -28,6 +29,7 @@ Harness-specific docs in this directory:
 - [Copilot](Copilot.md): built-in `copilot -> copilot --acp --stdio`
 - [Droid](Droid.md): built-in `droid -> droid exec --output-format acp` with `factory-droid` and `factorydroid` aliases
 - [fast-agent](FastAgent.md): built-in `fast-agent -> uvx fast-agent-mcp acp`
+- [Grok Build](GrokBuild.md): built-in `grok-build -> grok agent stdio`
 - [Cursor](Cursor.md): built-in `cursor -> cursor-agent acp`
 - [Gemini](Gemini.md): built-in `gemini -> gemini --acp`
 - [iFlow](Iflow.md): built-in `iflow -> iflow --experimental-acp`

--- a/docs/2026-02-17-agent-registry.md
+++ b/docs/2026-02-17-agent-registry.md
@@ -13,6 +13,7 @@ date: 2026-02-17
 - `openclaw -> openclaw acp`
 - `codex -> npx @zed-industries/codex-acp`
 - `claude -> npx -y @agentclientprotocol/claude-agent-acp`
+- `grok-build -> grok agent stdio`
 
 The built-in agents table lives in [../README.md](../README.md). Additional built-in agent docs live under [../agents/README.md](../agents/README.md).
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -20,6 +20,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `copilot`    | `copilot --acp --stdio`                        | [GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-chat/use-copilot-chat-in-the-command-line) |
 | `droid`      | `droid exec --output-format acp`               | [Factory Droid](https://www.factory.ai)                                                                         |
 | `fast-agent` | `uvx fast-agent-mcp acp`                       | [fast-agent](https://fast-agent.ai/)                                                                            |
+| `grok-build` | `grok agent stdio`                             | [Grok Build](https://docs.x.ai/build/overview)                                                                  |
 | `iflow`      | `iflow --experimental-acp`                     | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                              |
 | `kilocode`   | `npx -y @kilocode/cli acp`                     | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | `kimi acp`                                     | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
@@ -134,6 +135,14 @@ If your Cursor install exposes ACP as `agent acp` instead of `cursor-agent acp`,
 `acpx fast-agent` starts fast-agent through its ACP entrypoint. It requires `uvx` on `PATH`.
 
 Configure model/provider settings through fast-agent environment variables, fast-agent configuration, or an `acpx` agent override with additional `fast-agent-mcp acp` arguments.
+
+### Grok Build
+
+- Built-in name: `grok-build`
+- Default command: `grok agent stdio`
+- Upstream: [xAI Grok Build](https://docs.x.ai/build/overview)
+
+`acpx grok-build` uses the installed `grok` CLI ACP server. Install Grok Build and complete its normal authentication flow before using it through `acpx`. If the Grok ACP server advertises `cached_token`, `acpx` asks it to authenticate with its agent-managed cached login. If it advertises `xai.api_key`, `acpx` also accepts `XAI_API_KEY` for this built-in.
 
 ### Qoder
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ acpx flow run examples/flows/branch.flow.ts \
 
 ## What acpx does
 
-- **One CLI, every coding agent.** Built-in adapters for Codex, Claude, Pi, OpenClaw, Gemini, Cursor, Copilot, Droid, Qwen, Qoder, Trae, and more — plus `--agent` for any custom ACP server.
+- **One CLI, every coding agent.** Built-in adapters for Codex, Claude, Pi, OpenClaw, Gemini, Cursor, Copilot, Droid, Grok Build, Qwen, Qoder, Trae, and more — plus `--agent` for any custom ACP server.
 - **Persistent sessions.** Multi-turn conversations survive across invocations, scoped per repo. `-s <name>` runs parallel workstreams (`backend`, `docs`, `pr-842`).
 - **Queue-aware prompts.** Submit while a turn is running; new prompts queue and drain in order. `--no-wait` enqueues and returns. `cancel` aborts cooperatively without tearing the session down.
 - **Crash-resistant.** Dead agent processes are detected and reloaded automatically. `Ctrl+C` sends ACP `session/cancel` before any force-kill.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ acpx flow run examples/flows/branch.flow.ts \
 
 ## What acpx does
 
-- **One CLI, every coding agent.** Built-in adapters for Codex, Claude, Pi, OpenClaw, Gemini, Cursor, Copilot, Droid, Grok Build, Qwen, Qoder, Trae, and more — plus `--agent` for any custom ACP server.
+- **One CLI, every coding agent.** Built-in adapters for Codex, Claude, Pi, OpenClaw, Gemini, Cursor, Copilot, Droid, Qwen, Qoder, Trae, and more — plus `--agent` for any custom ACP server.
 - **Persistent sessions.** Multi-turn conversations survive across invocations, scoped per repo. `-s <name>` runs parallel workstreams (`backend`, `docs`, `pr-842`).
 - **Queue-aware prompts.** Submit while a turn is running; new prompts queue and drain in order. `--no-wait` enqueues and returns. `cancel` aborts cooperatively without tearing the session down.
 - **Crash-resistant.** Dead agent processes are detected and reloaded automatically. `Ctrl+C` sends ACP `session/cancel` before any force-kill.

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ Some older Corepack builds bundled with supported Node.js versions have stale
 package-signing keys and fail while preparing current pnpm releases. Installing
 pnpm with npm avoids that bootstrap failure.
 
-`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`, `mux`) are auto-fetched with `npx` on first use. The `fast-agent` built-in uses `uvx fast-agent-mcp acp`, so it requires `uvx` on `PATH`. Native CLI built-ins such as `grok-build` require their upstream CLI to be installed and authenticated separately.
+`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`, `mux`) are auto-fetched with `npx` on first use. The `fast-agent` built-in uses `uvx fast-agent-mcp acp`, so it requires `uvx` on `PATH`. Native CLI built-ins require their upstream CLI to be installed and authenticated separately.
 
 ## Global install (recommended)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ Some older Corepack builds bundled with supported Node.js versions have stale
 package-signing keys and fail while preparing current pnpm releases. Installing
 pnpm with npm avoids that bootstrap failure.
 
-`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`, `mux`) are auto-fetched with `npx` on first use. The `fast-agent` built-in uses `uvx fast-agent-mcp acp`, so it requires `uvx` on `PATH`.
+`acpx` itself does not need a global install of every adapter. Built-in adapters that ship as npm packages (`pi-acp`, `@agentclientprotocol/codex-acp`, `@agentclientprotocol/claude-agent-acp`, `@kilocode/cli`, `opencode-ai`, `mux`) are auto-fetched with `npx` on first use. The `fast-agent` built-in uses `uvx fast-agent-mcp acp`, so it requires `uvx` on `PATH`. Native CLI built-ins such as `grok-build` require their upstream CLI to be installed and authenticated separately.
 
 ## Global install (recommended)
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -90,6 +90,7 @@ Friendly agent names resolve to commands:
 - `copilot` -> `copilot --acp --stdio`
 - `droid` -> `droid exec --output-format acp` (`factory-droid` and `factorydroid` also resolve to `droid`)
 - `fast-agent` -> `uvx fast-agent-mcp acp`
+- `grok-build` -> `grok agent stdio`
 - `iflow` -> `iflow --experimental-acp`
 - `kilocode` -> `npx -y @kilocode/cli acp`
 - `kimi` -> `kimi acp`

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -237,7 +237,7 @@ type PendingConnectionRequest = {
 
 type AuthSelection = {
   methodId: string;
-  credential: string;
+  credential?: string;
   source: "env" | "config" | "agent";
 };
 
@@ -1616,7 +1616,6 @@ export class AcpClient {
     }
     return {
       methodId,
-      credential: "agent-managed",
       source: "agent",
     };
   }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -238,7 +238,7 @@ type PendingConnectionRequest = {
 type AuthSelection = {
   methodId: string;
   credential: string;
-  source: "env" | "config";
+  source: "env" | "config" | "agent";
 };
 
 type AgentLaunchPlan = {
@@ -1581,9 +1581,55 @@ export class AcpClient {
           source: "config",
         };
       }
+
+      const agentSpecificEnvCredential = this.readAgentSpecificEnvCredential(method.id);
+      if (agentSpecificEnvCredential) {
+        return {
+          methodId: method.id,
+          credential: agentSpecificEnvCredential,
+          source: "env",
+        };
+      }
+    }
+
+    for (const method of methods) {
+      const agentManagedSelection = this.selectAgentManagedAuthMethod(method.id);
+      if (agentManagedSelection) {
+        return agentManagedSelection;
+      }
     }
 
     return undefined;
+  }
+
+  private readAgentSpecificEnvCredential(methodId: string): string | undefined {
+    if (!this.isGrokBuildAcpCommand() || methodId !== "xai.api_key") {
+      return undefined;
+    }
+    const value = process.env.XAI_API_KEY;
+    return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+  }
+
+  private selectAgentManagedAuthMethod(methodId: string): AuthSelection | undefined {
+    if (!this.isGrokBuildAcpCommand() || methodId !== "cached_token") {
+      return undefined;
+    }
+    return {
+      methodId,
+      credential: "agent-managed",
+      source: "agent",
+    };
+  }
+
+  private isGrokBuildAcpCommand(): boolean {
+    const { command, args } = splitCommandLine(this.options.agentCommand);
+    const executable = command
+      .replace(/\\/g, "/")
+      .split("/")
+      .pop()
+      ?.replace(/\.(cmd|exe|ps1)$/iu, "")
+      .toLowerCase();
+    return executable === "grok" && args[0] === "agent" && args[1] === "stdio";
   }
 
   private async authenticateIfRequired(

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -46,6 +46,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   copilot: "copilot --acp --stdio",
   droid: "droid exec --output-format acp",
   "fast-agent": "uvx fast-agent-mcp acp",
+  "grok-build": "grok agent stdio",
   iflow: "iflow --experimental-acp",
   kilocode: "npx -y @kilocode/cli acp",
   kimi: "kimi acp",

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -54,6 +54,11 @@ test("fast-agent built-in runs the ACP entrypoint through uvx", () => {
   assert.equal(resolveAgentCommand("fast-agent"), "uvx fast-agent-mcp acp");
 });
 
+test("grok-build built-in runs the Grok Build ACP entrypoint", () => {
+  assert.equal(AGENT_REGISTRY["grok-build"], "grok agent stdio");
+  assert.equal(resolveAgentCommand("grok-build"), "grok agent stdio");
+});
+
 test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
   assert.equal(AGENT_REGISTRY.mux, "npx -y mux@^0.27.0 acp");
   assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.27.0 acp");
@@ -74,6 +79,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
   assert.deepEqual(agents.slice(7), [
     "droid",
     "fast-agent",
+    "grok-build",
     "iflow",
     "kilocode",
     "kimi",

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -358,7 +358,6 @@ test("AcpClient selects Grok Build cached_token as agent-managed auth", async ()
       const selection = internals.selectAuthMethod?.([{ id: "cached_token" }]);
       assert.deepEqual(selection, {
         methodId: "cached_token",
-        credential: "agent-managed",
         source: "agent",
       });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -297,6 +297,86 @@ test("AcpClient ignores ambient normalized provider env vars for auth selection"
   );
 });
 
+test("AcpClient uses XAI_API_KEY for Grok Build xai.api_key auth", async () => {
+  await withEnv(
+    {
+      XAI_API_KEY: "xai-ambient",
+      ACPX_AUTH_XAI_API_KEY: undefined,
+    },
+    async () => {
+      const client = makeClient({ agentCommand: "grok agent stdio" });
+      const internals = asInternals(client);
+
+      const selection = internals.selectAuthMethod?.([{ id: "xai.api_key" }]);
+      assert.deepEqual(selection, {
+        methodId: "xai.api_key",
+        credential: "xai-ambient",
+        source: "env",
+      });
+
+      let authenticatedMethod: string | undefined;
+      await internals.authenticateIfRequired?.(
+        {
+          authenticate: async ({ methodId }: { methodId: string }) => {
+            authenticatedMethod = methodId;
+          },
+        },
+        [{ id: "xai.api_key" }],
+      );
+
+      assert.equal(authenticatedMethod, "xai.api_key");
+    },
+  );
+});
+
+test("AcpClient keeps XAI_API_KEY scoped to Grok Build auth", async () => {
+  await withEnv(
+    {
+      XAI_API_KEY: "xai-ambient",
+      ACPX_AUTH_XAI_API_KEY: undefined,
+    },
+    async () => {
+      const client = makeClient({ agentCommand: "custom-acp-server" });
+      const internals = asInternals(client);
+
+      const selection = internals.selectAuthMethod?.([{ id: "xai.api_key" }]);
+      assert.equal(selection, undefined);
+    },
+  );
+});
+
+test("AcpClient selects Grok Build cached_token as agent-managed auth", async () => {
+  await withEnv(
+    {
+      XAI_API_KEY: undefined,
+      ACPX_AUTH_CACHED_TOKEN: undefined,
+    },
+    async () => {
+      const client = makeClient({ agentCommand: "grok agent stdio" });
+      const internals = asInternals(client);
+
+      const selection = internals.selectAuthMethod?.([{ id: "cached_token" }]);
+      assert.deepEqual(selection, {
+        methodId: "cached_token",
+        credential: "agent-managed",
+        source: "agent",
+      });
+
+      let authenticatedMethod: string | undefined;
+      await internals.authenticateIfRequired?.(
+        {
+          authenticate: async ({ methodId }: { methodId: string }) => {
+            authenticatedMethod = methodId;
+          },
+        },
+        [{ id: "cached_token" }],
+      );
+
+      assert.equal(authenticatedMethod, "cached_token");
+    },
+  );
+});
+
 test("AcpClient authenticateIfRequired throws when auth policy is fail and credentials are missing", async () => {
   const client = makeClient({ authPolicy: "fail" });
   const internals = asInternals(client);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -848,6 +848,33 @@ test("integration: built-in fast-agent resolves to uvx fast-agent-mcp acp", asyn
   });
 });
 
+test("integration: built-in grok-build agent resolves to grok agent stdio", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-grok-build-"));
+
+    try {
+      await writeFakeGrokBuildAgent(fakeBinDir);
+
+      const result = await runCli(
+        ["--approve-all", "--cwd", cwd, "--format", "quiet", "grok-build", "exec", "echo hello"],
+        homeDir,
+        {
+          env: {
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /hello/);
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: built-in iflow agent resolves to iflow --experimental-acp", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -4484,6 +4511,41 @@ async function writeFakeIflowAgent(binDir: string): Promise<void> {
       "#!/bin/sh",
       'if [ "$1" = "--experimental-acp" ]; then',
       "  shift",
+      "fi",
+      `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
+      "",
+    ].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function writeFakeGrokBuildAgent(binDir: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      path.join(binDir, "grok.cmd"),
+      [
+        "@echo off",
+        "setlocal",
+        'if not "%~1"=="agent" exit /b 2',
+        'if not "%~2"=="stdio" exit /b 2',
+        `"${process.execPath}" "${MOCK_AGENT_PATH}" %3 %4 %5 %6 %7 %8 %9`,
+        "",
+      ].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  await fs.writeFile(
+    path.join(binDir, "grok"),
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "agent" ] && [ "$2" = "stdio" ]; then',
+      "  shift",
+      "  shift",
+      "else",
+      '  echo "unexpected grok command: $*" 1>&2',
+      "  exit 2",
       "fi",
       `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
       "",


### PR DESCRIPTION
## Summary

Grok Build is now a real ACPX built-in rather than a downstream docs-only example.

- adds `grok-build` as `grok agent stdio`
- selects Grok's advertised `xai.api_key` method from `XAI_API_KEY`
- treats advertised `cached_token` as agent-managed authentication
- adds registry, auth, integration, agent, public-doc, skill, and changelog coverage
- keeps main landing docs neutral under the repository documentation policy

This supersedes https://github.com/openclaw/acpx/pull/423.

## Provider contract

- Official xAI docs document Grok Build's ACP mode and `XAI_API_KEY`: https://docs.x.ai/build/overview
- Live proof used current stable Grok CLI `0.2.82`, installed through its own stable updater.

## Exact-head proof

Head: `68b94a718bc0770fffbeca71e632732d4fd9edb1`

- `pnpm run check`: 829/829 broad tests and 109/109 coverage tests; 94.14% statements/lines, 87.36% branches, 96.07% functions
- `pnpm run check:docs`: clean
- `pnpm run mutate`: 90.66% mutation score, threshold 80, zero timeouts
- full mock conformance: 21/21
- Slophammer rules/DRY/dependency boundaries: clean; zero findings
- independent packed-install CLI version and mock-agent exec smoke: clean
- production and full dependency audits: no known vulnerabilities
- skill frontmatter YAML validation and `git diff --check`: clean
- fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.86 confidence

## Live Grok proof

With only the targeted `XAI_API_KEY` credential injected through 1Password, the exact built CLI:

1. spawned `grok agent stdio`
2. observed the advertised `xai.api_key` ACP auth method
3. authenticated with the environment-backed selection
4. created the one-shot session and completed the prompt
5. returned the exact expected `ACPX_GROK_LIVE_OK` response with exit 0

No credential value was printed or persisted. A cached Grok login was not present on this machine, so the `cached_token` path is regression-tested but not claimed as live-proven.

## Public Model Identifier Gate

Pass. The diff, fixtures, and publishable proof introduce no model identifier. `grok-build` is the ACPX agent name, not a model selector.

Thanks @TheAngryPit for the implementation and follow-through from the original proposal.
