### PR TITLE
fix(flows): swallow heartbeat write rejections from setInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Flows: swallow best-effort heartbeat write failures at the timer boundary so storage errors do not become unhandled promise rejections. Thanks @SebTardif.
+
 ## 2026.7.23 (v0.12.1)
 
 ### Changes

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -1014,7 +1014,11 @@ export class FlowRunner {
 
     if (heartbeatMs > 0) {
       timer = setInterval(() => {
-        void heartbeat();
+        // Heartbeat writes are best-effort; never leave a rejected promise
+        // from setInterval (unhandledRejection noise / process flags).
+        void heartbeat().catch(() => {
+          // ignore
+        });
       }, heartbeatMs);
     }
 

--- a/test/flows-heartbeat-rejection.test.ts
+++ b/test/flows-heartbeat-rejection.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+/**
+ * Mirrors FlowRunner.runWithHeartbeat's timer boundary: best-effort writes
+ * must not surface as unhandledRejection when writeLive rejects.
+ */
+test("heartbeat timer boundary swallows writeLive rejections", async () => {
+  const rejections: unknown[] = [];
+  const onUnhandled = (reason: unknown) => {
+    rejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandled);
+
+  let calls = 0;
+  const writeLive = async (): Promise<void> => {
+    calls += 1;
+    throw new Error("disk full (proof)");
+  };
+
+  const heartbeat = async (): Promise<void> => {
+    await writeLive();
+  };
+
+  const timer = setInterval(() => {
+    void heartbeat().catch(() => {
+      // best effort — same as FlowRunner.runWithHeartbeat
+    });
+  }, 15);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 80);
+  });
+  clearInterval(timer);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 30);
+  });
+  process.off("unhandledRejection", onUnhandled);
+
+  assert.ok(calls >= 2, `expected multiple heartbeat attempts, got ${calls}`);
+  assert.equal(rejections.length, 0, `unexpected unhandledRejection: ${String(rejections)}`);
+});

--- a/test/flows-heartbeat-rejection.test.ts
+++ b/test/flows-heartbeat-rejection.test.ts
@@ -1,42 +1,110 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { extractJsonObject } from "../src/flows/json.js";
+import { FlowRunner, defineFlow, shell } from "../src/flows/runtime.js";
+
+type WriteLiveArgs = [string, unknown, { type?: string }?];
 
 /**
- * Mirrors FlowRunner.runWithHeartbeat's timer boundary: best-effort writes
- * must not surface as unhandledRejection when writeLive rejects.
+ * Production-path regression: FlowRunner.runWithHeartbeat must swallow
+ * writeLive rejections from the setInterval boundary so a failing live
+ * store cannot surface unhandledRejection while a shell node runs.
  */
-test("heartbeat timer boundary swallows writeLive rejections", async () => {
+test("FlowRunner heartbeat writeLive rejections do not become unhandledRejection", async () => {
   const rejections: unknown[] = [];
   const onUnhandled = (reason: unknown) => {
     rejections.push(reason);
   };
   process.on("unhandledRejection", onUnhandled);
 
-  let calls = 0;
-  const writeLive = async (): Promise<void> => {
-    calls += 1;
-    throw new Error("disk full (proof)");
-  };
+  const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-hb-reject-home-"));
+  const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-hb-reject-runs-"));
+  const previousHome = process.env.HOME;
+  process.env.HOME = homeDir;
 
-  const heartbeat = async (): Promise<void> => {
-    await writeLive();
-  };
-
-  const timer = setInterval(() => {
-    void heartbeat().catch(() => {
-      // best effort — same as FlowRunner.runWithHeartbeat
+  try {
+    const runner = new FlowRunner({
+      resolveAgent: () => ({
+        agentName: "unused",
+        agentCommand: "unused",
+        cwd: process.cwd(),
+      }),
+      permissionMode: "approve-all",
+      outputRoot,
     });
-  }, 15);
 
-  await new Promise((resolve) => {
-    setTimeout(resolve, 80);
-  });
-  clearInterval(timer);
-  await new Promise((resolve) => {
-    setTimeout(resolve, 30);
-  });
-  process.off("unhandledRejection", onUnhandled);
+    const store = (
+      runner as unknown as {
+        store: {
+          writeLive: (...args: WriteLiveArgs) => Promise<void>;
+        };
+      }
+    ).store;
+    const originalWriteLive = store.writeLive.bind(store);
+    let heartbeatAttempts = 0;
+    let rejectedIntervalHeartbeats = 0;
+    store.writeLive = async (...args: WriteLiveArgs) => {
+      const event = args[2];
+      if (event?.type === "node_heartbeat") {
+        heartbeatAttempts += 1;
+        // First call is awaited during shell prepare (must succeed so the
+        // node can run). Interval ticks from runWithHeartbeat must be
+        // swallowed so they never become unhandledRejection.
+        if (heartbeatAttempts > 1) {
+          rejectedIntervalHeartbeats += 1;
+          throw new Error("disk full (proof)");
+        }
+      }
+      return originalWriteLive(...args);
+    };
 
-  assert.ok(calls >= 2, `expected multiple heartbeat attempts, got ${calls}`);
-  assert.equal(rejections.length, 0, `unexpected unhandledRejection: ${String(rejections)}`);
+    const flow = defineFlow({
+      name: "heartbeat-reject-test",
+      startAt: "slow",
+      nodes: {
+        slow: shell({
+          heartbeatMs: 20,
+          exec: () => ({
+            command: process.execPath,
+            args: [
+              "-e",
+              "setTimeout(() => process.stdout.write(JSON.stringify({done:true})), 120)",
+            ],
+          }),
+          parse: (result) => extractJsonObject(result.stdout),
+        }),
+      },
+      edges: [],
+    });
+
+    const result = await runner.run(flow, {});
+    // Allow any late timer ticks to surface
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    assert.equal(result.state.status, "completed");
+    assert.deepEqual(result.state.outputs.slow, { done: true });
+    assert.ok(
+      rejectedIntervalHeartbeats >= 1,
+      `expected at least one rejected interval heartbeat, got attempts=${heartbeatAttempts} rejected=${rejectedIntervalHeartbeats}`,
+    );
+    assert.equal(
+      rejections.length,
+      0,
+      `unexpected unhandledRejection: ${String(rejections[0] ?? "")}`,
+    );
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    await fs.rm(homeDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    await fs.rm(outputRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+  }
 });

--- a/test/flows-heartbeat-rejection.test.ts
+++ b/test/flows-heartbeat-rejection.test.ts
@@ -92,11 +92,7 @@ test("FlowRunner heartbeat writeLive rejections do not become unhandledRejection
       rejectedIntervalHeartbeats >= 1,
       `expected at least one rejected interval heartbeat, got attempts=${heartbeatAttempts} rejected=${rejectedIntervalHeartbeats}`,
     );
-    assert.equal(
-      rejections.length,
-      0,
-      `unexpected unhandledRejection: ${String(rejections[0] ?? "")}`,
-    );
+    assert.deepEqual(rejections, []);
   } finally {
     process.off("unhandledRejection", onUnhandled);
     if (previousHome === undefined) {


### PR DESCRIPTION
## What Problem This Solves

Flow node heartbeats are written from setInterval. If the write rejects (disk full, closed handle, race at shutdown), an uncaught rejection from the interval callback can surface as unhandledRejection noise or flaky process flags.

## Evidence

### After-fix proof (2026-07-26)

```console
$ pnpm build && pnpm test
ℹ tests 849
ℹ pass 849
ℹ fail 0
```

Code path (flows runtime):

```ts
void heartbeat().catch(() => {
  // swallow interval write rejections
});
```

## Real behavior proof

- **Behavior or issue addressed:** Swallow heartbeat write rejections from setInterval so disposable flow runs complete without unhandledRejection from heartbeats.
- **Real environment tested:** macOS arm64, Node 22, full package test suite on PR branch.
- **Exact steps or command run after this patch:** pnpm build; pnpm test (849 pass).
- **Evidence after fix:** terminal summary above; catch wired on heartbeat interval in src/flows/runtime.ts.
- **Observed result after fix:** suite green; interval path does not rethrow.
- **What was not tested:** intentional disk-full injection during a multi-hour live flow (covered by catch + unit/integration suite).

