### PR TITLE
feat: add ZeroClaw ACP agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/timers: preserve tiny positive timeout and TTL values from flags or config as 1 ms instead of disabling timers, and reject delays beyond Node's supported timer range. Thanks @realmehmetali.
 
+- Agents/built-ins: add ZeroClaw via `zeroclaw acp`, ZeroClaw's native ACP v1 stdio server. Thanks @JordanTheJet.
+
 ### Breaking
 
 - Windows agent launches now require structured `agents.<name>.argv`; unambiguous legacy `command` plus `args` entries migrate automatically, while raw, ambiguous, or directly executable `.sh` commands fail with explicit migration guidance instead of lossy parsing or CreateProcess ENOENT. Existing custom-agent sessions without saved argv must be recreated. Fixes #466. Thanks @MarcelCFritsche.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Built-ins:
 | `qoder`      | native (`qodercli --acp`)                                                   | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | native (`qwen --acp`)                                                       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
 | `trae`       | native (`traecli acp serve`)                                                | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
+| `zeroclaw`   | native (`zeroclaw acp`)                                                     | [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)                                                           |
 
 `factory-droid` and `factorydroid` also resolve to the built-in `droid` adapter.
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -22,6 +22,7 @@ Built-in agents:
 - `qoder -> qodercli --acp`
 - `qwen -> qwen --acp`
 - `trae -> traecli acp serve`
+- `zeroclaw -> zeroclaw acp`
 
 Harness-specific docs in this directory:
 
@@ -43,3 +44,4 @@ Harness-specific docs in this directory:
 - [Qoder](Qoder.md): built-in `qoder -> qodercli --acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`
 - [Trae](Trae.md): built-in `trae -> traecli acp serve`
+- [ZeroClaw](ZeroClaw.md): built-in `zeroclaw -> zeroclaw acp`

--- a/agents/ZeroClaw.md
+++ b/agents/ZeroClaw.md
@@ -1,0 +1,57 @@
+# ZeroClaw
+
+- Built-in name: `zeroclaw`
+- Default command: `zeroclaw acp`
+- Upstream: https://github.com/zeroclaw-labs/zeroclaw
+
+`acpx zeroclaw` starts ZeroClaw's built-in ACP server (`zeroclaw acp`), a JSON-RPC 2.0
+stdio server that implements Agent Client Protocol v1 (`protocolVersion: 1`, no auth
+methods). The `channel-acp-server` feature it needs is included in ZeroClaw's default
+build, so a standard `zeroclaw` install works out of the box; a binary compiled without
+it exits, reporting that the `channel-acp-server` feature is required.
+
+## Agent selection
+
+acpx's `session/new` does not pass a ZeroClaw agent alias, so the server picks the
+session's agent from your ZeroClaw config in this order:
+
+1. `acp.default_agent`, when set.
+2. The single `[agents.<alias>]` entry, when exactly one agent is configured.
+
+Single-agent setups therefore need no extra configuration. Multi-agent configs must set
+`acp.default_agent`, otherwise `session/new` fails, reporting that it requires an
+`agentAlias`.
+
+## Notes
+
+- Text prompts only — the server advertises no image, audio, or embedded-context prompt
+  capability.
+- Session resume/close (acpx `ensure` and reuse) is advertised when ZeroClaw's ACP
+  session store is available.
+- MCP tools are opt-in per agent via `[agents.<alias>].acp_enable_mcp` (off by default);
+  the `mcpServers` acpx sends on `session/new` are ignored.
+- `zeroclaw acp --max-sessions <n>` and `--session-timeout <secs>` bound concurrency.
+  Override the built-in command in acpx config to pass them.
+
+## Connecting to a running gateway
+
+To route acpx to an already-running ZeroClaw gateway/daemon instead of spawning a fresh
+in-process server, override the built-in command to use `zeroclaw-acp-bridge`, which
+bridges stdio to the gateway's ACP-over-WebSocket endpoint:
+
+```json
+{
+  "agents": {
+    "zeroclaw": {
+      "command": "zeroclaw-acp-bridge"
+    }
+  }
+}
+```
+
+The bridge is a separate Cargo binary target and is not included in ZeroClaw's normal
+prebuilt archives or installer, so build/install `zeroclaw-acp-bridge` from the ZeroClaw
+source tree before using this override. It reads the gateway URL from the local ZeroClaw
+config. When gateway pairing is active, run `zeroclaw gateway get-paircode --new`, then
+start the bridge once with `zeroclaw-acp-bridge --pair-code <code>` to cache a token; an
+existing token can instead be supplied through `ZEROCLAW_ACP_BRIDGE_TOKEN`.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -31,6 +31,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `qoder`      | `qodercli --acp`                               | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | `qwen --acp`                                   | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
 | `trae`       | `traecli acp serve`                            | [Trae CLI](https://docs.trae.cn/cli)                                                                            |
+| `zeroclaw`   | `zeroclaw acp`                                 | [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)                                                           |
 
 `factory-droid` and `factorydroid` also resolve to the built-in `droid` adapter.
 
@@ -212,6 +213,15 @@ Configure at least one model provider before prompting (for example `ANTHROPIC_A
 - Built-in name: `trae`
 - Default command: `traecli acp serve`
 - Upstream: [docs.trae.cn](https://docs.trae.cn/cli)
+
+### ZeroClaw
+
+- Built-in name: `zeroclaw`
+- Default command: `zeroclaw acp`
+- Upstream: [zeroclaw-labs/zeroclaw](https://github.com/zeroclaw-labs/zeroclaw)
+- `zeroclaw acp` is ZeroClaw's native JSON-RPC 2.0 stdio server for ACP v1 (`protocolVersion: 1`, no auth methods). The `channel-acp-server` feature it needs ships in ZeroClaw's default build.
+- `session/new` does not carry a ZeroClaw agent alias, so the server binds the session to `acp.default_agent` when set, otherwise to the sole `[agents.<alias>]` entry. Single-agent configs work as-is; multi-agent configs must set `acp.default_agent` or `session/new` fails.
+- Text prompts only (no image, audio, or embedded-context capability). Session resume/close is advertised when the ZeroClaw ACP session store is available. MCP tools are opt-in per agent via `[agents.<alias>].acp_enable_mcp`.
 
 ## Overriding a built-in
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -102,6 +102,7 @@ Friendly agent names resolve to commands:
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.
 - `qwen` -> `qwen --acp`
 - `trae` -> `traecli acp serve`
+- `zeroclaw` -> `zeroclaw acp`
 
 Rules:
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -85,6 +85,7 @@ export const AGENT_ARGV_REGISTRY: Record<string, string[]> = {
   qoder: ["qodercli", "--acp"],
   qwen: ["qwen", "--acp"],
   trae: ["traecli", "acp", "serve"],
+  zeroclaw: ["zeroclaw", "acp"],
 };
 
 export const BUILT_IN_AGENT_PACKAGES = {

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -57,6 +57,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   qoder: "qodercli --acp",
   qwen: "qwen --acp",
   trae: "traecli acp serve",
+  zeroclaw: "zeroclaw acp",
 };
 
 export const AGENT_ARGV_REGISTRY: Record<string, string[]> = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -80,6 +80,11 @@ test("pool built-in runs the Poolside ACP entrypoint", () => {
   assert.equal(resolveAgentCommand("pool"), "pool acp");
 });
 
+test("zeroclaw built-in launches the native ZeroClaw ACP server", () => {
+  assert.equal(AGENT_REGISTRY.zeroclaw, "zeroclaw acp");
+  assert.equal(resolveAgentCommand("zeroclaw"), "zeroclaw acp");
+});
+
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {
   const agents = listBuiltInAgents();
   assert.deepEqual(agents, Object.keys(AGENT_REGISTRY));
@@ -106,6 +111,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
     "qoder",
     "qwen",
     "trae",
+    "zeroclaw",
   ]);
 });
 

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -82,6 +82,7 @@ test("pool built-in runs the Poolside ACP entrypoint", () => {
 
 test("zeroclaw built-in launches the native ZeroClaw ACP server", () => {
   assert.equal(AGENT_REGISTRY.zeroclaw, "zeroclaw acp");
+  assert.deepEqual(AGENT_ARGV_REGISTRY.zeroclaw, ["zeroclaw", "acp"]);
   assert.equal(resolveAgentCommand("zeroclaw"), "zeroclaw acp");
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -961,6 +961,33 @@ test("integration: built-in pool agent resolves to pool acp", async () => {
   });
 });
 
+test("integration: built-in zeroclaw agent resolves to zeroclaw acp", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-zeroclaw-"));
+
+    try {
+      await writeFakeZeroClawAgent(fakeBinDir);
+
+      const result = await runCli(
+        ["--approve-all", "--cwd", cwd, "--format", "quiet", "zeroclaw", "exec", "echo hello"],
+        homeDir,
+        {
+          env: {
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /hello/);
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: built-in iflow agent resolves to iflow --experimental-acp", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -4706,6 +4733,39 @@ async function writeFakePoolAgent(binDir: string): Promise<void> {
       "  shift",
       "else",
       '  echo "unexpected pool command: $*" 1>&2',
+      "  exit 2",
+      "fi",
+      `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
+      "",
+    ].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function writeFakeZeroClawAgent(binDir: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      path.join(binDir, "zeroclaw.cmd"),
+      [
+        "@echo off",
+        "setlocal",
+        'if not "%~1"=="acp" exit /b 2',
+        `"${process.execPath}" "${MOCK_AGENT_PATH}" %2 %3 %4 %5 %6 %7 %8 %9`,
+        "",
+      ].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  await fs.writeFile(
+    path.join(binDir, "zeroclaw"),
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "acp" ]; then',
+      "  shift",
+      "else",
+      '  echo "unexpected zeroclaw command: $*" 1>&2',
       "  exit 2",
       "fi",
       `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,


### PR DESCRIPTION
## What

Registers **ZeroClaw** as a built-in acpx agent. The friendly name `zeroclaw` resolves to ZeroClaw's native ACP server command, `zeroclaw acp` — mirroring the existing `openclaw -> openclaw acp` native entry.

```ts
// src/agent-registry.ts
zeroclaw: "zeroclaw acp",
```

## Why

`zeroclaw acp` is a first-class JSON-RPC 2.0 stdio server that already implements Agent Client Protocol **v1** (`protocolVersion: 1`, `authMethods: []`, standard `agentCapabilities` with `session/update` streaming). The `channel-acp-server` feature it needs is in ZeroClaw's default feature set, so a standard `zeroclaw` install exposes it out of the box — acpx can drive it as a drop-in ACP agent with no adapter package to download, the same shape as `gemini --acp` / `cursor-agent acp`.

## Integration notes

acpx's `session/new` sends `{ cwd, mcpServers, _meta }` and no agent alias, so `zeroclaw acp` binds the session to `acp.default_agent` when set, otherwise to the sole `[agents.<alias>]` entry. Single-agent ZeroClaw configs therefore work with no extra setup; multi-agent configs set `acp.default_agent`. This and the other behaviors — text-only prompts, session resume/close when ZeroClaw's ACP session store is present, opt-in per-agent MCP, and an optional `zeroclaw-acp-bridge` override to reach an already-running gateway — are documented in `agents/ZeroClaw.md` and `docs/agents.md`.

## Changes

- `src/agent-registry.ts` — add the `zeroclaw -> zeroclaw acp` built-in (appended after `trae`, preserving the alphabetical tail the registry test asserts).
- `test/agent-registry.test.ts` — extend the `listBuiltInAgents` tail assertion and add a focused `zeroclaw` resolution test.
- `agents/README.md`, `agents/ZeroClaw.md` (new), `docs/agents.md`, `README.md`, `skills/acpx/SKILL.md` — document the built-in across the exhaustive agent lists.
- `CHANGELOG.md` — `Unreleased` entry.

Upstream: https://github.com/zeroclaw-labs/zeroclaw

## Testing

Fully tested locally on this branch:

- `pnpm run format:check` — pass
- `pnpm run lint` / `pnpm run lint:docs` — pass
- `pnpm run typecheck` — pass
- `pnpm test` — **849/849 pass**, including the new `zeroclaw` registry test.

## AI assistance

AI-assisted (Claude Code), fully tested as above. The diff was cross-checked against the ZeroClaw ACP server source (`orchestrator/acp_server.rs` `handle_initialize`/`handle_session_new`, the `zeroclaw acp` CLI command, and `Cargo.toml` default features) to confirm every documented claim, and against acpx's own `src/acp/client.ts` to confirm the `session/new` handshake. I understand the change and will follow up on any review conversations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
