### PR TITLE
fix(client): reap the bridge process tree on close

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -442,6 +442,7 @@ export class AcpClient {
   private agentStartedAt?: string;
   private lastAgentExit?: AgentExitInfo;
   private lastKnownPid?: number;
+  private agentGroupLeader = false;
   private readonly promptPermissionFailures = new Map<string, PermissionPromptUnavailableError>();
   private readonly pendingConnectionRequests = new Set<PendingConnectionRequest>();
   private readonly modelConfigIds = new Map<string, string>();
@@ -710,11 +711,16 @@ export class AcpClient {
   private async spawnAgentProcess(
     plan: AgentLaunchPlan,
   ): Promise<ChildProcessByStdio<Writable, Readable, Readable>> {
+    const agentGroupLeader = process.platform !== "win32";
     const spawnedChild = spawn(
       plan.spawnCommand,
       plan.args,
-      buildSpawnCommandOptions(plan.spawnCommand, plan.spawnOptions),
+      buildSpawnCommandOptions(plan.spawnCommand, {
+        ...plan.spawnOptions,
+        detached: agentGroupLeader,
+      }),
     ) as ChildProcessByStdio<Writable, Readable, Readable>;
+    this.agentGroupLeader = agentGroupLeader;
     try {
       await waitForSpawn(spawnedChild);
     } catch (error) {
@@ -1369,6 +1375,7 @@ export class AcpClient {
     this.initResult = undefined;
     this.connection = undefined;
     this.agent = undefined;
+    this.agentGroupLeader = false;
   }
 
   private async terminateAgentProcess(
@@ -1381,6 +1388,14 @@ export class AcpClient {
     if (!exited) {
       this.log(`agent did not exit after ${AGENT_CLOSE_TERM_GRACE_MS}ms; forcing SIGKILL`);
       exited = await this.killAgentIfRunning(child, exited, "SIGKILL", AGENT_CLOSE_KILL_GRACE_MS);
+    }
+
+    // The bridge PID may have exited on its own during the stdin-close grace,
+    // which bypasses the group signal above. Sweep the process group once more
+    // (best-effort) so descendants that outlived the bridge — model process,
+    // MCP servers — are reaped instead of leaking.
+    if (this.agentGroupLeader && child.pid !== undefined) {
+      this.signalAgentProcess(child, "SIGKILL");
     }
 
     // Ensure stdio handles don't keep this process alive after close() returns.
@@ -1408,12 +1423,41 @@ export class AcpClient {
     if (alreadyExited || !isChildProcessRunning(child)) {
       return alreadyExited;
     }
-    try {
-      child.kill(signal);
-    } catch {
-      // best effort
-    }
+    this.signalAgentProcess(child, signal);
     return await waitForChildExit(child, waitMs);
+  }
+
+  private signalAgentProcess(
+    child: ChildProcessByStdio<Writable, Readable, Readable>,
+    signal: NodeJS.Signals,
+  ): void {
+    const pid = child.pid;
+    // Detached Unix bridges lead their own process group (pgid == pid), so a
+    // negative PID reaps that group and its descendants. agentGroupLeader gates
+    // it so acpx never signals its own group. A failed group signal — and every
+    // non-detached / Windows case — falls back to killing the bridge PID.
+    if (this.agentGroupLeader && pid !== undefined) {
+      if (this.tryKill(() => process.kill(-pid, signal), signal, `group -${pid}`)) {
+        return;
+      }
+    }
+    this.tryKill(() => child.kill(signal), signal, `pid ${pid ?? "unknown"}`);
+  }
+
+  private tryKill(kill: () => void, signal: NodeJS.Signals, target: string): boolean {
+    try {
+      kill();
+      return true;
+    } catch (error) {
+      // ESRCH just means the target is already gone (the common case); anything
+      // else (e.g. EPERM) gets a debug trace so a silent descendant leak stays
+      // diagnosable.
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "ESRCH") {
+        this.log(`agent ${signal} to ${target} failed: ${(error as Error | undefined)?.message ?? code}`);
+      }
+      return false;
+    }
   }
 
   private detachAgentHandles(agent: ChildProcess, unref: boolean): void {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import type { RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
 import {
   AcpClient,
@@ -20,6 +22,10 @@ import {
   PermissionPromptUnavailableError,
   UnsupportedPromptContentError,
 } from "../src/errors.js";
+import { isProcessAlive } from "../src/process-liveness.js";
+import { fileExists, withTempDir } from "./runtime-test-helpers.js";
+
+const MOCK_AGENT_PATH = fileURLToPath(new URL("./mock-agent.js", import.meta.url));
 
 test("parseAcpJsonMessageLine ignores non-object JSON values", () => {
   for (const line of ["1", "null", '"diagnostic"', "[]", "[{}]"]) {
@@ -1276,6 +1282,103 @@ test("AcpClient start fails fast when the agent exits during initialize", async 
   assert(Date.now() - startedAt < 2_000);
 });
 
+test("AcpClient close terminates long-lived bridge grandchildren", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  await withTempDir("acpx-client-grandchild-", async (tempDir) => {
+    const grandchildPidFile = path.join(tempDir, "grandchild.pid");
+    const client = makeClient({
+      agentCommand: [
+        JSON.stringify(process.execPath),
+        JSON.stringify(MOCK_AGENT_PATH),
+        "--ignore-sigterm",
+        "--stay-alive-after-stdin-end",
+        "--grandchild-pid-file",
+        JSON.stringify(grandchildPidFile),
+      ].join(" "),
+    });
+    let grandchildPid: number | undefined;
+
+    try {
+      await client.start();
+      await waitUntil(() => fileExists(grandchildPidFile));
+
+      grandchildPid = Number((await fs.readFile(grandchildPidFile, "utf8")).trim());
+      assert(
+        Number.isInteger(grandchildPid) && grandchildPid > 0,
+        "grandchild PID must be a positive integer",
+      );
+      assert.equal(isProcessAlive(grandchildPid), true, "grandchild must be alive before close");
+
+      await client.close();
+
+      const grandchildExited = await waitUntil(() =>
+        Promise.resolve(!isProcessAlive(grandchildPid)),
+      );
+      assert.equal(
+        grandchildExited,
+        true,
+        `grandchild process ${grandchildPid} must be dead after AcpClient.close()`,
+      );
+    } finally {
+      await client.close();
+      killProcessIfAlive(grandchildPid);
+    }
+  });
+});
+
+test("AcpClient close reaps grandchildren when the bridge exits during stdin-close", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  // A well-behaved bridge exits on stdin-close (no --ignore-sigterm /
+  // --stay-alive-after-stdin-end), but it spawned a grandchild that outlives it.
+  // The bridge PID is already gone before the SIGTERM path runs, so only the
+  // final group sweep can reap the grandchild.
+  await withTempDir("acpx-client-grandchild-cleanexit-", async (tempDir) => {
+    const grandchildPidFile = path.join(tempDir, "grandchild.pid");
+    const client = makeClient({
+      agentCommand: [
+        JSON.stringify(process.execPath),
+        JSON.stringify(MOCK_AGENT_PATH),
+        "--exit-on-stdin-end",
+        "--grandchild-pid-file",
+        JSON.stringify(grandchildPidFile),
+      ].join(" "),
+    });
+    let grandchildPid: number | undefined;
+
+    try {
+      await client.start();
+      await waitUntil(() => fileExists(grandchildPidFile));
+
+      grandchildPid = Number((await fs.readFile(grandchildPidFile, "utf8")).trim());
+      assert(
+        Number.isInteger(grandchildPid) && grandchildPid > 0,
+        "grandchild PID must be a positive integer",
+      );
+      assert.equal(isProcessAlive(grandchildPid), true, "grandchild must be alive before close");
+
+      await client.close();
+
+      const grandchildExited = await waitUntil(() =>
+        Promise.resolve(!isProcessAlive(grandchildPid)),
+      );
+      assert.equal(
+        grandchildExited,
+        true,
+        `grandchild ${grandchildPid} must be dead after close even when the bridge exited on its own`,
+      );
+    } finally {
+      await client.close();
+      killProcessIfAlive(grandchildPid);
+    }
+  });
+});
+
 test("AcpClient close resets in-memory state and shuts down terminal manager", async () => {
   const client = makeClient();
   const internals = asInternals(client);
@@ -1356,6 +1459,32 @@ function makeClient(
 
 function asInternals(client: AcpClient): ClientInternals {
   return client as unknown as ClientInternals;
+}
+
+async function waitUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs = 2_000,
+  pollMs = 50,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) {
+      return true;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+  }
+  return false;
+}
+
+function killProcessIfAlive(pid: number | undefined): void {
+  if (pid === undefined || !isProcessAlive(pid)) {
+    return;
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // best effort cleanup for the intentional RED leak
+  }
 }
 
 function makePermissionRequest(

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import path from "node:path";
@@ -68,8 +69,12 @@ type MockAgentOptions = {
   loadReplayText: string;
   ignoreSigterm: boolean;
   cancelDelayMs: number;
+  stayAliveAfterStdinEnd: boolean;
+  exitOnStdinEnd: boolean;
   /** If set, the agent writes its PID to this path at startup (before ACP handshake). */
   pidFile?: string;
+  /** If set, the agent spawns a long-lived child and writes its PID to this path. */
+  grandchildPidFile?: string;
 };
 
 type SessionState = {
@@ -379,7 +384,10 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let ignoreSigterm = false;
   let cancelDelayMs = 0;
   let hangOnNewSession = false;
+  let stayAliveAfterStdinEnd = false;
+  let exitOnStdinEnd = false;
   let pidFile: string | undefined;
+  let grandchildPidFile: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -513,6 +521,16 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       continue;
     }
 
+    if (token === "--stay-alive-after-stdin-end") {
+      stayAliveAfterStdinEnd = true;
+      continue;
+    }
+
+    if (token === "--exit-on-stdin-end") {
+      exitOnStdinEnd = true;
+      continue;
+    }
+
     if (token === "--cancel-delay-ms") {
       cancelDelayMs = parsePositiveIntegerOption(argv, index + 1, token);
       index += 1;
@@ -526,6 +544,12 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
 
     if (token === "--pid-file") {
       pidFile = parseOptionValue(argv, index + 1, token);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--grandchild-pid-file") {
+      grandchildPidFile = parseOptionValue(argv, index + 1, token);
       index += 1;
       continue;
     }
@@ -596,7 +620,10 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     loadReplayText,
     ignoreSigterm,
     cancelDelayMs,
+    stayAliveAfterStdinEnd,
+    exitOnStdinEnd,
     pidFile,
+    grandchildPidFile,
   };
 }
 
@@ -1481,16 +1508,43 @@ const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
 const stream = ndJsonStream(output, input);
 const mockAgentOptions = parseMockAgentOptions(process.argv.slice(2));
 
+function spawnLongLivedGrandchild(pidFile: string): void {
+  const grandchild = spawn(process.execPath, ["--eval", "setInterval(() => {}, 1000);"], {
+    stdio: "ignore",
+  });
+  if (!grandchild.pid) {
+    throw new Error("long-lived grandchild did not receive a PID");
+  }
+  grandchild.unref();
+  writeFileSync(pidFile, `${grandchild.pid}\n`, "utf8");
+}
+
 // Write PID to a file before doing anything else so that the parent can track
 // this bridge process and verify it is dead after queue-owner shutdown.
 if (mockAgentOptions.pidFile) {
   writeFileSync(mockAgentOptions.pidFile, `${process.pid}\n`, "utf8");
 }
 
+if (mockAgentOptions.grandchildPidFile) {
+  spawnLongLivedGrandchild(mockAgentOptions.grandchildPidFile);
+}
+
 if (mockAgentOptions.ignoreSigterm) {
   process.on("SIGTERM", () => {
     // Intentionally ignore to exercise ACP client SIGKILL fallback behavior.
   });
+}
+
+if (mockAgentOptions.stayAliveAfterStdinEnd) {
+  setInterval(() => undefined, 1_000);
+}
+
+if (mockAgentOptions.exitOnStdinEnd) {
+  // Deterministically exit when acpx closes our stdin, modelling a well-behaved
+  // bridge that shuts down on stdin EOF regardless of ACP SDK version. This makes
+  // the "reaps grandchildren when the bridge exits during stdin-close" test rely
+  // on the final group sweep rather than on incidental SDK teardown timing.
+  process.stdin.on("end", () => process.exit(0));
 }
 
 const connection = new AgentSideConnection(


### PR DESCRIPTION
## Problem

When acpx terminates an agent bridge, `killAgentIfRunning` (`src/acp/client.ts`) called `child.kill(signal)` — signalling **only the bridge PID**. The bridge (codex-acp etc.) spawns its own children: the model process and MCP servers (e.g. `serena`). Those descendants were never signalled, so they survived as orphans and accumulated until the agent app-server choked and new sessions hung at `session/new`.

## Fix

On **POSIX**, spawn the bridge in its own process group (`detached`, `pgid == pid`) and signal the **whole group** on close (`process.kill(-pid, signal)`), gated on an `agentGroupLeader` flag so acpx never signals its own group. Windows and any non-detached path keep the previous single-PID `child.kill`.

A **final best-effort group sweep** also runs after the bridge PID itself has gone — e.g. a well-behaved bridge that exits during the stdin-close grace — so descendants that outlived the bridge are still reaped. Signal failures other than `ESRCH` are traced (verbose) rather than silently swallowed.

## Scope & limitations (explicit)

- **Process group, not full tree.** Reaps descendants that stay in the bridge's group. A descendant that re-detaches into its **own** session (`setsid`) leaves the group and is out of scope.
- **POSIX-only.** On Windows `agentGroupLeader` is false and behaviour is unchanged (no group reaping). A Job-Object path can follow.
- **Cooperative close only.** This couples descendants to `AcpClient.close()`. It does **not** cover abrupt death of acpx itself (`SIGKILL`/OOM) — there is no `PR_SET_PDEATHSIG` here. Note that detaching also means the bridge no longer receives signals sent to acpx's process group; both are left to a follow-up that adds a real die-with-parent mechanism.
- **Headless assumption.** `detached` puts the bridge in a new session without a controlling terminal; tools that need `/dev/tty` directly would be affected. acpx bridges are headless ACP adapters, so this is expected.

## Real behavior proof

Deterministic regression (`--exit-on-stdin-end` makes the mock bridge exit on stdin EOF, so only the post-exit sweep can reap the grandchild). Same test, with and without the fix:

```
# WITH the fix
✔ AcpClient close reaps grandchildren when the bridge exits during stdin-close
ℹ pass 1  ℹ fail 0

# WITHOUT the fix (git stash of src/acp/client.ts)
✖ AcpClient close reaps grandchildren when the bridge exits during stdin-close
  AssertionError: grandchild 57370 must be dead after close even when the bridge exited on its own
ℹ pass 0  ℹ fail 1
```

Full suite: `850 tests, 847 pass, 0 fail, 3 skipped`. `typecheck` + `lint` clean.

## Tests

`test/client.test.ts` (+ `test/mock-agent.ts`), real-process, Unix:
- grandchild reaped when the bridge is **stubborn** (`--ignore-sigterm --stay-alive-after-stdin-end`, forcing the group `SIGKILL`);
- grandchild reaped when the bridge **exits cleanly** on stdin-close (`--exit-on-stdin-end`, exercising the post-exit group sweep — the case ClawSweeper flagged).

---

Addresses the ClawSweeper review of the previous revision (the stdin-close descendant leak). Maintainer edits enabled (personal fork).
