### PR TITLE
fix: surface quiet-mode failures on stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/queue: drain active turns before releasing queue-owner leases and preserve typed retryable shutdown responses while terminating agent bridges. Thanks @superWorldSavior.
 
+- CLI/quiet output: emit exactly one structured stderr diagnostic for direct and queued prompt failures without adding diagnostics to stdout. Thanks @superWorldSavior.
+
 ## 2026.6.23 (v0.11.1)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ acpx --format json codex exec 'review this PR' \
 # json-strict: suppresses non-JSON stderr output (requires --format json)
 acpx --format json --json-strict codex exec 'review this PR'
 
-# quiet: final assistant text only
+# quiet: final assistant text on stdout; one structured stderr line on failure
 acpx --format quiet codex 'give me a 3-line summary'
 
 # suppress read payloads while keeping the selected output format
@@ -319,7 +319,7 @@ acpx --suppress-reads codex exec 'inspect the repo and report tool usage'
 
 - `text`: human-readable stream with assistant text and tool updates
 - `json`: raw ACP NDJSON stream for automation
-- `quiet`: final assistant text only
+- `quiet`: final assistant text on stdout; failed prompts emit one structured `[acpx] error:` line on stderr
 - `--suppress-reads`: replace raw read-file contents with `[read output suppressed]` in `text` and `json` output
 
 JSON events include a stable envelope for correlation:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -517,14 +517,14 @@ When a prompt is already in flight for a session, `acpx` uses a per-session queu
 
 - `text` (default): human-readable stream
 - `json`: raw ACP NDJSON stream for automation
-- `quiet`: assistant text only
+- `quiet`: assistant text on stdout; failed prompts emit one structured `[acpx] error:` line on stderr
 - `--format json --json-strict`: same ACP NDJSON stream, with non-JSON stderr output suppressed
 
 ### Prompt/exec output behavior
 
 - `text`: assistant text, tool status blocks, client-operation logs, plan updates, and `[done] <reason>`
 - `json`: one raw ACP JSON-RPC message per line
-- `quiet`: concatenated assistant text only
+- `quiet`: concatenated assistant text on stdout; failed prompts emit one structured `[acpx] error:` line on stderr
 
 When `--suppress-reads` is enabled:
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -83,6 +83,14 @@ echo "$SUMMARY"
 
 When the adapter includes final token usage and cost metadata in the prompt result, `acpx` emits that to **stderr** in `quiet` mode. stdout stays as the assistant text only.
 
+If a quiet prompt fails, `acpx` exits non-zero and emits exactly one single-line diagnostic to stderr:
+
+```text
+[acpx] error: <CODE> [<DETAIL_CODE>] <message>
+```
+
+`DETAIL_CODE` is omitted when unavailable. Embedded line endings in the message are replaced with spaces. The diagnostic never goes to stdout; quiet stdout remains reserved for any assistant text the adapter produced. This stderr contract applies to direct and queued prompts; it does not change the `json` or `--json-strict` streams.
+
 `quiet` is unaffected by `--suppress-reads` because it does not print tool call output to begin with.
 
 ## `--suppress-reads`

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -411,7 +411,7 @@ Use `--format <fmt>`:
 
 - `text` (default): human-readable stream with updates/tool status and done line
 - `json`: NDJSON event stream (good for automation)
-- `quiet`: final assistant text only
+- `quiet`: final assistant text on stdout; failed prompts emit one structured `[acpx] error:` line on stderr
 - `--suppress-reads`: replace raw read-file contents with `[read output suppressed]` in `text` and `json` output
 - `--json-strict`: pair with `--format json` to suppress non-JSON stderr noise (logs, banners) for downstream consumers
 

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -409,6 +409,13 @@ async function emitRequestedError(
     return;
   }
 
+  if (outputPolicy.format === "quiet") {
+    const formatter = createOutputFormatter("quiet");
+    formatter.onError(normalized);
+    formatter.flush();
+    return;
+  }
+
   if (!outputPolicy.suppressNonJsonStderr) {
     process.stderr.write(`${normalized.message}\n`);
     if (outputPolicy.format === "text") {

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -20,6 +20,7 @@ import {
 import { EXIT_CODES } from "../types.js";
 import type {
   OutputFormat,
+  OutputFormatter,
   OutputPolicy,
   SessionAgentContent,
   SessionRecord,
@@ -137,19 +138,28 @@ async function readPromptFromFile(
   return prompt;
 }
 
-function applyPermissionExitCode(result: {
-  permissionStats: {
-    requested: number;
-    approved: number;
-    denied: number;
-    cancelled: number;
-  };
-}): void {
+function applyPermissionExitCode(
+  result: {
+    permissionStats: {
+      requested: number;
+      approved: number;
+      denied: number;
+      cancelled: number;
+    };
+  },
+  quietOutput?: OutputFormatter,
+): void {
   const stats = result.permissionStats;
   const deniedOrCancelled = stats.denied + stats.cancelled;
 
   if (stats.requested > 0 && stats.approved === 0 && deniedOrCancelled > 0) {
     process.exitCode = EXIT_CODES.PERMISSION_DENIED;
+    quietOutput?.onError({
+      code: "PERMISSION_DENIED",
+      origin: "runtime",
+      message: "Permission request denied or cancelled",
+    });
+    quietOutput?.flush();
   }
 }
 
@@ -368,7 +378,7 @@ export async function handlePrompt(
     return;
   }
 
-  applyPermissionExitCode(result);
+  applyPermissionExitCode(result, outputPolicy.format === "quiet" ? outputFormatter : undefined);
 
   if (globalFlags.verbose && result.loadError) {
     process.stderr.write(
@@ -433,6 +443,9 @@ export async function handleExec(
     authPolicy: globalFlags.authPolicy,
     terminal: globalFlags.terminal,
     outputFormatter,
+    errorEmissionPolicy: {
+      queueErrorAlreadyEmitted: outputPolicy.queueErrorAlreadyEmitted,
+    },
     suppressSdkConsoleErrors: outputPolicy.suppressSdkConsoleErrors,
     timeoutMs: globalFlags.timeout,
     verbose: globalFlags.verbose,
@@ -445,7 +458,7 @@ export async function handleExec(
     },
   });
 
-  applyPermissionExitCode(result);
+  applyPermissionExitCode(result, outputPolicy.format === "quiet" ? outputFormatter : undefined);
 }
 
 function printCancelResultByFormat(

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -500,7 +500,7 @@ export function resolveOutputPolicy(format: OutputFormat, jsonStrict: boolean): 
     suppressReads: false,
     suppressNonJsonStderr: jsonStrict,
     queueErrorAlreadyEmitted: format !== "quiet",
-    suppressSdkConsoleErrors: jsonStrict,
+    suppressSdkConsoleErrors: jsonStrict || format === "quiet",
   };
 }
 

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -113,6 +113,17 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
+function parseJsonRpcErrorSummary(message: AcpJsonRpcMessage): string | undefined {
+  const fallback = parseJsonRpcErrorMessage(message);
+  if (!fallback) {
+    return undefined;
+  }
+
+  const error = asRecord((message as { error?: unknown }).error);
+  const details = asRecord(error?.data)?.details;
+  return typeof details === "string" && details.trim().length > 0 ? details.trim() : fallback;
+}
+
 function extractJsonRpcMethod(message: AnyMessage): string | undefined {
   return Object.hasOwn(message, "method")
     ? (message as { method?: unknown }).method?.toString()
@@ -786,7 +797,7 @@ class TextOutputFormatter implements OutputFormatter {
       return;
     }
 
-    const errorMessage = parseJsonRpcErrorMessage(message);
+    const errorMessage = parseJsonRpcErrorSummary(message);
     if (errorMessage) {
       this.onError({
         code: "RUNTIME",
@@ -1146,7 +1157,7 @@ class QuietOutputFormatter implements OutputFormatter {
     }
   }
 
-  onError(_params: {
+  onError(params: {
     code: OutputErrorCode;
     detailCode?: string;
     origin?: OutputErrorOrigin;
@@ -1155,7 +1166,9 @@ class QuietOutputFormatter implements OutputFormatter {
     acp?: OutputErrorAcpPayload;
     timestamp?: string;
   }): void {
-    // no-op in quiet mode
+    const qualifier = params.detailCode ? `${params.code} ${params.detailCode}` : params.code;
+    const message = preferredAcpErrorDetails(params.acp) ?? params.message;
+    this.stderr.write(`[acpx] error: ${qualifier} ${message.replace(/\r\n?|\n/g, " ")}\n`);
   }
 
   onPermissionEscalation(_event: PermissionEscalationEvent): void {
@@ -1258,6 +1271,11 @@ class QuietOutputFormatter implements OutputFormatter {
 
     return undefined;
   }
+}
+
+function preferredAcpErrorDetails(acp: OutputErrorAcpPayload | undefined): string | undefined {
+  const details = asRecord(acp?.data)?.details;
+  return typeof details === "string" && details.trim().length > 0 ? details.trim() : undefined;
 }
 
 export function createOutputFormatter(

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -160,7 +160,13 @@ function emitQueueOwnerError(
     });
     formatter.flush();
   }
-  return queueConnectionErrorFromOwner(message, queueErrorAlreadyEmitted);
+  // If we just emitted via the formatter, mark the error as already-emitted so
+  // that the top-level emitRequestedError handler (cli-core.ts) does not emit
+  // the same error a second time on stderr.  Without this, quiet mode (where
+  // queueErrorAlreadyEmitted === false) results in two stderr lines: one
+  // structured "[acpx] error: …" from the formatter and one raw line from the
+  // catch handler.
+  return queueConnectionErrorFromOwner(message, queueErrorAlreadyEmitted || shouldEmitInFormatter);
 }
 
 function parseQueueOwnerResponseLine(

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -50,6 +50,7 @@ export type RunOnceOptions = {
   authPolicy?: AuthPolicy;
   terminal?: boolean;
   outputFormatter: OutputFormatter;
+  errorEmissionPolicy?: OutputErrorEmissionPolicy;
   onAcpMessage?: (direction: AcpMessageDirection, message: AcpJsonRpcMessage) => void;
   onSessionUpdate?: (notification: SessionNotification) => void;
   onClientOperation?: (operation: ClientOperation) => void;

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -1,5 +1,6 @@
 import { AcpClient } from "../../acp/client.js";
 import {
+  extractAcpError,
   formatErrorMessage,
   isRetryablePromptError,
   normalizeOutputError,
@@ -55,11 +56,13 @@ import {
 } from "../../session/persistence.js";
 import type {
   AcpJsonRpcMessage,
+  AcpMessageDirection,
   AuthPolicy,
   McpServer,
   NonInteractivePermissionPolicy,
   OutputErrorAcpPayload,
   OutputErrorCode,
+  OutputErrorEmissionPolicy,
   OutputErrorOrigin,
   OutputFormatter,
   PermissionEscalationEvent,
@@ -77,7 +80,7 @@ const INTERRUPT_CANCEL_WAIT_MS = 2_500;
 
 type RunSessionPromptOptions = Omit<
   SessionSendOptions,
-  "errorEmissionPolicy" | "maxQueueDepth" | "sessionId" | "ttlMs" | "waitForCompletion"
+  "maxQueueDepth" | "sessionId" | "ttlMs" | "waitForCompletion"
 > & {
   sessionRecordId: string;
   handleProcessInterrupts?: boolean;
@@ -87,6 +90,11 @@ type RunSessionPromptOptions = Omit<
 };
 
 type ActiveSessionController = QueueOwnerActiveSessionController;
+
+type BufferedAcpOutputMessage = {
+  direction: AcpMessageDirection;
+  message: AcpJsonRpcMessage;
+};
 
 class QueueTaskOutputFormatter implements OutputFormatter {
   private readonly requestId: string;
@@ -146,6 +154,81 @@ const DISCARD_OUTPUT_FORMATTER: OutputFormatter = {
   onPermissionEscalation() {},
   flush() {},
 };
+
+function markOutputAlreadyEmitted(error: unknown, outputAlreadyEmitted: boolean): void {
+  if (!outputAlreadyEmitted || !error || typeof error !== "object") {
+    return;
+  }
+  (error as { outputAlreadyEmitted?: boolean }).outputAlreadyEmitted = true;
+}
+
+async function runWithOptionalInterrupt<T>(options: {
+  handleProcessInterrupts?: boolean;
+  run: () => Promise<T>;
+  handleInterrupt: () => Promise<void>;
+}): Promise<T> {
+  if (options.handleProcessInterrupts === false) {
+    return await options.run();
+  }
+  return await withInterrupt(options.run, options.handleInterrupt);
+}
+
+function attachAcpErrorPayload(error: unknown, acp: OutputErrorAcpPayload | undefined): void {
+  if (!acp || !error || typeof error !== "object") {
+    return;
+  }
+  (error as { acp?: OutputErrorAcpPayload }).acp = acp;
+}
+
+function rendersAcpErrors(policy: OutputErrorEmissionPolicy | undefined): boolean {
+  return policy?.queueErrorAlreadyEmitted ?? true;
+}
+
+function normalizedErrorText(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function outboundAcpErrorMatches(error: unknown, acp: OutputErrorAcpPayload): boolean {
+  const errorText = normalizedErrorText(formatErrorMessage(error));
+  const details = (acp.data as { details?: unknown } | undefined)?.details;
+  const candidate =
+    typeof details === "string" && details.trim().length > 0 ? details : acp.message;
+  const candidateText = normalizedErrorText(candidate);
+  return errorText === candidateText || errorText.includes(candidateText);
+}
+
+class AcpErrorTracker {
+  private latestInbound: OutputErrorAcpPayload | undefined;
+  private readonly outbound: OutputErrorAcpPayload[] = [];
+
+  reset(): void {
+    this.latestInbound = undefined;
+    this.outbound.length = 0;
+  }
+
+  observe(
+    output: OutputFormatter,
+    direction: AcpMessageDirection,
+    message: AcpJsonRpcMessage,
+  ): void {
+    output.onAcpMessage(message);
+    const acp = extractAcpError(message);
+    if (!acp) {
+      return;
+    }
+    if (direction === "inbound") {
+      this.latestInbound = acp;
+      return;
+    }
+    this.outbound.push(acp);
+  }
+
+  match(error: unknown): OutputErrorAcpPayload | undefined {
+    return (
+      this.latestInbound ?? this.outbound.findLast((acp) => outboundAcpErrorMatches(error, acp))
+    );
+  }
+}
 
 function toPromptResult(
   stopReason: RunPromptResult["stopReason"],
@@ -366,6 +449,19 @@ function filterRecoverableLoadFallbackOutput(messages: AcpJsonRpcMessage[]): Acp
   });
 }
 
+function filterBufferedConnectOutput(
+  messages: BufferedAcpOutputMessage[],
+  loadError: string | undefined,
+): BufferedAcpOutputMessage[] {
+  if (loadError == null) {
+    return messages;
+  }
+  const filteredMessages = new Set(
+    filterRecoverableLoadFallbackOutput(messages.map(({ message }) => message)),
+  );
+  return messages.filter(({ message }) => filteredMessages.has(message));
+}
+
 function emitPromptRetryNotice(params: {
   error: unknown;
   delayMs: number;
@@ -483,6 +579,7 @@ function buildQueuedTaskRunOptions(
     authCredentials: options.authCredentials,
     authPolicy: options.authPolicy,
     outputFormatter,
+    errorEmissionPolicy: { queueErrorAlreadyEmitted: true },
     timeoutMs: task.timeoutMs,
     suppressSdkConsoleErrors: task.suppressSdkConsoleErrors ?? options.suppressSdkConsoleErrors,
     verbose: options.verbose,
@@ -572,6 +669,7 @@ export async function runQueuedTask(
 async function runSessionPrompt(options: RunSessionPromptOptions): Promise<SessionSendResult> {
   const stopTotalTimer = startPerfTimer("runtime.prompt.total");
   const output = options.outputFormatter;
+  const shouldMarkAcpErrorsEmitted = rendersAcpErrors(options.errorEmissionPolicy);
   const record = await measurePerf("session.resolve_prompt_record", async () => {
     return await resolveSessionRecord(options.sessionRecordId);
   });
@@ -593,7 +691,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     return await SessionEventWriter.open(record);
   });
   const pendingMessages: AcpJsonRpcMessage[] = [];
-  const pendingConnectOutputMessages: AcpJsonRpcMessage[] = [];
+  const pendingConnectOutputMessages: BufferedAcpOutputMessage[] = [];
   const sessionOptions = mergeSessionOptions(
     options.sessionOptions,
     sessionOptionsFromRecord(record),
@@ -601,7 +699,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
   let bufferingConnectOutput = true;
   let promptTurnActive = false;
   let promptTurnHadSideEffects = false;
-  let sawAcpMessage = false;
+  const acpErrors = new AcpErrorTracker();
   let eventWriterClosed = false;
 
   const closeEventWriter = async (checkpoint: boolean): Promise<void> => {
@@ -683,16 +781,15 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
   });
   client.setEventHandlers({
     onAcpMessage: (direction, message) => {
-      sawAcpMessage = true;
       pendingMessages.push(message);
       options.onAcpMessage?.(direction, message);
     },
-    onAcpOutputMessage: (_direction, message) => {
+    onAcpOutputMessage: (direction, message) => {
       if (bufferingConnectOutput) {
-        pendingConnectOutputMessages.push(message);
+        pendingConnectOutputMessages.push({ direction, message });
         return;
       }
-      output.onAcpMessage(message);
+      acpErrors.observe(output, direction, message);
     },
     onSessionUpdate: (notification) => {
       if (promptTurnActive) {
@@ -764,12 +861,9 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
 
   const flushConnectOutput = (loadError?: string): void => {
     bufferingConnectOutput = false;
-    const messages =
-      loadError == null
-        ? pendingConnectOutputMessages
-        : filterRecoverableLoadFallbackOutput(pendingConnectOutputMessages);
-    for (const message of messages) {
-      output.onAcpMessage(message);
+    const outputMessages = filterBufferedConnectOutput(pendingConnectOutputMessages, loadError);
+    for (const { direction, message } of outputMessages) {
+      acpErrors.observe(output, direction, message);
     }
     pendingConnectOutputMessages.length = 0;
   };
@@ -822,6 +916,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
   };
 
   const runPromptAttempt = async (sessionId: string, attempt: number) => {
+    acpErrors.reset();
     const promptStartedAt = Date.now();
     const response = await measurePerf("runtime.prompt.agent_turn", async () => {
       return await runPromptTurn({
@@ -867,7 +962,11 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     promptTurnActive = false;
     applyLifecycleSnapshotToRecord(record, snapshot);
     emitPromptDisconnectNotice(snapshot, options.verbose);
-    const normalizedError = normalizeOutputError(error, { origin: "runtime" });
+    const matchedAcpError = acpErrors.match(error);
+    const normalizedError = normalizeOutputError(error, {
+      origin: "runtime",
+      acp: matchedAcpError,
+    });
     await flushPendingMessages(false).catch(() => {
       // best effort while bubbling prompt failure
     });
@@ -876,7 +975,9 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     applyConversation(record, conversation);
     record.acpx = acpxState;
     const propagated = error instanceof Error ? error : new Error(formatErrorMessage(error));
-    (propagated as { outputAlreadyEmitted?: boolean }).outputAlreadyEmitted = sawAcpMessage;
+    attachAcpErrorPayload(propagated, normalizedError.acp);
+    (propagated as { outputAlreadyEmitted?: boolean }).outputAlreadyEmitted =
+      matchedAcpError !== undefined && shouldMarkAcpErrorsEmitted;
     (propagated as { normalizedOutputError?: unknown }).normalizedOutputError = normalizedError;
     throw propagated;
   };
@@ -954,10 +1055,16 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
   };
 
   try {
-    if (options.handleProcessInterrupts === false) {
-      return await runPrompt();
-    }
-    return await withInterrupt(runPrompt, handleInterrupt);
+    return await runWithOptionalInterrupt({
+      handleProcessInterrupts: options.handleProcessInterrupts,
+      run: runPrompt,
+      handleInterrupt,
+    });
+  } catch (error) {
+    const matchedAcpError = acpErrors.match(error);
+    attachAcpErrorPayload(error, matchedAcpError);
+    markOutputAlreadyEmitted(error, matchedAcpError !== undefined && shouldMarkAcpErrorsEmitted);
+    throw error;
   } finally {
     if (options.verbose) {
       process.stderr.write(`[acpx] ${formatPerfMetric("prompt.total", stopTotalTimer())}\n`);
@@ -991,8 +1098,10 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
 
 export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult> {
   const output = options.outputFormatter;
+  const shouldMarkAcpErrorsEmitted = rendersAcpErrors(options.errorEmissionPolicy);
   let promptTurnActive = false;
   let promptTurnHadSideEffects = false;
+  const acpErrors = new AcpErrorTracker();
   const client = new AcpClient({
     agentCommand: options.agentCommand,
     cwd: absolutePath(options.cwd),
@@ -1006,7 +1115,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
     suppressSdkConsoleErrors: options.suppressSdkConsoleErrors,
     verbose: options.verbose,
     onAcpMessage: options.onAcpMessage,
-    onAcpOutputMessage: (_direction, message) => output.onAcpMessage(message),
+    onAcpOutputMessage: (direction, message) => {
+      acpErrors.observe(output, direction, message);
+    },
     onSessionUpdate: (notification) => {
       if (promptTurnActive) {
         promptTurnHadSideEffects = true;
@@ -1027,6 +1138,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
   });
 
   const runExecPromptAttempt = async (sessionId: string) => {
+    acpErrors.reset();
     return await measurePerf("runtime.exec.prompt", async () => {
       return await withTimeout(client.prompt(sessionId, options.prompt), options.timeoutMs);
     });
@@ -1090,6 +1202,11 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
         await client.close();
       },
     );
+  } catch (error) {
+    const matchedAcpError = acpErrors.match(error);
+    attachAcpErrorPayload(error, matchedAcpError);
+    markOutputAlreadyEmitted(error, matchedAcpError !== undefined && shouldMarkAcpErrorsEmitted);
+    throw error;
   } finally {
     await client.close();
   }
@@ -1108,6 +1225,7 @@ export async function sendSessionDirect(options: SessionSendOptions): Promise<Se
     authPolicy: options.authPolicy,
     terminal: options.terminal,
     outputFormatter: options.outputFormatter,
+    errorEmissionPolicy: options.errorEmissionPolicy,
     onAcpMessage: options.onAcpMessage,
     onSessionUpdate: options.onSessionUpdate,
     onClientOperation: options.onClientOperation,

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -464,7 +464,7 @@ test("resolveOutputPolicy maps json-strict output behavior", () => {
     suppressReads: false,
     suppressNonJsonStderr: false,
     queueErrorAlreadyEmitted: false,
-    suppressSdkConsoleErrors: false,
+    suppressSdkConsoleErrors: true,
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1488,23 +1488,16 @@ test("queued prompt failures remain visible in quiet mode", async () => {
       });
 
       const writeResult = await runCli(
-        [
-          "--cwd",
-          cwd,
-          "--format",
-          "quiet",
-          "--non-interactive-permissions",
-          "fail",
-          "codex",
-          "prompt",
-          `write ${path.join(cwd, "x.txt")} hi`,
-        ],
+        ["--cwd", cwd, "--format", "quiet", "codex", "prompt", "retryable-error-once"],
         homeDir,
       );
 
-      assert.equal(writeResult.code, 5);
-      assert.match(writeResult.stdout, /error:\s*Internal error/i);
-      assert.match(writeResult.stderr, /Permission prompt unavailable in non-interactive mode/);
+      assert.equal(writeResult.code, 1);
+      assert.equal(writeResult.stdout, "");
+      assert.equal(
+        writeResult.stderr,
+        "[acpx] error: RUNTIME QUEUE_RUNTIME_PROMPT_FAILED Internal error\n",
+      );
     } finally {
       if (blocker.exitCode === null && blocker.signalCode == null) {
         blocker.kill("SIGKILL");
@@ -1513,6 +1506,156 @@ test("queued prompt failures remain visible in quiet mode", async () => {
         });
       }
     }
+  });
+});
+
+test("queued setup failures emit exactly one structured quiet diagnostic", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(homeDir, ".acpx", "config.json"),
+      `${JSON.stringify(
+        {
+          agents: {
+            codex: {
+              command: `${MOCK_AGENT_COMMAND} --set-session-model-fails`,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const session = await runCli(
+      ["--cwd", cwd, "--format", "json", "codex", "sessions", "new"],
+      homeDir,
+    );
+    assert.equal(session.code, 0, session.stderr);
+
+    const blocker = spawn(
+      process.execPath,
+      [CLI_PATH, "--cwd", cwd, "codex", "prompt", "sleep 1500"],
+      {
+        env: { ...process.env, HOME: homeDir },
+        stdio: ["ignore", "ignore", "ignore"],
+      },
+    );
+
+    try {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200);
+      });
+
+      const writeResult = await runCli(
+        [
+          "--cwd",
+          cwd,
+          "--format",
+          "quiet",
+          "--model",
+          "fast-model",
+          "codex",
+          "prompt",
+          "queued model failure",
+        ],
+        homeDir,
+      );
+
+      assert.equal(writeResult.code, 1);
+      assert.equal(writeResult.stdout, "");
+      assert.equal(
+        writeResult.stderr,
+        "[acpx] error: RUNTIME QUEUE_RUNTIME_PROMPT_FAILED setSessionModel failed\n",
+      );
+    } finally {
+      if (blocker.exitCode === null && blocker.signalCode == null) {
+        blocker.kill("SIGKILL");
+        await new Promise<void>((resolve) => {
+          blocker.once("close", () => resolve());
+        });
+      }
+    }
+  });
+});
+
+test("direct prompt failures emit exactly one structured quiet diagnostic", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const result = await runCli(
+      [
+        "--agent",
+        MOCK_AGENT_COMMAND,
+        "--cwd",
+        cwd,
+        "--format",
+        "quiet",
+        "exec",
+        "retryable-error-once",
+      ],
+      homeDir,
+    );
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "[acpx] error: RUNTIME Internal error\n");
+  });
+});
+
+test("quiet successful prompts do not report handled ACP client errors", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const result = await runCli(
+      [
+        "--agent",
+        MOCK_AGENT_COMMAND,
+        "--cwd",
+        cwd,
+        "--format",
+        "quiet",
+        "exec",
+        `read ${path.join(cwd, "missing.txt")}`,
+      ],
+      homeDir,
+    );
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /^error:/i);
+    assert.equal(result.stderr, "");
+  });
+});
+
+test("quiet successful retries do not report intermediate ACP errors", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const result = await runCli(
+      [
+        "--agent",
+        MOCK_AGENT_COMMAND,
+        "--cwd",
+        cwd,
+        "--format",
+        "quiet",
+        "--prompt-retries",
+        "1",
+        "exec",
+        "retryable-error-once",
+      ],
+      homeDir,
+    );
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(result.stdout, "recovered after retry\n");
+    assert.equal(result.stderr, "");
   });
 });
 
@@ -1559,6 +1702,10 @@ test("non-queued write permission denial exits with code 5", async () => {
 
     assert.equal(writeResult.code, 5);
     assert.match(writeResult.stdout, /error:\s*Internal error/i);
+    assert.equal(
+      writeResult.stderr,
+      "[acpx] error: PERMISSION_DENIED Permission request denied or cancelled\n",
+    );
   });
 });
 
@@ -1611,6 +1758,20 @@ test("prompt exits with NO_SESSION when no session exists (no auto-create)", asy
         `⚠ No acpx session found \\(searched up to ${escapedCwd}\\)\\.\\nCreate one: acpx codex sessions new\\n?`,
       ),
     );
+  });
+});
+
+test("quiet prompt emits a structured NO_SESSION diagnostic", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace", "packages", "app");
+    await fs.mkdir(cwd, { recursive: true });
+
+    const result = await runCli(["--cwd", cwd, "--format", "quiet", "codex", "hello"], homeDir);
+
+    assert.equal(result.code, 4);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr.split("\n").filter(Boolean).length, 1);
+    assert.match(result.stderr, /^\[acpx\] error: NO_SESSION /);
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1170,7 +1170,8 @@ test("integration: non-Devin ACP launch rejects Devin diagnostics extension requ
         result.stdout,
         /extension request accepted: _cognition\.ai\/request_diagnostics/,
       );
-      assert.match(result.stderr, /"Method not found": _cognition\.ai\/request_diagnostics/);
+      assert.match(result.stdout, /^error:/i);
+      assert.equal(result.stderr, "");
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -54,6 +54,18 @@ function doneResult(stopReason: string, result: Record<string, unknown> = {}): u
   };
 }
 
+function errorResult(message: string, details?: string): unknown {
+  return {
+    jsonrpc: "2.0",
+    id: "req-1",
+    error: {
+      code: -32603,
+      message,
+      ...(details ? { data: { details } } : {}),
+    },
+  };
+}
+
 test("text formatter batches thought chunks from ACP notifications", () => {
   const writer = new CaptureWriter();
   const formatter = createOutputFormatter("text", { stdout: writer });
@@ -589,4 +601,112 @@ test("quiet formatter emits final usage and cost metadata to stderr", () => {
     stderr.toString(),
     "[acpx] tokens: input=17030 output=4 cache_read=12 cache_write=3 total=17049\n[acpx] cost: 0.051276 USD\n",
   );
+});
+
+test("quiet formatter ignores non-terminal ACP JSON-RPC errors", () => {
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onAcpMessage(errorResult("provider failed") as never);
+
+  assert.equal(stdout.toString(), "");
+  assert.equal(stderr.toString(), "");
+});
+
+test("quiet formatter emits structured error line to stderr on onError (never swallows errors)", () => {
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    detailCode: "QUEUE_RUNTIME_PROMPT_FAILED",
+    origin: "queue",
+    message: "rate limit exceeded",
+  });
+
+  // stdout must remain empty — the quiet contract only covers stdout
+  assert.equal(stdout.toString(), "");
+  // stderr must contain exactly one structured line, parseable by machines
+  assert.equal(
+    stderr.toString(),
+    "[acpx] error: RUNTIME QUEUE_RUNTIME_PROMPT_FAILED rate limit exceeded\n",
+  );
+});
+
+test("quiet formatter prefers actionable ACP details on terminal errors", () => {
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    message: "Internal error",
+    acp: {
+      code: -32603,
+      message: "Internal error",
+      data: { details: "provider quota exceeded" },
+    },
+  });
+
+  assert.equal(stderr.toString(), "[acpx] error: RUNTIME provider quota exceeded\n");
+});
+
+test("quiet formatter onError line uses code when detailCode is absent", () => {
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "NO_SESSION",
+    message: "session not found",
+  });
+
+  assert.equal(stdout.toString(), "");
+  assert.equal(stderr.toString(), "[acpx] error: NO_SESSION session not found\n");
+});
+
+test("quiet formatter onError collapses multi-line message to a single stderr line", () => {
+  // A message containing \n would break a line-by-line parser reading stderr.
+  // The formatter must squash all newlines before interpolation.
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    message: "line one\nline two\nline three",
+  });
+
+  assert.equal(stdout.toString(), "");
+  const stderrStr = stderr.toString();
+  // Exactly one non-empty line in the output.
+  assert.equal(
+    stderrStr.split("\n").filter(Boolean).length,
+    1,
+    "stderr must be a single line when the message contains embedded newlines",
+  );
+  assert.equal(stderrStr, "[acpx] error: RUNTIME line one line two line three\n");
+});
+
+test("quiet formatter onError collapses CRLF line endings in message to a single stderr line", () => {
+  // Windows-style \r\n line endings must be collapsed the same way as \n.
+  // A lone \r (old Mac style) is also normalised.
+  const stdout = new CaptureWriter();
+  const stderr = new CaptureWriter();
+  const formatter = createOutputFormatter("quiet", { stdout, stderr });
+
+  formatter.onError({
+    code: "RUNTIME",
+    message: "line one\r\nline two\r\nline three",
+  });
+
+  assert.equal(stdout.toString(), "");
+  const stderrStr = stderr.toString();
+  assert.equal(
+    stderrStr.split("\n").filter(Boolean).length,
+    1,
+    "stderr must be a single line when the message contains embedded CRLF newlines",
+  );
+  assert.equal(stderrStr, "[acpx] error: RUNTIME line one line two line three\n");
 });

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -883,3 +883,102 @@ test("trySubmitToRunningOwner recovers stale owners before MCP conflict checks",
     }
   });
 });
+
+test("trySubmitToRunningOwner marks quiet errors as outputAlreadyEmitted after formatter emits", async () => {
+  // Regression test for double-emission in quiet mode.
+  //
+  // When the owner has not emitted an ACP error event, emitQueueOwnerError()
+  // calls formatter.onError() to emit the structured error line, then must
+  // return a QueueConnectionError with
+  // outputAlreadyEmitted === true so that the top-level emitRequestedError
+  // handler in cli-core.ts does not emit the same error a second time on
+  // stderr.  Without the fix, two stderr lines would appear: one structured
+  // "[acpx] error: …" from the formatter and one raw line from the catch.
+  await withTempHome(async (homeDir) => {
+    const sessionId = "quiet-double-emit-session";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+    });
+
+    const server = createSingleRequestServer((socket, request) => {
+      assert.equal(request.type, "submit_prompt");
+      socket.write(
+        `${JSON.stringify({
+          type: "accepted",
+          requestId: request.requestId,
+        })}\n`,
+      );
+      socket.write(
+        `${JSON.stringify({
+          type: "error",
+          requestId: request.requestId,
+          code: "RUNTIME",
+          detailCode: "QUEUE_RUNTIME_PROMPT_FAILED",
+          origin: "queue",
+          retryable: false,
+          message: "prompt failed in queue owner",
+        })}\n`,
+      );
+      socket.end();
+    });
+
+    await listenServer(server, socketPath);
+
+    const onErrorCalls: string[] = [];
+    const spyFormatter: OutputFormatter = {
+      setContext() {
+        // no-op
+      },
+      onAcpMessage() {
+        // no-op
+      },
+      onError(params) {
+        onErrorCalls.push(params.code);
+      },
+      onPermissionEscalation() {
+        // no-op
+      },
+      flush() {
+        // no-op
+      },
+    };
+
+    try {
+      await assert.rejects(
+        async () =>
+          await trySubmitToRunningOwner({
+            sessionId,
+            message: "hello",
+            permissionMode: "approve-reads",
+            outputFormatter: spyFormatter,
+            errorEmissionPolicy: { queueErrorAlreadyEmitted: true },
+            waitForCompletion: true,
+          }),
+        (error: unknown) => {
+          assert(error instanceof QueueConnectionError, "expected QueueConnectionError");
+          // After the fix: formatter emitted once → error must be marked so
+          // the top-level handler does not emit a second time.
+          assert.equal(
+            error.outputAlreadyEmitted,
+            true,
+            "QueueConnectionError must carry outputAlreadyEmitted=true when formatter already emitted",
+          );
+          return true;
+        },
+      );
+
+      // The formatter's onError must have been called exactly once.
+      assert.equal(onErrorCalls.length, 1, "formatter.onError must be called exactly once");
+      assert.equal(onErrorCalls[0], "RUNTIME");
+    } finally {
+      await closeServer(server);
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});


### PR DESCRIPTION
Supersedes #425 because the contributor branch advertises maintainer edits but rejects authenticated maintainer pushes. The original head remains untouched at `74f908024c345f3b165f6fe1fb74be40398f015a`.

Thanks @superWorldSavior for identifying the silent quiet-mode failure and contributing the original fix. This replacement preserves that work and credits Erwan Lee Pesle as co-author.

## What changed

- emit exactly one structured stderr diagnostic for failed `quiet` prompts
- preserve assistant-only quiet stdout
- cover direct, queued, setup, permission, and no-session failures
- attach terminal ACP error details without leaking handled or intermediate retry errors
- propagate `outputAlreadyEmitted` so queued failures are never duplicated
- document the quiet stderr contract across public docs and the ACPX skill
- retain detached queue-owner signal handling introduced by #430

## Proof

- `pnpm run check`: 848/848 repository tests and 109/109 coverage tests
- coverage: 94.14% statements, 87.36% branches, 96.07% functions, 94.14% lines
- `pnpm run check:docs`: clean; docs site built
- skill frontmatter: YAML-valid
- live mock-agent CLI: exit 1, stdout 0 bytes, exactly one stderr line: `[acpx] error: RUNTIME Internal error`
- `git diff --check`: clean
- fresh autoreview: no accepted or actionable findings
- Public Model Identifier Gate: pass; this change introduces no model identifiers

Exact head: `0421aa5b0a71a306252f591d3c3285d978ad7e50`
