### PR TITLE
feat: add Pool ACP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Built-ins:
 | `kiro`       | native (`kiro-cli-chat acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
 | `mux`        | `mux acp` via an ACPX-owned npm range                                       | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                                                    | [OpenCode](https://opencode.ai)                                                                                 |
+| `pool`       | native (`pool acp`)                                                         | [Poolside](https://poolside.ai)                                                                                 |
 | `qoder`      | native (`qodercli --acp`)                                                   | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | native (`qwen --acp`)                                                       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
 | `trae`       | native (`traecli acp serve`)                                                | [Trae CLI](https://docs.trae.cn/cli)                                                                            |

--- a/agents/Pool.md
+++ b/agents/Pool.md
@@ -2,9 +2,9 @@
 
 - Built-in name: `pool`
 - Default command: `pool acp`
-- Upstream: [Poolside](https://poolside.ai)
+- Upstream: [Poolside pool](https://github.com/poolsideai/pool)
 
-`acpx pool` launches the installed `pool` CLI through its ACP stdio entrypoint (`pool acp` starts the ACP server for Poolside's coding agent). Install `pool` and complete its normal authentication flow with `pool login` before using it through `acpx`; credentials are stored under `~/.config/poolside/`.
+`acpx pool` launches the installed `pool` CLI through its ACP stdio entrypoint. Install `pool` using the [official instructions](https://github.com/poolsideai/pool#install), then run `pool login` before using it through `acpx`. Poolside stores its configuration and credentials under `~/.config/poolside/`.
 
 Examples:
 
@@ -20,7 +20,7 @@ If your Poolside install exposes ACP through a different command, override the b
 {
   "agents": {
     "pool": {
-      "command": "pool acp"
+      "argv": ["pool", "acp"]
     }
   }
 }

--- a/agents/Pool.md
+++ b/agents/Pool.md
@@ -1,0 +1,27 @@
+# Pool
+
+- Built-in name: `pool`
+- Default command: `pool acp`
+- Upstream: [Poolside](https://poolside.ai)
+
+`acpx pool` launches the installed `pool` CLI through its ACP stdio entrypoint (`pool acp` starts the ACP server for Poolside's coding agent). Install `pool` and complete its normal authentication flow with `pool login` before using it through `acpx`; credentials are stored under `~/.config/poolside/`.
+
+Examples:
+
+```bash
+acpx pool sessions new
+acpx pool 'review this branch'
+acpx pool exec 'summarize this repository'
+```
+
+If your Poolside install exposes ACP through a different command, override the built-in in `~/.acpx/config.json`:
+
+```json
+{
+  "agents": {
+    "pool": {
+      "command": "pool acp"
+    }
+  }
+}
+```

--- a/agents/README.md
+++ b/agents/README.md
@@ -18,6 +18,7 @@ Built-in agents:
 - `kiro -> kiro-cli-chat acp`
 - `mux -> mux acp` via an ACPX-owned npm range
 - `opencode -> npx -y opencode-ai acp`
+- `pool -> pool acp`
 - `qoder -> qodercli --acp`
 - `qwen -> qwen --acp`
 - `trae -> traecli acp serve`
@@ -38,6 +39,7 @@ Harness-specific docs in this directory:
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli-chat acp`
 - [Mux](Mux.md): built-in `mux -> mux acp` via an ACPX-owned npm range
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
+- [Pool](Pool.md): built-in `pool -> pool acp`
 - [Qoder](Qoder.md): built-in `qoder -> qodercli --acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`
 - [Trae](Trae.md): built-in `trae -> traecli acp serve`

--- a/docs/2026-02-17-agent-registry.md
+++ b/docs/2026-02-17-agent-registry.md
@@ -14,6 +14,7 @@ date: 2026-02-17
 - `codex -> npx @zed-industries/codex-acp`
 - `claude -> npx -y @agentclientprotocol/claude-agent-acp`
 - `grok-build -> grok agent stdio`
+- `pool -> pool acp`
 
 The built-in agents table lives in [../README.md](../README.md). Additional built-in agent docs live under [../agents/README.md](../agents/README.md).
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -27,6 +27,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `kiro`       | `kiro-cli-chat acp`                            | [Kiro CLI](https://kiro.dev)                                                                                    |
 | `mux`        | `mux acp` via an ACPX-owned npm range          | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                       | [OpenCode](https://opencode.ai)                                                                                 |
+| `pool`       | `pool acp`                                     | [Poolside](https://poolside.ai)                                                                                 |
 | `qoder`      | `qodercli --acp`                               | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | `qwen --acp`                                   | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
 | `trae`       | `traecli acp serve`                            | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
@@ -191,6 +192,14 @@ Configure at least one model provider before prompting (for example `ANTHROPIC_A
 - Built-in name: `opencode`
 - Default command: `npx -y opencode-ai acp`
 - Upstream: [opencode.ai](https://opencode.ai)
+
+### Pool
+
+- Built-in name: `pool`
+- Default command: `pool acp`
+- Upstream: [Poolside](https://poolside.ai)
+
+`acpx pool` uses the installed `pool` CLI ACP server (`pool acp`). Install `pool` and complete its authentication flow with `pool login` before using it through `acpx`; credentials are stored under `~/.config/poolside/`.
 
 ### Qwen
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -97,6 +97,7 @@ Friendly agent names resolve to commands:
 - `kiro` -> `kiro-cli-chat acp`
 - `mux` -> `mux acp` via an ACPX-owned npm range
 - `opencode` -> `npx -y opencode-ai acp`
+- `pool` -> `pool acp`
 - `qoder` -> `qodercli --acp`
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.
 - `qwen` -> `qwen --acp`

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -53,6 +53,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   kiro: "kiro-cli-chat acp",
   mux: `npx -y mux@${ACP_ADAPTER_PACKAGE_RANGES.mux} acp`,
   opencode: "npx -y opencode-ai acp",
+  pool: "pool acp",
   qoder: "qodercli --acp",
   qwen: "qwen --acp",
   trae: "traecli acp serve",

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -80,6 +80,7 @@ export const AGENT_ARGV_REGISTRY: Record<string, string[]> = {
   kiro: ["kiro-cli-chat", "acp"],
   mux: ["npx", "-y", `mux@${ACP_ADAPTER_PACKAGE_RANGES.mux}`, "acp"],
   opencode: ["npx", "-y", "opencode-ai", "acp"],
+  pool: ["pool", "acp"],
   qoder: ["qodercli", "--acp"],
   qwen: ["qwen", "--acp"],
   trae: ["traecli", "acp", "serve"],

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -76,6 +76,7 @@ test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
 
 test("pool built-in runs the Poolside ACP entrypoint", () => {
   assert.equal(AGENT_REGISTRY.pool, "pool acp");
+  assert.deepEqual(AGENT_ARGV_REGISTRY.pool, ["pool", "acp"]);
   assert.equal(resolveAgentCommand("pool"), "pool acp");
 });
 

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -74,6 +74,11 @@ test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
   assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.28.0 acp");
 });
 
+test("pool built-in runs the Poolside ACP entrypoint", () => {
+  assert.equal(AGENT_REGISTRY.pool, "pool acp");
+  assert.equal(resolveAgentCommand("pool"), "pool acp");
+});
+
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {
   const agents = listBuiltInAgents();
   assert.deepEqual(agents, Object.keys(AGENT_REGISTRY));
@@ -96,6 +101,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
     "kiro",
     "mux",
     "opencode",
+    "pool",
     "qoder",
     "qwen",
     "trae",

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -934,6 +934,33 @@ test("integration: built-in grok-build agent resolves to grok agent stdio", asyn
   });
 });
 
+test("integration: built-in pool agent resolves to pool acp", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-pool-"));
+
+    try {
+      await writeFakePoolAgent(fakeBinDir);
+
+      const result = await runCli(
+        ["--approve-all", "--cwd", cwd, "--format", "quiet", "pool", "exec", "echo hello"],
+        homeDir,
+        {
+          env: {
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /hello/);
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: built-in iflow agent resolves to iflow --experimental-acp", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -4637,6 +4664,39 @@ async function writeFakeGrokBuildAgent(binDir: string): Promise<void> {
       "  shift",
       "else",
       '  echo "unexpected grok command: $*" 1>&2',
+      "  exit 2",
+      "fi",
+      `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
+      "",
+    ].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function writeFakePoolAgent(binDir: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      path.join(binDir, "pool.cmd"),
+      [
+        "@echo off",
+        "setlocal",
+        'if not "%~1"=="acp" exit /b 2',
+        `"${process.execPath}" "${MOCK_AGENT_PATH}" %2 %3 %4 %5 %6 %7 %8 %9`,
+        "",
+      ].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  await fs.writeFile(
+    path.join(binDir, "pool"),
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "acp" ]; then',
+      "  shift",
+      "else",
+      '  echo "unexpected pool command: $*" 1>&2',
       "  exit 2",
       "fi",
       `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,


### PR DESCRIPTION
## Summary
- Add Poolside as a built-in agent (`pool` → `pool acp`)
- Add harness docs, registry/tests, and changelog entry

## Live proof

Tested at PR head with installed Poolside CLI (`pool --help` shows `pool acp`).

```bash
$ pnpm run build
$ node dist/cli.js --approve-all pool exec 'echo hello'
[client] initialize (running)
[client] session/new (running)
[tool] Echo hello to the terminal: `echo hello` (completed)
...
hello
[done] end_turn
$ echo $?
0

## Test plan (all passed)

 - pnpm run check
 - pnpm run check:docs
 - Live acpx pool exec against installed Poolside CLI (exit 0)

## Notes
- Requires users to install the `pool` CLI and run `pool login`