### PR TITLE
fix(cli): report a cold-start session as "agent starting", not "needs reconnect"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Repo: https://github.com/openclaw/acpx
 
 - Runtime/sessions: use collision-resistant temporary paths for concurrent atomic session and index writes. Thanks @henkterharmsel.
 
+- CLI/status: report a normal cold-start session as `agent starting` while preserving `needs reconnect` for an unreachable live owner. Thanks @guettli.
+
 ## 2026.7.23 (v0.12.1)
 
 ### Changes

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -16,17 +16,23 @@ function formatRoutedFrom(sessionCwd: string, currentCwd: string): string | unde
   return relative.startsWith(".") ? relative : `.${path.sep}${relative}`;
 }
 
-// A session with no healthy queue owner is not broken: the owner is started on
-// demand by the very prompt this banner introduces. Cold-start every run (a
-// fresh container, a CI job) lands here, so the status has to read as the
-// normal path, not as a defect the operator must act on.
-type SessionConnectionStatus = "connected" | "starting";
+type SessionConnectionStatus = "connected" | "starting" | "needs reconnect";
+
+export function classifySessionConnectionStatus(health: {
+  healthy: boolean;
+  hasLease: boolean;
+}): SessionConnectionStatus {
+  if (health.healthy) {
+    return "connected";
+  }
+  return health.hasLease ? "needs reconnect" : "starting";
+}
 
 async function resolveSessionConnectionStatus(
   record: SessionRecord,
 ): Promise<SessionConnectionStatus> {
   const health = await probeQueueOwnerHealth(record.acpxRecordId);
-  return health.healthy ? "connected" : "starting";
+  return classifySessionConnectionStatus(health);
 }
 
 export function printSessionsByFormat(sessions: SessionRecord[], format: OutputFormat): void {

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -16,13 +16,17 @@ function formatRoutedFrom(sessionCwd: string, currentCwd: string): string | unde
   return relative.startsWith(".") ? relative : `.${path.sep}${relative}`;
 }
 
-type SessionConnectionStatus = "connected" | "needs reconnect";
+// A session with no healthy queue owner is not broken: the owner is started on
+// demand by the very prompt this banner introduces. Cold-start every run (a
+// fresh container, a CI job) lands here, so the status has to read as the
+// normal path, not as a defect the operator must act on.
+type SessionConnectionStatus = "connected" | "starting";
 
 async function resolveSessionConnectionStatus(
   record: SessionRecord,
 ): Promise<SessionConnectionStatus> {
   const health = await probeQueueOwnerHealth(record.acpxRecordId);
-  return health.healthy ? "connected" : "needs reconnect";
+  return health.healthy ? "connected" : "starting";
 }
 
 export function printSessionsByFormat(sessions: SessionRecord[], format: OutputFormat): void {
@@ -203,7 +207,7 @@ export function printQueuedPromptByFormat(
 export function formatPromptSessionBannerLine(
   record: SessionRecord,
   currentCwd: string,
-  connectionStatus: SessionConnectionStatus = "needs reconnect",
+  connectionStatus: SessionConnectionStatus = "starting",
 ): string {
   const label = formatSessionLabel(record);
   const normalizedSessionCwd = path.resolve(record.cwd);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -235,10 +235,23 @@ test("formatPromptSessionBannerLine prints single-line prompt banner for matchin
   });
 
   const line = formatPromptSessionBannerLine(record, "/home/user/project");
-  assert.equal(
-    line,
-    "[acpx] session calm-forest (abc123) · /home/user/project · agent needs reconnect",
-  );
+  assert.equal(line, "[acpx] session calm-forest (abc123) · /home/user/project · agent starting");
+});
+
+test("formatPromptSessionBannerLine reports a live queue owner as connected", () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "abc123",
+    acpSessionId: "abc123",
+    agentCommand: "agent-a",
+    cwd: "/home/user/project",
+    name: "calm-forest",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastUsedAt: "2026-01-01T00:00:00.000Z",
+    closed: false,
+  });
+
+  const line = formatPromptSessionBannerLine(record, "/home/user/project", "connected");
+  assert.equal(line, "[acpx] session calm-forest (abc123) · /home/user/project · agent connected");
 });
 
 test("formatPromptSessionBannerLine includes routed-from path when cwd differs", () => {
@@ -256,7 +269,7 @@ test("formatPromptSessionBannerLine includes routed-from path when cwd differs",
   const line = formatPromptSessionBannerLine(record, "/home/user/project/src/auth");
   assert.equal(
     line,
-    "[acpx] session calm-forest (abc123) · /home/user/project (routed from ./src/auth) · agent needs reconnect",
+    "[acpx] session calm-forest (abc123) · /home/user/project (routed from ./src/auth) · agent starting",
   );
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -15,6 +15,7 @@ import {
   parseMaxTurns,
   parseTtlSeconds,
 } from "../src/cli.js";
+import { classifySessionConnectionStatus } from "../src/cli/output/render.js";
 import { serializeSessionRecordForDisk } from "../src/session/persistence.js";
 import type { SessionRecord } from "../src/types.js";
 import {
@@ -252,6 +253,15 @@ test("formatPromptSessionBannerLine reports a live queue owner as connected", ()
 
   const line = formatPromptSessionBannerLine(record, "/home/user/project", "connected");
   assert.equal(line, "[acpx] session calm-forest (abc123) · /home/user/project · agent connected");
+});
+
+test("session banner status distinguishes cold start from an unreachable owner", () => {
+  assert.equal(classifySessionConnectionStatus({ healthy: true, hasLease: true }), "connected");
+  assert.equal(classifySessionConnectionStatus({ healthy: false, hasLease: false }), "starting");
+  assert.equal(
+    classifySessionConnectionStatus({ healthy: false, hasLease: true }),
+    "needs reconnect",
+  );
 });
 
 test("formatPromptSessionBannerLine includes routed-from path when cwd differs", () => {


### PR DESCRIPTION
## What

The prompt banner reports a session with no live queue owner as `agent needs reconnect`. Rename that status to `agent starting`.

```
- [acpx] session calm-forest (abc123) · /home/user/project · agent needs reconnect
+ [acpx] session calm-forest (abc123) · /home/user/project · agent starting
```

## Why

`resolveSessionConnectionStatus` derives the banner status from `probeQueueOwnerHealth`, and renders anything unhealthy as `needs reconnect`:

```ts
type SessionConnectionStatus = "connected" | "needs reconnect";

async function resolveSessionConnectionStatus(record) {
  const health = await probeQueueOwnerHealth(record.acpxRecordId);
  return health.healthy ? "connected" : "needs reconnect";
}
```

But a session without a live queue owner isn't broken — the owner is spawned on demand by the very prompt this banner introduces (`sendSession` → `spawnQueueOwnerProcess`). So **every cold start lands here**: a fresh container, a CI job, a per-task worker Pod. Those runs print `agent needs reconnect` on stderr and then complete perfectly.

The string describes a defect that doesn't exist, at precisely the moment nothing needs reconnecting. And because it's on stderr and reads like an auth/connection failure, it's indistinguishable from a real one to anything reading logs. We run acpx one-shot per task in Kubernetes, so *100%* of our runs emit it; a supervisor of ours pattern-matched the line as a Claude auth failure and parked its whole fleet on healthy credentials. That regex was our bug to own — but the wording is what invited it, and no other acpx output distinguishes "cold start, about to spawn an owner" from "this session is broken".

`starting` states what acpx is about to do. It also matches the tone of the existing sibling string, `session idle; queue owner will start on next prompt`.

## Before / after

Real runs, published `acpx@0.12.0` vs this branch. Both succeed (`stopReason: end_turn`, exit 0):

**Before**
```
$ npx acpx@0.12.0 --approve-all --timeout 90 --format json claude -s demo --file p.md
[acpx] session demo-before (f17003f4-…) · /tmp/acpxdemo · agent needs reconnect
```

**After**
```
$ node dist/cli.js --approve-all --timeout 90 --format json claude -s demo --file p.md
[acpx] session demo-after (da550294-…) · /tmp/acpxdemo · agent starting
```

## Notes

- Behaviour is unchanged; this is the status wording only.
- `SessionConnectionStatus` is internal to `render.ts`. `formatPromptSessionBannerLine` is exported, but its `connectionStatus` parameter is optional and defaults to the cold-start value, so existing callers are unaffected.
- I deliberately left two adjacent things alone to keep this focused, happy to open separate PRs if you'd like them:
  - the banner still goes to **stderr**, and is still printed under `--format json` (it's only suppressed under `--json-strict` / `--format quiet`);
  - `spawnQueueOwnerProcess` uses `stdio: "ignore"`, so when a queue owner *does* fail to start you get `Session queue owner failed to start for session <id>` with no cause. That one cost us a production outage we could not diagnose.

## Testing

- `pnpm run check` passes (format, typecheck, lint, build, viewer, tests + coverage).
- `pnpm run test`: 849/849 pass.
- Updated the two banner assertions in `test/cli.test.ts`, and added one pinning the `connected` wording so the regression can't quietly come back.
- Verified end-to-end against a real `claude` agent (output above).
