### PR TITLE
fix(cli): handle main() rejections and non-EPIPE stream errors

### DIFF
--- a/src/cli-fatal.ts
+++ b/src/cli-fatal.ts
@@ -1,0 +1,29 @@
+import { writeSync } from "node:fs";
+
+/**
+ * Write a fatal diagnostic to fd 2 without relying on async stream buffers.
+ * process.stderr.write + process.exit can drop the message on pipes.
+ */
+export function writeFatalLine(message: string): void {
+  const line = message.endsWith("\n") ? message : `${message}\n`;
+  try {
+    writeSync(2, line);
+  } catch {
+    // stderr may already be closed or broken
+  }
+}
+
+export function handleStreamError(error: NodeJS.ErrnoException): void {
+  if (error.code === "EPIPE") {
+    process.exit(0);
+  }
+
+  writeFatalLine(`[acpx] stream error: ${error.message}`);
+  process.exit(1);
+}
+
+export function handleMainRejection(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  writeFatalLine(`[acpx] ${message}`);
+  process.exitCode = 1;
+}

--- a/src/cli-fatal.ts
+++ b/src/cli-fatal.ts
@@ -23,7 +23,10 @@ export function handleStreamError(error: NodeJS.ErrnoException): void {
 }
 
 export function handleMainRejection(error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
+  // Unexpected top-level failures should keep stack/file/line diagnostics.
+  // Expected command errors are handled inside main() before reject.
+  const message =
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
   writeFatalLine(`[acpx] ${message}`);
   process.exitCode = 1;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { realpathSync } from "node:fs";
+import { realpathSync, writeSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { main } from "./cli-core.js";
 import { buildQueueOwnerArgOverride } from "./cli/session/queue-owner-process.js";
@@ -8,19 +8,37 @@ import { buildQueueOwnerArgOverride } from "./cli/session/queue-owner-process.js
 export { formatPromptSessionBannerLine } from "./cli-core.js";
 export { parseAllowedTools, parseMaxTurns, parseTtlSeconds } from "./cli/flags.js";
 
+/**
+ * Write a fatal diagnostic to fd 2 without relying on async stream buffers.
+ * process.stderr.write + process.exit can drop the message on pipes.
+ */
+export function writeFatalLine(message: string): void {
+  const line = message.endsWith("\n") ? message : `${message}\n`;
+  try {
+    writeSync(2, line);
+  } catch {
+    // stderr may already be closed or broken
+  }
+}
+
+export function handleStreamError(error: NodeJS.ErrnoException): void {
+  if (error.code === "EPIPE") {
+    process.exit(0);
+  }
+
+  writeFatalLine(`[acpx] stream error: ${error.message}`);
+  process.exit(1);
+}
+
+export function handleMainRejection(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  writeFatalLine(`[acpx] ${message}`);
+  process.exitCode = 1;
+}
+
 function installBrokenPipeHandler(stream: NodeJS.WritableStream): void {
   stream.on("error", (error: NodeJS.ErrnoException) => {
-    if (error.code === "EPIPE") {
-      process.exit(0);
-    }
-
-    // Event-emitter throws become uncaughtException. Surface and exit instead.
-    try {
-      process.stderr.write(`[acpx] stream error: ${error.message}\n`);
-    } catch {
-      // ignore secondary write failures
-    }
-    process.exit(1);
+    handleStreamError(error);
   });
 }
 
@@ -49,16 +67,5 @@ if (isCliEntrypoint(process.argv)) {
     process.env.ACPX_QUEUE_OWNER_ARGS ??= queueOwnerArgOverride;
   }
 
-  void main(process.argv).catch((error: unknown) => {
-    // Avoid unhandled promise rejections for top-level CLI failures.
-    // Commander parse errors are already handled inside main(); this
-    // catches unexpected throws and stream-handler rethrows.
-    const message = error instanceof Error ? error.message : String(error);
-    try {
-      process.stderr.write(`[acpx] ${message}\n`);
-    } catch {
-      // stderr may already be broken
-    }
-    process.exitCode = 1;
-  });
+  void main(process.argv).catch(handleMainRejection);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,13 @@ function installBrokenPipeHandler(stream: NodeJS.WritableStream): void {
       process.exit(0);
     }
 
-    throw error;
+    // Event-emitter throws become uncaughtException. Surface and exit instead.
+    try {
+      process.stderr.write(`[acpx] stream error: ${error.message}\n`);
+    } catch {
+      // ignore secondary write failures
+    }
+    process.exit(1);
   });
 }
 
@@ -43,5 +49,16 @@ if (isCliEntrypoint(process.argv)) {
     process.env.ACPX_QUEUE_OWNER_ARGS ??= queueOwnerArgOverride;
   }
 
-  void main(process.argv);
+  void main(process.argv).catch((error: unknown) => {
+    // Avoid unhandled promise rejections for top-level CLI failures.
+    // Commander parse errors are already handled inside main(); this
+    // catches unexpected throws and stream-handler rethrows.
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      process.stderr.write(`[acpx] ${message}\n`);
+    } catch {
+      // stderr may already be broken
+    }
+    process.exitCode = 1;
+  });
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,40 +1,13 @@
 #!/usr/bin/env node
 
-import { realpathSync, writeSync } from "node:fs";
+import { realpathSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { main } from "./cli-core.js";
+import { handleMainRejection, handleStreamError } from "./cli-fatal.js";
 import { buildQueueOwnerArgOverride } from "./cli/session/queue-owner-process.js";
 
 export { formatPromptSessionBannerLine } from "./cli-core.js";
 export { parseAllowedTools, parseMaxTurns, parseTtlSeconds } from "./cli/flags.js";
-
-/**
- * Write a fatal diagnostic to fd 2 without relying on async stream buffers.
- * process.stderr.write + process.exit can drop the message on pipes.
- */
-export function writeFatalLine(message: string): void {
-  const line = message.endsWith("\n") ? message : `${message}\n`;
-  try {
-    writeSync(2, line);
-  } catch {
-    // stderr may already be closed or broken
-  }
-}
-
-export function handleStreamError(error: NodeJS.ErrnoException): void {
-  if (error.code === "EPIPE") {
-    process.exit(0);
-  }
-
-  writeFatalLine(`[acpx] stream error: ${error.message}`);
-  process.exit(1);
-}
-
-export function handleMainRejection(error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
-  writeFatalLine(`[acpx] ${message}`);
-  process.exitCode = 1;
-}
 
 function installBrokenPipeHandler(stream: NodeJS.WritableStream): void {
   stream.on("error", (error: NodeJS.ErrnoException) => {

--- a/test/cli-entrypoint.test.ts
+++ b/test/cli-entrypoint.test.ts
@@ -6,9 +6,15 @@ import test from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleMainRejection } from "../src/cli-fatal.js";
 
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
+// Package root: source tests live in test/, compiled tests under dist-test/test/.
+const ROOT = fileURLToPath(
+  new URL(
+    fileURLToPath(import.meta.url).includes(`${path.sep}dist-test${path.sep}`) ? "../.." : "..",
+    import.meta.url,
+  ),
+);
 const DIST_CLI = path.join(ROOT, "dist", "cli.js");
-const CLI_FATAL_TS = fileURLToPath(new URL("../src/cli-fatal.ts", import.meta.url));
+const CLI_FATAL_TS = path.join(ROOT, "src", "cli-fatal.ts");
 
 test("importing the CLI module does not install entrypoint-only process state", async () => {
   const stdoutErrorListeners = process.stdout.listeners("error");

--- a/test/cli-entrypoint.test.ts
+++ b/test/cli-entrypoint.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
-import { handleMainRejection } from "../src/cli.js";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { handleMainRejection } from "../src/cli-fatal.js";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DIST_CLI = path.join(ROOT, "dist", "cli.js");
+const CLI_FATAL_TS = fileURLToPath(new URL("../src/cli-fatal.ts", import.meta.url));
 
 test("importing the CLI module does not install entrypoint-only process state", async () => {
   const stdoutErrorListeners = process.stdout.listeners("error");
@@ -29,6 +35,15 @@ test("importing the CLI module does not install entrypoint-only process state", 
   }
 });
 
+test("package root does not export fatal handlers", async () => {
+  assert.ok(fs.existsSync(DIST_CLI), "dist/cli.js must exist (run pnpm build)");
+  const mod = await import(`${pathToFileURL(DIST_CLI).href}?exports=${Date.now()}`);
+  assert.equal("handleMainRejection" in mod, false);
+  assert.equal("handleStreamError" in mod, false);
+  assert.equal("writeFatalLine" in mod, false);
+  assert.equal(typeof mod.parseAllowedTools, "function");
+});
+
 test("handleMainRejection sets process.exitCode to 1", () => {
   const previous = process.exitCode;
   try {
@@ -42,7 +57,7 @@ test("handleMainRejection sets process.exitCode to 1", () => {
 
 test("spawned handleMainRejection writes [acpx] diagnostic and exits 1", async () => {
   const result = await spawnEval(`
-    import { handleMainRejection } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    import { handleMainRejection } from ${JSON.stringify(CLI_FATAL_TS)};
     handleMainRejection(new Error("spawned boom"));
   `);
   assert.equal(result.code, 1);
@@ -52,7 +67,7 @@ test("spawned handleMainRejection writes [acpx] diagnostic and exits 1", async (
 
 test("spawned handleStreamError EPIPE exits 0 without diagnostic", async () => {
   const result = await spawnEval(`
-    import { handleStreamError } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    import { handleStreamError } from ${JSON.stringify(CLI_FATAL_TS)};
     const err = new Error("broken pipe");
     err.code = "EPIPE";
     handleStreamError(err);
@@ -63,7 +78,7 @@ test("spawned handleStreamError EPIPE exits 0 without diagnostic", async () => {
 
 test("spawned handleStreamError non-EPIPE writes diagnostic and exits 1", async () => {
   const result = await spawnEval(`
-    import { handleStreamError } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    import { handleStreamError } from ${JSON.stringify(CLI_FATAL_TS)};
     const err = new Error("EIO on stdout");
     err.code = "EIO";
     handleStreamError(err);
@@ -74,26 +89,59 @@ test("spawned handleStreamError non-EPIPE writes diagnostic and exits 1", async 
 
 test("writeFatalLine is usable when stderr is a pipe", async () => {
   const result = await spawnEval(`
-    import { writeFatalLine } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    import { writeFatalLine } from ${JSON.stringify(CLI_FATAL_TS)};
     writeFatalLine("[acpx] sync write ok");
   `);
   assert.equal(result.code, 0);
   assert.match(result.stderr, /\[acpx\] sync write ok/);
 });
 
+test("built acpx entrypoint path: main rejection prints [acpx] diagnostic", async () => {
+  assert.ok(fs.existsSync(DIST_CLI), "dist/cli.js must exist (run pnpm build)");
+  // Real Node process using the same fatal handler wired by dist/cli.js entry.
+  // Mirrors: void main(process.argv).catch(handleMainRejection)
+  const harness = path.join(ROOT, "scripts", "proof-main-reject.mjs");
+  fs.mkdirSync(path.dirname(harness), { recursive: true });
+  fs.writeFileSync(
+    harness,
+    `import { handleMainRejection } from ${JSON.stringify(pathToFileURL(CLI_FATAL_TS).href)};
+const main = async () => {
+  throw new Error("proof main rejection via acpx fatal path");
+};
+void main().catch(handleMainRejection);
+`,
+  );
+  try {
+    const result = await spawnNode(["--import", "tsx", harness]);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /\[acpx\] proof main rejection via acpx fatal path/);
+  } finally {
+    fs.rmSync(harness, { force: true });
+  }
+});
+
+test("built package bin --version works (entrypoint health)", async () => {
+  assert.ok(fs.existsSync(DIST_CLI), "dist/cli.js must exist (run pnpm build)");
+  const result = await spawnNode([DIST_CLI, "--version"]);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /\d+\.\d+/);
+});
+
 function spawnEval(
   source: string,
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return spawnNode(["--import", "tsx", "--input-type=module", "-e", source]);
+}
+
+function spawnNode(
+  args: string[],
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      ["--import", "tsx", "--input-type=module", "-e", source],
-      {
-        cwd: fileURLToPath(new URL("..", import.meta.url)),
-        env: process.env,
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
+    const child = spawn(process.execPath, args, {
+      cwd: ROOT,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     let stdout = "";
     let stderr = "";
     child.stdout.setEncoding("utf8");

--- a/test/cli-entrypoint.test.ts
+++ b/test/cli-entrypoint.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { handleMainRejection } from "../src/cli.js";
 
 test("importing the CLI module does not install entrypoint-only process state", async () => {
   const stdoutErrorListeners = process.stdout.listeners("error");
@@ -25,3 +28,85 @@ test("importing the CLI module does not install entrypoint-only process state", 
     }
   }
 });
+
+test("handleMainRejection sets process.exitCode to 1", () => {
+  const previous = process.exitCode;
+  try {
+    process.exitCode = undefined;
+    handleMainRejection(new Error("top-level boom"));
+    assert.equal(process.exitCode, 1);
+  } finally {
+    process.exitCode = previous;
+  }
+});
+
+test("spawned handleMainRejection writes [acpx] diagnostic and exits 1", async () => {
+  const result = await spawnEval(`
+    import { handleMainRejection } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    handleMainRejection(new Error("spawned boom"));
+  `);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /\[acpx\] spawned boom/);
+  assert.equal(result.stdout, "");
+});
+
+test("spawned handleStreamError EPIPE exits 0 without diagnostic", async () => {
+  const result = await spawnEval(`
+    import { handleStreamError } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    const err = new Error("broken pipe");
+    err.code = "EPIPE";
+    handleStreamError(err);
+  `);
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, "");
+});
+
+test("spawned handleStreamError non-EPIPE writes diagnostic and exits 1", async () => {
+  const result = await spawnEval(`
+    import { handleStreamError } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    const err = new Error("EIO on stdout");
+    err.code = "EIO";
+    handleStreamError(err);
+  `);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /\[acpx\] stream error: EIO on stdout/);
+});
+
+test("writeFatalLine is usable when stderr is a pipe", async () => {
+  const result = await spawnEval(`
+    import { writeFatalLine } from ${JSON.stringify(fileURLToPath(new URL("../src/cli.ts", import.meta.url)))};
+    writeFatalLine("[acpx] sync write ok");
+  `);
+  assert.equal(result.code, 0);
+  assert.match(result.stderr, /\[acpx\] sync write ok/);
+});
+
+function spawnEval(
+  source: string,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", source],
+      {
+        cwd: fileURLToPath(new URL("..", import.meta.url)),
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}

--- a/test/cli-entrypoint.test.ts
+++ b/test/cli-entrypoint.test.ts
@@ -61,7 +61,9 @@ test("spawned handleMainRejection writes [acpx] diagnostic and exits 1", async (
     handleMainRejection(new Error("spawned boom"));
   `);
   assert.equal(result.code, 1);
-  assert.match(result.stderr, /\[acpx\] spawned boom/);
+  assert.match(result.stderr, /\[acpx\] Error: spawned boom/);
+  // Unexpected errors keep Node-style stack (file/line), not message-only.
+  assert.match(result.stderr, /at /);
   assert.equal(result.stdout, "");
 });
 
@@ -114,7 +116,8 @@ void main().catch(handleMainRejection);
   try {
     const result = await spawnNode(["--import", "tsx", harness]);
     assert.equal(result.code, 1);
-    assert.match(result.stderr, /\[acpx\] proof main rejection via acpx fatal path/);
+    assert.match(result.stderr, /\[acpx\] Error: proof main rejection via acpx fatal path/);
+    assert.match(result.stderr, /at /);
   } finally {
     fs.rmSync(harness, { force: true });
   }


### PR DESCRIPTION
## What Problem This Solves

Top-level `main()` rejections and non-EPIPE stream errors could exit without a reliable diagnostic. Unexpected `Error` rejections must keep stack traces. EPIPE on stdout/stderr remains a quiet success exit for pipe consumers.

## Evidence

### Live handlers on PR head (2026-07-26)

```console
$ pnpm exec tsx -e 'import { handleMainRejection } from "./src/cli-fatal.ts"; handleMainRejection(new Error("proof boom")); process.exit(process.exitCode ?? 0);'
[acpx] Error: proof boom
    at [eval]:2:43
    at runScriptInThisContext (node:internal/vm:219:10)
    ...
exit=1

$ pnpm exec tsx -e 'import { handleStreamError } from "./src/cli-fatal.ts"; handleStreamError(Object.assign(new Error("write failed"), { code: "EIO" }));'
[acpx] stream error: write failed
exit=1

$ pnpm exec tsx -e 'import { handleStreamError } from "./src/cli-fatal.ts"; handleStreamError(Object.assign(new Error("broken pipe"), { code: "EPIPE" }));'
exit=0
```

## Real behavior proof

- **Behavior or issue addressed:** Unexpected main() rejections print stack under `[acpx]` and set exit code 1; non-EPIPE stream errors print and exit 1; EPIPE stays silent exit 0.
- **Real environment tested:** macOS arm64, Node 26, acpx worktree at PR head `905c51e` after `pnpm build`.
- **Exact steps or command run after this patch:** `pnpm exec tsx` invocations of `handleMainRejection` and `handleStreamError` as above.
- **Evidence after fix:** terminal output above (stack on rejection, stream error line on EIO, quiet success on EPIPE).
- **Observed result after fix:** Diagnostics use `writeSync(2, ...)` path so pipe consumers still see the fatal line; EPIPE remains non-fatal.
- **What was not tested:** full live ACP agent session end-to-end through the CLI entrypoint.
