### PR TITLE
fix: make queue owner shutdown lossless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- CLI/queue: drain active turns before releasing queue-owner leases and preserve typed retryable shutdown responses while terminating agent bridges. Thanks @superWorldSavior.
+
 ## 2026.6.23 (v0.11.1)
 
 ### Changes

--- a/src/cli/queue/ipc-server.ts
+++ b/src/cli/queue/ipc-server.ts
@@ -22,6 +22,8 @@ type QueueOwnerSocketLease = {
   ownerGeneration?: number;
 };
 
+const QUEUE_SOCKET_DRAIN_TIMEOUT_MS = 1_000;
+
 function makeQueueOwnerError(
   requestId: string,
   message: string,
@@ -122,6 +124,9 @@ export class SessionQueueOwner {
   private readonly onQueueDepthChanged?: (queueDepth: number) => void;
   private readonly pending: QueueTask[] = [];
   private readonly waiters: Array<(task: QueueTask | undefined) => void> = [];
+  private readonly sockets = new Set<net.Socket>();
+  private readonly taskSockets = new Set<net.Socket>();
+  private readonly drainingSockets = new Set<net.Socket>();
   private closed = false;
 
   private constructor(
@@ -168,7 +173,7 @@ export class SessionQueueOwner {
     return ownerRef.current;
   }
 
-  async close(): Promise<void> {
+  beginShutdown(): void {
     if (this.closed) {
       return;
     }
@@ -193,10 +198,28 @@ export class SessionQueueOwner {
       }
       task.close();
     }
+    for (const socket of this.sockets) {
+      if (!this.taskSockets.has(socket) && !this.drainingSockets.has(socket)) {
+        socket.destroy();
+      }
+    }
     this.emitQueueDepth();
+  }
+
+  async close(): Promise<void> {
+    this.beginShutdown();
 
     await new Promise<void>((resolve) => {
-      this.server.close(() => resolve());
+      const forceCloseTimer = setTimeout(() => {
+        for (const socket of this.sockets) {
+          socket.destroy();
+        }
+      }, QUEUE_SOCKET_DRAIN_TIMEOUT_MS);
+      forceCloseTimer.unref();
+      this.server.close(() => {
+        clearTimeout(forceCloseTimer);
+        resolve();
+      });
     });
   }
 
@@ -320,10 +343,20 @@ export class SessionQueueOwner {
         });
       })
       .finally(() => {
-        if (!options.socket.destroyed) {
-          options.socket.end();
-        }
+        this.endSocket(options.socket);
       });
+  }
+
+  private endSocket(socket: net.Socket): void {
+    if (socket.destroyed || this.drainingSockets.has(socket)) {
+      return;
+    }
+    this.taskSockets.delete(socket);
+    this.drainingSockets.add(socket);
+    socket.end(() => {
+      this.drainingSockets.delete(socket);
+      socket.destroy();
+    });
   }
 
   private failRequest(
@@ -338,7 +371,7 @@ export class SessionQueueOwner {
       }),
       ownerGeneration: this.ownerGeneration,
     });
-    socket.end();
+    this.endSocket(socket);
   }
 
   private parseRequestLine(socket: net.Socket, line: string): QueueRequest | undefined {
@@ -375,6 +408,25 @@ export class SessionQueueOwner {
       "Queue request targeted a stale queue owner generation",
       "QUEUE_OWNER_GENERATION_MISMATCH",
     );
+    return true;
+  }
+
+  private rejectClosedOwner(socket: net.Socket, request: QueueRequest): boolean {
+    if (!this.closed) {
+      return false;
+    }
+    writeQueueMessage(socket, {
+      ...makeQueueOwnerError(
+        request.requestId,
+        "Queue owner is shutting down",
+        "QUEUE_OWNER_CLOSED",
+        {
+          retryable: true,
+        },
+      ),
+      ownerGeneration: this.ownerGeneration,
+    });
+    this.endSocket(socket);
     return true;
   }
 
@@ -464,6 +516,7 @@ export class SessionQueueOwner {
     socket: net.Socket,
     request: Extract<QueueRequest, { type: "submit_prompt" }>,
   ): void {
+    this.taskSockets.add(socket);
     const task: QueueTask = {
       requestId: request.requestId,
       message: request.message,
@@ -485,9 +538,7 @@ export class SessionQueueOwner {
         });
       },
       close: () => {
-        if (!socket.destroyed) {
-          socket.end();
-        }
+        this.endSocket(socket);
       },
     };
 
@@ -507,18 +558,13 @@ export class SessionQueueOwner {
   }
 
   private handleConnection(socket: net.Socket): void {
+    this.sockets.add(socket);
     socket.setEncoding("utf8");
-
-    if (this.closed) {
-      writeQueueMessage(
-        socket,
-        makeQueueOwnerError("unknown", "Queue owner is closed", "QUEUE_OWNER_CLOSED", {
-          retryable: true,
-        }),
-      );
-      socket.end();
-      return;
-    }
+    socket.once("close", () => {
+      this.sockets.delete(socket);
+      this.taskSockets.delete(socket);
+      this.drainingSockets.delete(socket);
+    });
 
     let buffer = "";
     let handled = false;
@@ -530,7 +576,11 @@ export class SessionQueueOwner {
       handled = true;
 
       const request = this.parseRequestLine(socket, line);
-      if (!request || this.rejectStaleOwnerGeneration(socket, request)) {
+      if (
+        !request ||
+        this.rejectClosedOwner(socket, request) ||
+        this.rejectStaleOwnerGeneration(socket, request)
+      ) {
         return;
       }
       if (this.handleControlQueueRequest(socket, request)) {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -5,7 +5,14 @@ import { queueBaseDir, queueLockFilePath, queueSocketBaseDir, queueSocketPath } 
 
 export { isProcessAlive } from "../../process-liveness.js";
 
-const PROCESS_EXIT_GRACE_MS = 1_500;
+// Budget for graceful SIGTERM shutdown of a queue-owner process.
+// The owner runs AcpClient.close() during shutdown:
+//   stdin-close grace (100 ms) + SIGTERM wait (1 500 ms) + SIGKILL wait (1 000 ms) = 2 600 ms worst case.
+// We add ~1 400 ms of headroom for event-loop latency and process startup overhead → 4 000 ms.
+// If the owner does not exit within this window we escalate to SIGKILL.
+const PROCESS_SIGTERM_GRACE_MS = 4_000;
+// After SIGKILL the OS terminates the process almost immediately; 1 500 ms is generous.
+const PROCESS_SIGKILL_GRACE_MS = 1_500;
 const PROCESS_POLL_MS = 50;
 const QUEUE_OWNER_STALE_HEARTBEAT_MS = 15_000;
 
@@ -203,7 +210,7 @@ export async function terminateProcess(pid: number): Promise<boolean> {
     return false;
   }
 
-  if (await waitForProcessExit(pid, PROCESS_EXIT_GRACE_MS)) {
+  if (await waitForProcessExit(pid, PROCESS_SIGTERM_GRACE_MS)) {
     return true;
   }
 
@@ -213,7 +220,7 @@ export async function terminateProcess(pid: number): Promise<boolean> {
     return false;
   }
 
-  await waitForProcessExit(pid, PROCESS_EXIT_GRACE_MS);
+  await waitForProcessExit(pid, PROCESS_SIGKILL_GRACE_MS);
   return true;
 }
 

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -43,6 +43,7 @@ import { runQueuedTask } from "./runtime.js";
 
 const QUEUE_OWNER_STARTUP_MAX_ATTEMPTS = 120;
 const QUEUE_OWNER_HEARTBEAT_INTERVAL_MS = 5_000;
+const QUEUE_OWNER_ACTIVE_TURN_CANCEL_GRACE_MS = 750;
 
 async function submitToRunningOwner(
   options: SessionSendOptions,
@@ -174,10 +175,11 @@ async function closeQueueOwnerRuntime(params: {
     clearInterval(params.heartbeatTimer);
   }
   params.turnController.beginClosing();
-  await params.owner?.close();
+  // Kill the bridge before draining IPC so it cannot outlive the owner.
   await params.sharedClient.close().catch(() => {
     // best effort while queue owner is shutting down
   });
+  await params.owner?.close();
   await writeQueueOwnerLifecycleSnapshot(params.sessionId, params.sharedClient);
   await releaseQueueOwnerLease(params.lease);
   if (params.verbose) {
@@ -196,6 +198,137 @@ async function writeQueueOwnerLifecycleSnapshot(
   } catch {
     // best effort - session may already be cleaned up
   }
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), timeoutMs);
+  });
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      timeout,
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+type QueueOwnerShutdownController = {
+  readonly requested: boolean;
+  request: () => void;
+  setActiveTurn: (turn: Promise<void>) => void;
+  clearActiveTurn: (turn: Promise<void>) => void;
+  shutdown: () => Promise<void>;
+};
+
+function createQueueOwnerShutdownController(params: {
+  lease: QueueOwnerLease;
+  getOwner: () => SessionQueueOwner | undefined;
+  stopHeartbeat: () => void;
+  turnController: QueueOwnerTurnController;
+  sharedClient: AcpClient;
+  sessionId: string;
+  verbose?: boolean;
+}): QueueOwnerShutdownController {
+  let requested = false;
+  let activeTurn: Promise<void> | undefined;
+  let activeTurnShutdown: Promise<void> | undefined;
+  let shutdownPromise: Promise<void> | undefined;
+
+  const drainActiveTurn = async (): Promise<void> => {
+    const turn = activeTurn;
+    if (!turn) {
+      return;
+    }
+
+    void params.turnController.requestCancel().catch((error) => {
+      logDeferredCancelFailure(error, params.verbose);
+    });
+
+    if (!(await settlesWithin(turn, QUEUE_OWNER_ACTIVE_TURN_CANCEL_GRACE_MS))) {
+      // A bridge that ignores session/cancel must still be terminated before
+      // the external queue-owner SIGKILL deadline. Closing it forces the active
+      // turn to unwind; the lease remains held until that unwind completes.
+      await params.sharedClient.close().catch(() => {
+        // best effort while forcing active-turn cancellation
+      });
+    }
+    await turn.catch(() => {
+      // The main loop preserves the original turn result; shutdown only waits
+      // for its cleanup boundary before releasing the lease.
+    });
+  };
+
+  const request = (): void => {
+    requested = true;
+    params.stopHeartbeat();
+    params.getOwner()?.beginShutdown();
+    activeTurnShutdown ??= drainActiveTurn();
+  };
+
+  return {
+    get requested() {
+      return requested;
+    },
+    request,
+    setActiveTurn: (turn) => {
+      activeTurn = turn;
+    },
+    clearActiveTurn: (turn) => {
+      if (activeTurn === turn) {
+        activeTurn = undefined;
+      }
+    },
+    shutdown: () => {
+      request();
+      shutdownPromise ??= (async () => {
+        await activeTurnShutdown;
+        await closeQueueOwnerRuntime({
+          lease: params.lease,
+          owner: params.getOwner(),
+          heartbeatTimer: undefined,
+          turnController: params.turnController,
+          sharedClient: params.sharedClient,
+          sessionId: params.sessionId,
+          verbose: params.verbose,
+        });
+      })();
+      return shutdownPromise;
+    },
+  };
+}
+
+function applyRequestedShutdown(
+  owner: SessionQueueOwner,
+  shutdown: QueueOwnerShutdownController,
+): void {
+  if (shutdown.requested) {
+    owner.beginShutdown();
+  }
+}
+
+function startQueueOwnerHeartbeat(params: {
+  enabled: boolean;
+  lease: QueueOwnerLease;
+  owner: SessionQueueOwner;
+}): NodeJS.Timeout | undefined {
+  if (!params.enabled) {
+    return undefined;
+  }
+  return setInterval(() => {
+    void refreshQueueOwnerLease(params.lease, { queueDepth: params.owner.queueDepth() }).catch(
+      () => {
+        // best effort heartbeat refresh while owner is live
+      },
+    );
+  }, QUEUE_OWNER_HEARTBEAT_INTERVAL_MS);
 }
 
 export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): Promise<void> {
@@ -255,6 +388,29 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     }
   };
 
+  const shutdown = createQueueOwnerShutdownController({
+    lease,
+    getOwner: () => owner,
+    stopHeartbeat: () => {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = undefined;
+      }
+    },
+    turnController,
+    sharedClient,
+    sessionId: options.sessionId,
+    verbose: options.verbose,
+  });
+
+  const onSignal = (): void => {
+    shutdown.request();
+  };
+
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  process.once("SIGHUP", onSignal);
+
   try {
     owner = await SessionQueueOwner.start(
       lease,
@@ -288,6 +444,8 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
       },
     );
 
+    applyRequestedShutdown(owner, shutdown);
+
     logQueueOwnerReady({
       sessionId: options.sessionId,
       ttlMs,
@@ -297,12 +455,11 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
     await refreshQueueOwnerLease(lease, { queueDepth: owner.queueDepth() }).catch(() => {
       // best effort initial heartbeat
     });
-    heartbeatTimer = setInterval(() => {
-      void refreshQueueOwnerLease(lease, { queueDepth: owner?.queueDepth() ?? 0 }).catch(() => {
-        // best effort heartbeat
-      });
-    }, QUEUE_OWNER_HEARTBEAT_INTERVAL_MS);
-
+    heartbeatTimer = startQueueOwnerHeartbeat({
+      enabled: !shutdown.requested,
+      lease,
+      owner,
+    });
     let isFirstTask = true;
     while (true) {
       const pollTimeoutMs = isFirstTask ? initialTaskPollTimeoutMs : taskPollTimeoutMs;
@@ -312,7 +469,7 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
       }
       isFirstTask = false;
 
-      await runPromptTurn(async () => {
+      const turnPromise = runPromptTurn(async () => {
         try {
           await runQueuedTask(options.sessionId, task, {
             sharedClient,
@@ -330,22 +487,24 @@ export async function runSessionQueueOwner(options: QueueOwnerRuntimeOptions): P
               turnController.markPromptActive();
               await applyPendingCancel();
             },
+            handleProcessInterrupts: false,
           });
         } finally {
           checkpointPerfMetricsCapture();
         }
       });
+      shutdown.setActiveTurn(turnPromise);
+      try {
+        await turnPromise;
+      } finally {
+        shutdown.clearActiveTurn(turnPromise);
+      }
     }
   } finally {
-    await closeQueueOwnerRuntime({
-      lease,
-      owner,
-      heartbeatTimer,
-      turnController,
-      sharedClient,
-      sessionId: options.sessionId,
-      verbose: options.verbose,
-    });
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    process.off("SIGHUP", onSignal);
+    await shutdown.shutdown();
   }
 }
 

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -80,6 +80,7 @@ type RunSessionPromptOptions = Omit<
   "errorEmissionPolicy" | "maxQueueDepth" | "sessionId" | "ttlMs" | "waitForCompletion"
 > & {
   sessionRecordId: string;
+  handleProcessInterrupts?: boolean;
   onClientAvailable?: (controller: ActiveSessionController) => void;
   onClientClosed?: () => void;
   onPromptActive?: () => Promise<void> | void;
@@ -490,6 +491,7 @@ function buildQueuedTaskRunOptions(
     onClientAvailable: options.onClientAvailable,
     onClientClosed: options.onClientClosed,
     onPromptActive: options.onPromptActive,
+    handleProcessInterrupts: options.handleProcessInterrupts,
     client: options.sharedClient,
   };
 }
@@ -545,6 +547,7 @@ export async function runQueuedTask(
     onClientAvailable?: (controller: ActiveSessionController) => void;
     onClientClosed?: () => void;
     onPromptActive?: () => Promise<void> | void;
+    handleProcessInterrupts?: boolean;
   },
 ): Promise<void> {
   const outputFormatter = task.waitForCompletion
@@ -907,50 +910,54 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     return response;
   };
 
+  const runPrompt = async (): Promise<SessionSendResult> => {
+    const { sessionId: activeSessionId, resumed, loadError } = await connectForPrompt();
+
+    await applyPromptModelIfAdvertised({
+      client,
+      sessionId: activeSessionId,
+      requestedModel: sessionOptions?.model,
+      record,
+      timeoutMs: options.timeoutMs,
+      suppressWarnings: options.suppressSdkConsoleErrors,
+    });
+    acpxState = cloneSessionAcpxState(record.acpx);
+
+    output.setContext({
+      sessionId: record.acpxRecordId,
+    });
+    await liveCheckpoint.checkpoint();
+
+    const response = await savePromptSuccess(await runPromptWithRetries(activeSessionId));
+    promptTurnActive = false;
+
+    return {
+      ...toPromptResult(response.stopReason, record.acpxRecordId, client),
+      record,
+      resumed,
+      loadError,
+    };
+  };
+
+  const handleInterrupt = async (): Promise<void> => {
+    await client.cancelActivePrompt(INTERRUPT_CANCEL_WAIT_MS);
+    applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
+    record.lastUsedAt = isoNow();
+    applyConversation(record, conversation);
+    record.acpx = acpxState;
+    await flushPendingMessages(false).catch(() => {
+      // best effort while process is being interrupted
+    });
+    if (ownClient) {
+      await client.close();
+    }
+  };
+
   try {
-    return await withInterrupt(
-      async () => {
-        const { sessionId: activeSessionId, resumed, loadError } = await connectForPrompt();
-
-        await applyPromptModelIfAdvertised({
-          client,
-          sessionId: activeSessionId,
-          requestedModel: sessionOptions?.model,
-          record,
-          timeoutMs: options.timeoutMs,
-          suppressWarnings: options.suppressSdkConsoleErrors,
-        });
-        acpxState = cloneSessionAcpxState(record.acpx);
-
-        output.setContext({
-          sessionId: record.acpxRecordId,
-        });
-        await liveCheckpoint.checkpoint();
-
-        const response = await savePromptSuccess(await runPromptWithRetries(activeSessionId));
-        promptTurnActive = false;
-
-        return {
-          ...toPromptResult(response.stopReason, record.acpxRecordId, client),
-          record,
-          resumed,
-          loadError,
-        };
-      },
-      async () => {
-        await client.cancelActivePrompt(INTERRUPT_CANCEL_WAIT_MS);
-        applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
-        record.lastUsedAt = isoNow();
-        applyConversation(record, conversation);
-        record.acpx = acpxState;
-        await flushPendingMessages(false).catch(() => {
-          // best effort while process is being interrupted
-        });
-        if (ownClient) {
-          await client.close();
-        }
-      },
-    );
+    if (options.handleProcessInterrupts === false) {
+      return await runPrompt();
+    }
+    return await withInterrupt(runPrompt, handleInterrupt);
   } finally {
     if (options.verbose) {
       process.stderr.write(`[acpx] ${formatPerfMetric("prompt.total", stopTotalTimer())}\n`);

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -67,6 +67,9 @@ type MockAgentOptions = {
   replayLoadSessionUpdates: boolean;
   loadReplayText: string;
   ignoreSigterm: boolean;
+  cancelDelayMs: number;
+  /** If set, the agent writes its PID to this path at startup (before ACP handshake). */
+  pidFile?: string;
 };
 
 type SessionState = {
@@ -374,7 +377,9 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let replayLoadSessionUpdates = false;
   let loadReplayText = "replayed load session update";
   let ignoreSigterm = false;
+  let cancelDelayMs = 0;
   let hangOnNewSession = false;
+  let pidFile: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -508,8 +513,20 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       continue;
     }
 
+    if (token === "--cancel-delay-ms") {
+      cancelDelayMs = parsePositiveIntegerOption(argv, index + 1, token);
+      index += 1;
+      continue;
+    }
+
     if (token === "--hang-on-new-session") {
       hangOnNewSession = true;
+      continue;
+    }
+
+    if (token === "--pid-file") {
+      pidFile = parseOptionValue(argv, index + 1, token);
+      index += 1;
       continue;
     }
 
@@ -578,6 +595,8 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     replayLoadSessionUpdates,
     loadReplayText,
     ignoreSigterm,
+    cancelDelayMs,
+    pidFile,
   };
 }
 
@@ -967,6 +986,9 @@ class MockAgent implements Agent {
   }
 
   async cancel(params: { sessionId: SessionId }): Promise<void> {
+    if (this.options.cancelDelayMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, this.options.cancelDelayMs));
+    }
     this.sessions.get(params.sessionId)?.pendingPrompt?.abort();
   }
 
@@ -1458,6 +1480,12 @@ const output = Writable.toWeb(process.stdout);
 const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
 const stream = ndJsonStream(output, input);
 const mockAgentOptions = parseMockAgentOptions(process.argv.slice(2));
+
+// Write PID to a file before doing anything else so that the parent can track
+// this bridge process and verify it is dead after queue-owner shutdown.
+if (mockAgentOptions.pidFile) {
+  writeFileSync(mockAgentOptions.pidFile, `${process.pid}\n`, "utf8");
+}
 
 if (mockAgentOptions.ignoreSigterm) {
   process.on("SIGTERM", () => {

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -624,6 +624,65 @@ test("SessionQueueOwner emits typed shutdown errors for pending prompts", async 
   });
 });
 
+test("SessionQueueOwner preserves request ids for clients arriving during shutdown", async () => {
+  await withTempHome(async () => {
+    const sessionId = "owner-shutdown-new-client";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+
+    const owner = await SessionQueueOwner.start(lease, {
+      cancelPrompt: async () => false,
+      closeSession: async () => false,
+      setSessionMode: async () => {
+        // no-op
+      },
+      setSessionModel: async () => {
+        // no-op
+      },
+      setSessionConfigOption: async () => ({
+        configOptions: [],
+      }),
+    });
+
+    try {
+      owner.beginShutdown();
+      const socket = await connectSocket(lease.socketPath);
+      const lines = readline.createInterface({ input: socket });
+      const iterator = lines[Symbol.asyncIterator]();
+      socket.write(
+        `${JSON.stringify({
+          type: "submit_prompt",
+          requestId: "req-during-shutdown",
+          ownerGeneration: lease.ownerGeneration,
+          message: "arrived during shutdown",
+          permissionMode: "approve-reads",
+          waitForCompletion: true,
+        })}\n`,
+      );
+
+      const payload = (await nextJsonLine(iterator)) as {
+        type: string;
+        requestId: string;
+        detailCode?: string;
+        origin?: string;
+        retryable?: boolean;
+        message: string;
+      };
+      assert.equal(payload.type, "error");
+      assert.equal(payload.requestId, "req-during-shutdown");
+      assert.equal(payload.detailCode, "QUEUE_OWNER_CLOSED");
+      assert.equal(payload.origin, "queue");
+      assert.equal(payload.retryable, true);
+      assert.match(payload.message, /shutting down/i);
+      lines.close();
+      socket.destroy();
+    } finally {
+      await owner.close();
+      await releaseQueueOwnerLease(lease);
+    }
+  });
+});
+
 test("SessionQueueOwner rejects no-wait prompts when queue depth exceeds the limit", async () => {
   await withTempHome(async () => {
     const lease = await tryAcquireQueueOwnerLease("owner-overloaded");

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
@@ -286,4 +288,81 @@ test("terminateProcess and terminateQueueOwnerForSession handle live and missing
       stopProcess(keeper);
     }
   });
+});
+
+test("terminateProcess waits long enough for a process that delays 2s before exiting on SIGTERM", async () => {
+  // Regression test for the SIGTERM grace-period mismatch.
+  //
+  // A queue-owner's AcpClient.close() can take up to ~2 600 ms (stdin-close
+  // 100 ms + SIGTERM wait 1 500 ms + SIGKILL wait 1 000 ms).  The old
+  // PROCESS_EXIT_GRACE_MS of 1 500 ms would SIGKILL the owner before it
+  // finished closing its bridge.  PROCESS_SIGTERM_GRACE_MS = 4 000 ms gives
+  // sufficient headroom.
+  //
+  // This test spawns a Node.js process that defers its exit by 2 000 ms after
+  // receiving SIGTERM and verifies that terminateProcess() returns true without
+  // needing to escalate to SIGKILL (i.e. the process exits on its own within
+  // the 4 s window).
+  if (process.platform === "win32") {
+    // SIGTERM semantics differ on Windows.
+    return;
+  }
+
+  // The child writes "ready\n" to stderr once its SIGTERM handler is installed.
+  // We wait for that line before sending SIGTERM to avoid the race where the
+  // signal arrives before the handler is registered.
+  const script = `
+    process.on('SIGTERM', () => {
+      setTimeout(() => process.exit(0), 2_000);
+    });
+    process.stderr.write('ready\\n');
+    // Keep the event loop alive until SIGTERM arrives.
+    setInterval(() => {}, 60_000);
+  `;
+
+  const child = spawn(process.execPath, ["-e", script], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+
+  // Wait for the "ready" signal before sending SIGTERM.
+  await new Promise<void>((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString();
+      if (buf.includes("ready")) {
+        child.stderr?.off("data", onData);
+        resolve();
+      }
+    };
+    child.stderr?.on("data", onData);
+    child.once("exit", () => reject(new Error("child exited before signalling ready")));
+  });
+
+  assert(child.pid, "child must have a pid");
+
+  try {
+    assert.equal(isProcessAlive(child.pid), true, "child must be alive before terminateProcess");
+    const result = await terminateProcess(child.pid);
+    assert.equal(result, true, "terminateProcess must return true");
+    assert.equal(isProcessAlive(child.pid), false, "process must be dead after terminateProcess");
+
+    // Wait for the ChildProcess object to pick up the close event so that
+    // exitCode / signalCode are populated.
+    if (child.exitCode == null && child.signalCode == null) {
+      await once(child, "close");
+    }
+
+    // The process should have exited with code 0 (clean exit via setTimeout),
+    // not killed by a signal, proving the 4 s SIGTERM grace was enough.
+    assert.equal(
+      child.signalCode,
+      null,
+      `process should have exited cleanly, not via signal ${child.signalCode}`,
+    );
+    assert.equal(child.exitCode, 0, "process must exit with code 0");
+  } finally {
+    if (child.exitCode == null && child.signalCode == null) {
+      child.kill("SIGKILL");
+    }
+  }
 });

--- a/test/queue-owner-lifecycle.test.ts
+++ b/test/queue-owner-lifecycle.test.ts
@@ -1,0 +1,615 @@
+/**
+ * Tests that the queue owner runtime shuts down gracefully on SIGTERM/SIGINT,
+ * so the codex-acp bridge adapter is never orphaned.
+ *
+ * See: src/cli/session/queue-owner-runtime.ts — the `runSessionQueueOwner`
+ * function previously had no signal handlers; SIGTERM from lease-store's
+ * terminateProcess() killed the Node process before the `finally` block could
+ * run closeQueueOwnerRuntime(), leaving bridge adapters orphaned.
+ */
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import readline from "node:readline";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { isProcessAlive } from "../src/cli/queue/lease-store.js";
+import { queueLockFilePath, queueSocketPath } from "../src/cli/queue/paths.js";
+import { makeSessionRecord, withTempHome, writeSessionRecordFile } from "./runtime-test-helpers.js";
+
+const CLI_PATH = fileURLToPath(new URL("../src/cli.js", import.meta.url));
+const MOCK_AGENT_PATH = fileURLToPath(new URL("./mock-agent.js", import.meta.url));
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs = 6_000,
+  pollMs = 50,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+async function waitForTerminalQueueMessage(
+  iterator: AsyncIterator<string>,
+  timeoutMs = 5_000,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const line = await Promise.race([
+        iterator.next(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("timeout waiting for queue result")),
+            timeoutMs,
+          );
+        }),
+      ]);
+      if (line.done) {
+        throw new Error("queue socket closed before terminal result");
+      }
+      const message = JSON.parse(line.value) as Record<string, unknown>;
+      if (message.type === "result" || message.type === "error") {
+        return message;
+      }
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+  throw new Error(`Queue result not received within ${timeoutMs}ms`);
+}
+
+function waitForProcessExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs = 8_000,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Queue owner process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe("queue owner lifecycle — graceful SIGTERM shutdown", () => {
+  it("exits with code 0 and releases its lease when it receives SIGTERM", async () => {
+    if (process.platform === "win32") {
+      // SIGTERM semantics differ on Windows; skip this test.
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-sigterm-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      // A minimal session record — the queue owner reads it during startup.
+      // The agent bridge is only spawned when the first prompt is run, so
+      // we just need any plausible agentCommand to pass startup validation.
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-sigterm-test",
+        acpSessionId: "lifecycle-sigterm-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      // Waiting for the socket avoids signaling before startup installs the
+      // queue-owner process handlers.
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      // Queue owner payload — no ttlMs so it waits indefinitely for tasks.
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      try {
+        // Wait until the queue owner has created its Unix socket and entered
+        // the idle task loop.
+        await waitUntil(() => fileExists(socketPath));
+
+        // Confirm the lock file is present before sending the signal.
+        assert.equal(await fileExists(lockPath), true, "lock file must exist before SIGTERM");
+
+        // Signal graceful shutdown.
+        child.kill("SIGTERM");
+
+        const { code, signal } = await waitForProcessExit(child);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        // Graceful shutdown: exit code 0, not killed by a signal.
+        assert.equal(
+          signal,
+          null,
+          `process should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected exit code 0 (graceful); stderr=${stderr}`);
+
+        // The lease must have been released: no orphaned lock file.
+        assert.equal(
+          await fileExists(lockPath),
+          false,
+          "lock file must be gone after graceful shutdown — lease was not released",
+        );
+      } finally {
+        // Safety net: kill the child if the test fails mid-way.
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("exits with code 0 and releases its lease when it receives SIGINT", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-sigint-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-sigint-test",
+        acpSessionId: "lifecycle-sigint-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      try {
+        // Wait for the socket — signal handlers are live at this point.
+        await waitUntil(() => fileExists(socketPath));
+
+        child.kill("SIGINT");
+
+        const { code, signal } = await waitForProcessExit(child);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `process should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected exit code 0 (graceful); stderr=${stderr}`);
+
+        assert.equal(
+          await fileExists(lockPath),
+          false,
+          "lock file must be gone after graceful shutdown — lease was not released",
+        );
+      } finally {
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("does not let an idle IPC socket block SIGTERM shutdown or lease release", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-idle-socket-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-idle-socket-test",
+        acpSessionId: "lifecycle-idle-socket-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: JSON.stringify({
+            sessionId: record.acpxRecordId,
+            permissionMode: "approve-reads",
+          }),
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+      let idleSocket: net.Socket | undefined;
+
+      try {
+        await waitUntil(() => fileExists(socketPath));
+        idleSocket = await new Promise<net.Socket>((resolve, reject) => {
+          const socket = net.createConnection(socketPath);
+          socket.once("connect", () => resolve(socket));
+          socket.once("error", reject);
+        });
+
+        child.kill("SIGTERM");
+        const { code, signal } = await waitForProcessExit(child, 5_000);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(signal, null, `queue owner should exit gracefully; stderr=${stderr}`);
+        assert.equal(code, 0, `expected queue owner exit code 0; stderr=${stderr}`);
+        assert.equal(await fileExists(lockPath), false, "lease must be released after shutdown");
+      } finally {
+        idleSocket?.destroy();
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+});
+
+describe("queue owner lifecycle — bridge process death on SIGTERM", () => {
+  // Verifies that when the queue owner is SIGTERMed while a prompt is in
+  // flight, the agent bridge process (mock-agent) is also killed by the
+  // queue owner's graceful shutdown before it exits.
+  //
+  // This test catches the race that existed before the SIGTERM grace-period
+  // fix: terminateProcess() used a 1 500 ms SIGTERM grace, but AcpClient.close()
+  // can take up to ~2 600 ms.  With the old grace the queue owner could be
+  // SIGKILLed before it finished killing the bridge, leaving it orphaned.
+  it("kills the agent bridge when the queue owner receives SIGTERM mid-prompt", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-bridge-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      // PID file: mock-agent writes its PID here as soon as it starts, before
+      // the ACP handshake.  We poll for it to know the bridge is live.
+      const pidFilePath = path.join(homeDir, "mock-agent.pid");
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-bridge-test",
+        acpSessionId: "lifecycle-bridge-session",
+        // Pass --pid-file so the bridge records its PID at startup.
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --pid-file ${JSON.stringify(pidFilePath)}`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      let queueSocket: net.Socket | undefined;
+
+      try {
+        // Wait for the queue owner socket — signal handlers are live at this point.
+        await waitUntil(() => fileExists(socketPath));
+
+        // Connect to the queue-owner socket and submit a long-running prompt.
+        // "sleep 10000" keeps the bridge busy for 10 s so it is still alive
+        // when we send SIGTERM to the queue owner.
+        queueSocket = await new Promise<net.Socket>((resolve, reject) => {
+          const s = net.createConnection(socketPath);
+          s.setEncoding("utf8");
+          s.once("connect", () => resolve(s));
+          s.once("error", reject);
+        });
+
+        queueSocket.write(
+          `${JSON.stringify({
+            type: "submit_prompt",
+            requestId: "req-bridge-test",
+            message: "sleep 10000",
+            permissionMode: "approve-reads",
+            waitForCompletion: true,
+          })}\n`,
+        );
+
+        // Read the "accepted" acknowledgement.
+        const lines = readline.createInterface({ input: queueSocket });
+        const iter = lines[Symbol.asyncIterator]();
+        const acceptedRaw = await Promise.race([
+          iter.next(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout waiting for accepted")), 5_000),
+          ),
+        ]);
+        const accepted = JSON.parse((acceptedRaw as IteratorYieldResult<string>).value) as {
+          type: string;
+        };
+        assert.equal(accepted.type, "accepted", "queue owner must acknowledge the prompt");
+
+        // Close the readline and socket before sending SIGTERM.
+        // (This was previously required to prevent a deadlock — server.close()
+        // waited for connected sockets to drain — but is now just one of two
+        // test scenarios; the companion test verifies the fix when the socket
+        // stays open.)
+        lines.close();
+        queueSocket.destroy();
+        queueSocket = undefined;
+
+        // Wait for the bridge to write its PID — this confirms the bridge
+        // process has been spawned and the ACP handshake has started.
+        await waitUntil(() => fileExists(pidFilePath), 8_000);
+
+        const bridgePidRaw = (await fs.readFile(pidFilePath, "utf8")).trim();
+        const bridgePid = Number(bridgePidRaw);
+        assert(
+          Number.isInteger(bridgePid) && bridgePid > 0,
+          "bridge PID must be a positive integer",
+        );
+        assert.equal(isProcessAlive(bridgePid), true, "bridge must be alive before SIGTERM");
+
+        // Signal the queue owner to shut down gracefully.
+        child.kill("SIGTERM");
+
+        const { code, signal } = await waitForProcessExit(child, 10_000);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `queue owner should not have been killed by a signal; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected queue owner exit code 0 (graceful); stderr=${stderr}`);
+
+        // After the queue owner exits, the bridge must also be dead.
+        // AcpClient.close() kills the bridge before releasing the lease.
+        assert.equal(
+          isProcessAlive(bridgePid),
+          false,
+          "bridge process must be dead after queue owner graceful shutdown — was it orphaned?",
+        );
+      } finally {
+        queueSocket?.destroy();
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("drains the active turn before releasing its lease on SIGTERM", async () => {
+    // Regression test for the connected-client deadlock.
+    //
+    // Before the fix:
+    //   closeQueueOwnerRuntime called owner.close() first, which called
+    //   server.close().  server.close() waits for all existing connections to
+    //   drain.  A client in waitForCompletion that never closed its socket
+    //   kept the drain blocked past the external 4 s SIGKILL grace period;
+    //   terminateProcess() then SIGKILLed the owner before sharedClient.close()
+    //   ran — leaving the bridge orphaned.
+    //
+    // After the fix, the owner stops admission, cancels and drains the active
+    // turn while retaining its lease, then kills the bridge and drains IPC.
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-bridge-open-socket-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const pidFilePath = path.join(homeDir, "mock-agent-open.pid");
+
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-bridge-open-socket-test",
+        acpSessionId: "lifecycle-bridge-open-socket-session",
+        agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --pid-file ${JSON.stringify(pidFilePath)} --cancel-delay-ms 500`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+
+      const payload = JSON.stringify({
+        sessionId: record.acpxRecordId,
+        permissionMode: "approve-reads",
+      });
+
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: payload,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      // This socket intentionally stays open (not destroyed before SIGTERM)
+      // to reproduce the deadlock that existed before the fix.
+      let queueSocket: net.Socket | undefined;
+
+      try {
+        await waitUntil(() => fileExists(socketPath));
+
+        queueSocket = await new Promise<net.Socket>((resolve, reject) => {
+          const s = net.createConnection(socketPath);
+          s.setEncoding("utf8");
+          s.once("connect", () => resolve(s));
+          s.once("error", reject);
+        });
+
+        queueSocket.write(
+          `${JSON.stringify({
+            type: "submit_prompt",
+            requestId: "req-open-socket-test",
+            message: "sleep 10000",
+            permissionMode: "approve-reads",
+            waitForCompletion: true,
+          })}\n`,
+        );
+
+        // Read the "accepted" acknowledgement.
+        const lines = readline.createInterface({ input: queueSocket });
+        const iter = lines[Symbol.asyncIterator]();
+        const acceptedRaw = await Promise.race([
+          iter.next(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout waiting for accepted")), 5_000),
+          ),
+        ]);
+        const accepted = JSON.parse((acceptedRaw as IteratorYieldResult<string>).value) as {
+          type: string;
+        };
+        assert.equal(accepted.type, "accepted", "queue owner must acknowledge the prompt");
+
+        // Deliberately do NOT close the readline or socket here.
+        // The fix must handle this — the socket remaining open must not block
+        // the bridge kill or prevent the owner from exiting within the grace period.
+
+        // Wait until the bridge has written its PID — ACP handshake started.
+        await waitUntil(() => fileExists(pidFilePath), 8_000);
+
+        const bridgePidRaw = (await fs.readFile(pidFilePath, "utf8")).trim();
+        const bridgePid = Number(bridgePidRaw);
+        assert(
+          Number.isInteger(bridgePid) && bridgePid > 0,
+          "bridge PID must be a positive integer",
+        );
+        assert.equal(isProcessAlive(bridgePid), true, "bridge must be alive before SIGTERM");
+
+        // Delay session/cancel in the mock so the lease-retention assertion is
+        // deterministic while the active turn is still unwinding.
+        child.kill("SIGTERM");
+
+        await new Promise<void>((resolve) => setTimeout(resolve, 150));
+        const leaseHeldDuringCancel = await fileExists(lockPath);
+        assert.equal(
+          leaseHeldDuringCancel,
+          true,
+          "lease must remain held until active turn cancellation completes",
+        );
+
+        const terminalMessage = await waitForTerminalQueueMessage(iter, 5_000);
+        assert.equal(terminalMessage.type, "result");
+        const clientResult = terminalMessage.result as { stopReason?: unknown };
+        assert.equal(clientResult.stopReason, "cancelled");
+
+        // Tight budget: the owner must finish within the external grace even
+        // though the client socket remained connected until its typed result.
+        const { code, signal } = await waitForProcessExit(child, 8_000);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(
+          signal,
+          null,
+          `queue owner should not have been killed by a signal — it likely stalled past the grace period; stderr=${stderr}`,
+        );
+        assert.equal(code, 0, `expected queue owner exit code 0 (graceful); stderr=${stderr}`);
+
+        // Bridge must be dead — it must not have been orphaned.
+        assert.equal(
+          isProcessAlive(bridgePid),
+          false,
+          "bridge process must be dead after queue owner graceful shutdown — was it orphaned? (connected-client deadlock regression)",
+        );
+
+        // Lock file must be released.
+        const leaseReleased = !(await fileExists(lockPath));
+        assert.equal(leaseReleased, true, "lock file must be gone after graceful shutdown");
+
+        if (process.env.ACPX_TEST_LIFECYCLE_TRACE === "1") {
+          process.stdout.write(
+            `ACPX_LIFECYCLE_PROOF ${JSON.stringify({
+              ownerPid: child.pid,
+              ownerExitCode: code,
+              ownerSignal: signal,
+              bridgePid,
+              bridgeAliveAfter: isProcessAlive(bridgePid),
+              leaseHeldDuringCancel,
+              leaseReleased,
+              clientType: terminalMessage.type,
+              clientStopReason: clientResult.stopReason,
+            })}\n`,
+          );
+        }
+
+        lines.close();
+      } finally {
+        queueSocket?.destroy();
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Supersedes #424 because the contributor branch advertises maintainer edits but rejects authenticated maintainer pushes. The original head remains untouched at `9383aba7888385a66727322d80f8f46c6f580fb0`.

Thanks @superWorldSavior for identifying the shutdown ordering defect and contributing the original fix. This replacement preserves that work and credits Erwan Lee Pesle as co-author.

## What changed

- keep the queue-owner lease until an active turn has completed or cancelled
- close the agent bridge before releasing the lease
- preserve typed retryable shutdown responses, including exact request IDs
- track and bound-drain idle, control, pending, and active IPC sockets
- prevent nested prompt signal handling inside the detached queue owner
- add process-level regressions for SIGTERM, SIGINT, bridge death, connected clients, idle sockets, lease timing, and typed client results

## Proof

- `pnpm run check`: 836/836 repository tests and 109/109 coverage tests
- coverage: 94.14% statements, 87.36% branches, 96.07% functions, 94.14% lines
- focused IPC/lifecycle tests: 21/21
- live mock-agent trace: owner exit 0; bridge dead; lease held during cancellation and released afterward; client received typed `cancelled` result
- `git diff --check`: clean
- fresh autoreview: no accepted or actionable findings
- Public Model Identifier Gate: pass; this change introduces no model identifiers

Exact head: `f43fc244919f17ff93b396c120f1239a01bf20f4`
