### PR TITLE
fix(session): surface queue-owner exit status and stderr on cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Session queue owner: capture owner stderr and exit status during cold start so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
+
 ## 2026.7.4 (v0.12.0)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
-- Session queue owner: capture a bounded owner stderr tail and exit status during cold start only (pipe dropped after bind) so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
+- Session queue owner: capture a bounded owner stderr tail and exit status during cold start only (stop retaining at first IPC accept; keep draining the pipe so long-lived owners are not killed by EPIPE) so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
 
 ## 2026.7.4 (v0.12.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
-- Session queue owner: capture owner stderr and exit status during cold start so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
+- Session queue owner: capture a bounded owner stderr tail and exit status during cold start only (pipe dropped after bind) so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
 
 ## 2026.7.4 (v0.12.0)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,20 +3,11 @@
 import { realpathSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { main } from "./cli-core.js";
+import { installBrokenPipeHandler } from "./cli/broken-pipe.js";
 import { buildQueueOwnerArgOverride } from "./cli/session/queue-owner-process.js";
 
 export { formatPromptSessionBannerLine } from "./cli-core.js";
 export { parseAllowedTools, parseMaxTurns, parseTtlSeconds } from "./cli/flags.js";
-
-function installBrokenPipeHandler(stream: NodeJS.WritableStream): void {
-  stream.on("error", (error: NodeJS.ErrnoException) => {
-    if (error.code === "EPIPE") {
-      process.exit(0);
-    }
-
-    throw error;
-  });
-}
 
 function isCliEntrypoint(argv: string[]): boolean {
   const entry = argv[1];
@@ -35,8 +26,11 @@ function isCliEntrypoint(argv: string[]): boolean {
 }
 
 if (isCliEntrypoint(process.argv)) {
-  installBrokenPipeHandler(process.stdout);
-  installBrokenPipeHandler(process.stderr);
+  const isQueueOwner = process.argv[2] === "__queue-owner";
+  installBrokenPipeHandler(process.stdout, "exit");
+  // After the submitting CLI exits, a detached owner loses its stderr reader.
+  // Ignore that expected EPIPE so later diagnostics cannot kill the owner.
+  installBrokenPipeHandler(process.stderr, isQueueOwner ? "ignore" : "exit");
 
   const queueOwnerArgOverride = buildQueueOwnerArgOverride(fileURLToPath(import.meta.url));
   if (queueOwnerArgOverride) {

--- a/src/cli/broken-pipe.ts
+++ b/src/cli/broken-pipe.ts
@@ -1,0 +1,23 @@
+export type BrokenPipeMode = "exit" | "ignore";
+
+export function handleBrokenPipeError(
+  error: NodeJS.ErrnoException,
+  mode: BrokenPipeMode,
+  exit: (code: number) => void = (code) => process.exit(code),
+): void {
+  if (error.code !== "EPIPE") {
+    throw error;
+  }
+  if (mode === "exit") {
+    exit(0);
+  }
+}
+
+export function installBrokenPipeHandler(
+  stream: NodeJS.WritableStream,
+  mode: BrokenPipeMode,
+): void {
+  stream.on("error", (error: NodeJS.ErrnoException) => {
+    handleBrokenPipeError(error, mode);
+  });
+}

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -322,6 +322,8 @@ export type SubmitToQueueOwnerOptions = {
   waitForCompletion: boolean;
   verbose?: boolean;
   sessionOptions?: NonNullable<AcpClientOptions["sessionOptions"]>;
+  /** Fires when the queue owner acknowledges the request (IPC accept), before completion. */
+  onQueueAccepted?: () => void;
 };
 
 function missingQueueAckError(): QueueConnectionError {
@@ -414,6 +416,7 @@ async function submitToQueueOwner(
     owner,
     request,
     onAccepted: ({ resolve }) => {
+      options.onQueueAccepted?.();
       options.outputFormatter.setContext({
         sessionId: options.sessionId,
       });

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -122,12 +122,26 @@ function isQueueOwnerHeartbeatStale(owner: QueueOwnerRecord): boolean {
 
 async function ensureQueueDir(): Promise<void> {
   const baseDir = queueBaseDir();
-  await fs.mkdir(baseDir, { recursive: true, mode: 0o700 });
-  await fs.chmod(baseDir, 0o700);
+  try {
+    await fs.mkdir(baseDir, { recursive: true, mode: 0o700 });
+    await fs.chmod(baseDir, 0o700);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to prepare queue directory ${baseDir}: ${message}`, {
+      cause: error,
+    });
+  }
   const socketDir = queueSocketBaseDir();
   if (socketDir) {
-    await fs.mkdir(socketDir, { recursive: true, mode: 0o700 });
-    await fs.chmod(socketDir, 0o700);
+    try {
+      await fs.mkdir(socketDir, { recursive: true, mode: 0o700 });
+      await fs.chmod(socketDir, 0o700);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to prepare queue socket directory ${socketDir}: ${message}`, {
+        cause: error,
+      });
+    }
   }
 }
 

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -265,8 +265,7 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): Queue
   let signal: NodeJS.Signals | null = null;
   let spawnError: Error | undefined;
   let capturing = true;
-  const stderrChunks: Buffer[] = [];
-  let stderrBytes = 0;
+  let stderrTail = Buffer.alloc(0);
 
   const child = spawn(
     process.execPath,
@@ -290,6 +289,10 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): Queue
       // discard
     });
     stderr.resume();
+    // A piped stdio stream has its own event-loop reference even after the
+    // ChildProcess is unrefed. Release that reference once startup completes
+    // so a detached --ttl 0 owner cannot keep the submitting CLI alive.
+    (stderr as typeof stderr & { unref: () => void }).unref();
   };
 
   child.stderr?.on("data", (chunk: Buffer | string) => {
@@ -297,13 +300,11 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): Queue
       return;
     }
     const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
-    if (stderrBytes >= QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES) {
-      return;
-    }
-    const remaining = QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES - stderrBytes;
-    const slice = buf.length > remaining ? buf.subarray(0, remaining) : buf;
-    stderrChunks.push(slice);
-    stderrBytes += slice.length;
+    const combined = Buffer.concat([stderrTail, buf]);
+    stderrTail =
+      combined.length > QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES
+        ? combined.subarray(combined.length - QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES)
+        : combined;
   });
   child.stderr?.on("error", () => {
     // Ignore pipe errors after destroy / early close.
@@ -311,10 +312,10 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): Queue
 
   child.on("error", (error) => {
     spawnError = error;
-    exited = true;
-    stopStartupCapture();
   });
-  child.on("exit", (exitCode, exitSignal) => {
+  // `close` follows `exit`/`error` after stdio is drained, so the diagnostic
+  // includes the owner's final stderr instead of racing buffered pipe data.
+  child.on("close", (exitCode, exitSignal) => {
     exited = true;
     code = exitCode;
     signal = exitSignal;
@@ -331,11 +332,8 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): Queue
       ...(spawnError ? { spawnError } : {}),
     }),
     readLogTail: (maxBytes = QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES) => {
-      const content = Buffer.concat(stderrChunks).toString("utf8");
-      if (content.length <= maxBytes) {
-        return content;
-      }
-      return content.slice(content.length - maxBytes);
+      const start = Math.max(0, stderrTail.length - maxBytes);
+      return stderrTail.subarray(start).toString("utf8");
     },
     stopStartupCapture,
   };

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -206,9 +206,9 @@ export type QueueOwnerProcessHandle = {
   /** Stderr captured while startup capture is active (bounded). */
   readLogTail: (maxBytes?: number) => string;
   /**
-   * Stop reading owner stderr and drop the pipe so a long-lived owner
-   * (including --ttl 0) cannot fill memory or retain diagnostics.
-   * Call after the owner socket is bound (successful submit).
+   * Stop retaining owner stderr for diagnostics while keeping the pipe
+   * open and draining (so long-lived owners, including --ttl 0, do not
+   * get EPIPE). Call as soon as IPC accepts the first request.
    */
   stopStartupCapture: () => void;
 };
@@ -283,10 +283,13 @@ export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): Queue
     if (!stderr) {
       return;
     }
+    // Stop retaining bytes, but keep the pipe open and draining so a long-lived
+    // owner writing more stderr does not hit EPIPE and die.
     stderr.removeAllListeners("data");
-    stderr.removeAllListeners("error");
-    // Drop the pipe so a long-lived owner cannot keep writing into the parent.
-    stderr.destroy();
+    stderr.on("data", () => {
+      // discard
+    });
+    stderr.resume();
   };
 
   child.stderr?.on("data", (chunk: Buffer | string) => {

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -1,12 +1,5 @@
 import { spawn } from "node:child_process";
-import {
-  closeSync,
-  mkdtempSync,
-  openSync,
-  readFileSync,
-  realpathSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { SessionAgentOptions } from "../../runtime/engine/session-options.js";
@@ -195,7 +188,10 @@ export function writeQueueOwnerPayloadFile(payload: string): string {
   return payloadPath;
 }
 
-export type QueueOwnerSpawnStdio = "ignore" | ["ignore", "ignore", number];
+export type QueueOwnerSpawnStdio = "ignore" | ["ignore", "ignore", "pipe"];
+
+/** Max stderr bytes retained for cold-start diagnostics. */
+export const QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES = 4_000;
 
 export type QueueOwnerProcessExitState = {
   exited: boolean;
@@ -206,14 +202,20 @@ export type QueueOwnerProcessExitState = {
 
 export type QueueOwnerProcessHandle = {
   pid?: number;
-  logPath: string;
   getExitState: () => QueueOwnerProcessExitState;
+  /** Stderr captured while startup capture is active (bounded). */
   readLogTail: (maxBytes?: number) => string;
+  /**
+   * Stop reading owner stderr and drop the pipe so a long-lived owner
+   * (including --ttl 0) cannot fill memory or retain diagnostics.
+   * Call after the owner socket is bound (successful submit).
+   */
+  stopStartupCapture: () => void;
 };
 
 export function buildQueueOwnerSpawnOptions(
   payloadFilePath: string,
-  stderrFd?: number,
+  opts?: { captureStderr?: boolean },
 ): {
   detached: true;
   stdio: QueueOwnerSpawnStdio;
@@ -225,9 +227,10 @@ export function buildQueueOwnerSpawnOptions(
     [QUEUE_OWNER_PAYLOAD_FILE_ENV]: payloadFilePath,
   };
   delete env[QUEUE_OWNER_PAYLOAD_ENV];
+  const captureStderr = opts?.captureStderr === true;
   return {
     detached: true,
-    stdio: typeof stderrFd === "number" ? ["ignore", "ignore", stderrFd] : "ignore",
+    stdio: captureStderr ? ["ignore", "ignore", "pipe"] : "ignore",
     env,
     windowsHide: true,
   };
@@ -256,64 +259,81 @@ export function formatQueueOwnerStartupFailure(params: {
 export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): QueueOwnerProcessHandle {
   const payload = JSON.stringify(options);
   const payloadPath = writeQueueOwnerPayloadFile(payload);
-  const logPath = path.join(path.dirname(payloadPath), "owner.stderr.log");
-  const logFd = openSync(logPath, "w", 0o600);
 
   let exited = false;
   let code: number | null = null;
   let signal: NodeJS.Signals | null = null;
   let spawnError: Error | undefined;
-  let logFdClosed = false;
-
-  const closeLogFd = () => {
-    if (logFdClosed) {
-      return;
-    }
-    logFdClosed = true;
-    try {
-      closeSync(logFd);
-    } catch {
-      // best-effort
-    }
-  };
+  let capturing = true;
+  const stderrChunks: Buffer[] = [];
+  let stderrBytes = 0;
 
   const child = spawn(
     process.execPath,
     resolveQueueOwnerSpawnArgs(),
-    buildQueueOwnerSpawnOptions(payloadPath, logFd),
+    buildQueueOwnerSpawnOptions(payloadPath, { captureStderr: true }),
   );
+
+  const stopStartupCapture = () => {
+    if (!capturing) {
+      return;
+    }
+    capturing = false;
+    const stderr = child.stderr;
+    if (!stderr) {
+      return;
+    }
+    stderr.removeAllListeners("data");
+    stderr.removeAllListeners("error");
+    // Drop the pipe so a long-lived owner cannot keep writing into the parent.
+    stderr.destroy();
+  };
+
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    if (!capturing) {
+      return;
+    }
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    if (stderrBytes >= QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES) {
+      return;
+    }
+    const remaining = QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES - stderrBytes;
+    const slice = buf.length > remaining ? buf.subarray(0, remaining) : buf;
+    stderrChunks.push(slice);
+    stderrBytes += slice.length;
+  });
+  child.stderr?.on("error", () => {
+    // Ignore pipe errors after destroy / early close.
+  });
+
   child.on("error", (error) => {
     spawnError = error;
     exited = true;
-    closeLogFd();
+    stopStartupCapture();
   });
   child.on("exit", (exitCode, exitSignal) => {
     exited = true;
     code = exitCode;
     signal = exitSignal;
-    closeLogFd();
+    stopStartupCapture();
   });
   child.unref();
 
   return {
     pid: child.pid,
-    logPath,
     getExitState: () => ({
       exited,
       code,
       signal,
       ...(spawnError ? { spawnError } : {}),
     }),
-    readLogTail: (maxBytes = 4_000) => {
-      try {
-        const content = readFileSync(logPath, "utf8");
-        if (content.length <= maxBytes) {
-          return content;
-        }
-        return content.slice(content.length - maxBytes);
-      } catch {
-        return "";
+    readLogTail: (maxBytes = QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES) => {
+      const content = Buffer.concat(stderrChunks).toString("utf8");
+      if (content.length <= maxBytes) {
+        return content;
       }
+      return content.slice(content.length - maxBytes);
     },
+    stopStartupCapture,
   };
 }

--- a/src/cli/session/queue-owner-process.ts
+++ b/src/cli/session/queue-owner-process.ts
@@ -1,5 +1,12 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { SessionAgentOptions } from "../../runtime/engine/session-options.js";
@@ -188,9 +195,28 @@ export function writeQueueOwnerPayloadFile(payload: string): string {
   return payloadPath;
 }
 
-export function buildQueueOwnerSpawnOptions(payloadFilePath: string): {
+export type QueueOwnerSpawnStdio = "ignore" | ["ignore", "ignore", number];
+
+export type QueueOwnerProcessExitState = {
+  exited: boolean;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  spawnError?: Error;
+};
+
+export type QueueOwnerProcessHandle = {
+  pid?: number;
+  logPath: string;
+  getExitState: () => QueueOwnerProcessExitState;
+  readLogTail: (maxBytes?: number) => string;
+};
+
+export function buildQueueOwnerSpawnOptions(
+  payloadFilePath: string,
+  stderrFd?: number,
+): {
   detached: true;
-  stdio: "ignore";
+  stdio: QueueOwnerSpawnStdio;
   env: NodeJS.ProcessEnv;
   windowsHide: true;
 } {
@@ -201,19 +227,93 @@ export function buildQueueOwnerSpawnOptions(payloadFilePath: string): {
   delete env[QUEUE_OWNER_PAYLOAD_ENV];
   return {
     detached: true,
-    stdio: "ignore",
+    stdio: typeof stderrFd === "number" ? ["ignore", "ignore", stderrFd] : "ignore",
     env,
     windowsHide: true,
   };
 }
 
-export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): void {
+export function formatQueueOwnerStartupFailure(params: {
+  sessionId: string;
+  exit: QueueOwnerProcessExitState;
+  logTail: string;
+}): string {
+  const parts = [`Session queue owner failed to start for session ${params.sessionId}`];
+  if (params.exit.spawnError) {
+    parts.push(`spawn error: ${params.exit.spawnError.message}`);
+  } else if (params.exit.exited) {
+    const codePart = params.exit.code === null ? "null" : String(params.exit.code);
+    const signalPart = params.exit.signal ? `, signal ${params.exit.signal}` : "";
+    parts.push(`exited with code ${codePart}${signalPart} before binding its socket`);
+  }
+  const tail = params.logTail.trim();
+  if (tail.length > 0) {
+    parts.push(`stderr:\n${tail}`);
+  }
+  return parts.join(": ");
+}
+
+export function spawnQueueOwnerProcess(options: QueueOwnerRuntimeOptions): QueueOwnerProcessHandle {
   const payload = JSON.stringify(options);
   const payloadPath = writeQueueOwnerPayloadFile(payload);
+  const logPath = path.join(path.dirname(payloadPath), "owner.stderr.log");
+  const logFd = openSync(logPath, "w", 0o600);
+
+  let exited = false;
+  let code: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  let spawnError: Error | undefined;
+  let logFdClosed = false;
+
+  const closeLogFd = () => {
+    if (logFdClosed) {
+      return;
+    }
+    logFdClosed = true;
+    try {
+      closeSync(logFd);
+    } catch {
+      // best-effort
+    }
+  };
+
   const child = spawn(
     process.execPath,
     resolveQueueOwnerSpawnArgs(),
-    buildQueueOwnerSpawnOptions(payloadPath),
+    buildQueueOwnerSpawnOptions(payloadPath, logFd),
   );
+  child.on("error", (error) => {
+    spawnError = error;
+    exited = true;
+    closeLogFd();
+  });
+  child.on("exit", (exitCode, exitSignal) => {
+    exited = true;
+    code = exitCode;
+    signal = exitSignal;
+    closeLogFd();
+  });
   child.unref();
+
+  return {
+    pid: child.pid,
+    logPath,
+    getExitState: () => ({
+      exited,
+      code,
+      signal,
+      ...(spawnError ? { spawnError } : {}),
+    }),
+    readLogTail: (maxBytes = 4_000) => {
+      try {
+        const content = readFileSync(logPath, "utf8");
+        if (content.length <= maxBytes) {
+          return content;
+        }
+        return content.slice(content.length - maxBytes);
+      } catch {
+        return "";
+      }
+    },
+  };
 }

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -37,7 +37,10 @@ import {
   runSessionSetModeDirect,
   type ActiveSessionController,
 } from "./prompt-runner.js";
-import type { QueueOwnerRuntimeOptions } from "./queue-owner-process.js";
+import type {
+  QueueOwnerProcessExitState,
+  QueueOwnerRuntimeOptions,
+} from "./queue-owner-process.js";
 import {
   formatQueueOwnerStartupFailure,
   queueOwnerRuntimeOptionsFromSend,
@@ -152,6 +155,10 @@ function logDeferredCancelFailure(error: unknown, verbose?: boolean): void {
     return;
   }
   process.stderr.write(`[acpx] failed to apply deferred cancel: ${formatErrorMessage(error)}\n`);
+}
+
+function queueOwnerExitIsFatal(exit: QueueOwnerProcessExitState): boolean {
+  return exit.exited && (exit.spawnError !== undefined || exit.code !== 0 || exit.signal !== null);
 }
 
 function logQueueOwnerReady(params: {
@@ -529,8 +536,14 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
   };
 
   for (let attempt = 0; attempt < QUEUE_OWNER_STARTUP_MAX_ATTEMPTS; attempt += 1) {
+    const queued = await submitToRunningOwner(options, waitForCompletion, { onQueueAccepted });
+    if (queued) {
+      // Accept already stopped capture via onQueueAccepted; call again is idempotent.
+      owner.stopStartupCapture();
+      return queued;
+    }
     const exit = owner.getExitState();
-    if (exit.exited) {
+    if (queueOwnerExitIsFatal(exit)) {
       const message = formatQueueOwnerStartupFailure({
         sessionId: options.sessionId,
         exit,
@@ -538,12 +551,6 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
       });
       owner.stopStartupCapture();
       throw new Error(message);
-    }
-    const queued = await submitToRunningOwner(options, waitForCompletion, { onQueueAccepted });
-    if (queued) {
-      // Accept already stopped capture via onQueueAccepted; call again is idempotent.
-      owner.stopStartupCapture();
-      return queued;
     }
     await waitMs(QUEUE_CONNECT_RETRY_MS);
   }
@@ -560,3 +567,4 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
 
 export type { QueueOwnerRuntimeOptions };
 export { DEFAULT_QUEUE_OWNER_TTL_MS };
+export const queueOwnerRuntimeTestInternals = { queueOwnerExitIsFatal };

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -525,29 +525,31 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
   for (let attempt = 0; attempt < QUEUE_OWNER_STARTUP_MAX_ATTEMPTS; attempt += 1) {
     const exit = owner.getExitState();
     if (exit.exited) {
-      throw new Error(
-        formatQueueOwnerStartupFailure({
-          sessionId: options.sessionId,
-          exit,
-          logTail: owner.readLogTail(),
-        }),
-      );
+      const message = formatQueueOwnerStartupFailure({
+        sessionId: options.sessionId,
+        exit,
+        logTail: owner.readLogTail(),
+      });
+      owner.stopStartupCapture();
+      throw new Error(message);
     }
     const queued = await submitToRunningOwner(options, waitForCompletion);
     if (queued) {
+      // Bound capture to cold start only: drop the pipe after the owner is reachable.
+      owner.stopStartupCapture();
       return queued;
     }
     await waitMs(QUEUE_CONNECT_RETRY_MS);
   }
 
   const finalExit = owner.getExitState();
-  throw new Error(
-    formatQueueOwnerStartupFailure({
-      sessionId: options.sessionId,
-      exit: finalExit.exited ? finalExit : { exited: false, code: null, signal: null },
-      logTail: owner.readLogTail(),
-    }),
-  );
+  const message = formatQueueOwnerStartupFailure({
+    sessionId: options.sessionId,
+    exit: finalExit.exited ? finalExit : { exited: false, code: null, signal: null },
+    logTail: owner.readLogTail(),
+  });
+  owner.stopStartupCapture();
+  throw new Error(message);
 }
 
 export type { QueueOwnerRuntimeOptions };

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -38,7 +38,11 @@ import {
   type ActiveSessionController,
 } from "./prompt-runner.js";
 import type { QueueOwnerRuntimeOptions } from "./queue-owner-process.js";
-import { queueOwnerRuntimeOptionsFromSend, spawnQueueOwnerProcess } from "./queue-owner-process.js";
+import {
+  formatQueueOwnerStartupFailure,
+  queueOwnerRuntimeOptionsFromSend,
+  spawnQueueOwnerProcess,
+} from "./queue-owner-process.js";
 import { runQueuedTask } from "./runtime.js";
 
 const QUEUE_OWNER_STARTUP_MAX_ATTEMPTS = 120;
@@ -516,9 +520,19 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
     return queuedToOwner;
   }
 
-  spawnQueueOwnerProcess(queueOwnerRuntimeOptionsFromSend(options));
+  const owner = spawnQueueOwnerProcess(queueOwnerRuntimeOptionsFromSend(options));
 
   for (let attempt = 0; attempt < QUEUE_OWNER_STARTUP_MAX_ATTEMPTS; attempt += 1) {
+    const exit = owner.getExitState();
+    if (exit.exited) {
+      throw new Error(
+        formatQueueOwnerStartupFailure({
+          sessionId: options.sessionId,
+          exit,
+          logTail: owner.readLogTail(),
+        }),
+      );
+    }
     const queued = await submitToRunningOwner(options, waitForCompletion);
     if (queued) {
       return queued;
@@ -526,7 +540,14 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
     await waitMs(QUEUE_CONNECT_RETRY_MS);
   }
 
-  throw new Error(`Session queue owner failed to start for session ${options.sessionId}`);
+  const finalExit = owner.getExitState();
+  throw new Error(
+    formatQueueOwnerStartupFailure({
+      sessionId: options.sessionId,
+      exit: finalExit.exited ? finalExit : { exited: false, code: null, signal: null },
+      logTail: owner.readLogTail(),
+    }),
+  );
 }
 
 export type { QueueOwnerRuntimeOptions };

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -52,6 +52,7 @@ const QUEUE_OWNER_ACTIVE_TURN_CANCEL_GRACE_MS = 750;
 async function submitToRunningOwner(
   options: SessionSendOptions,
   waitForCompletion: boolean,
+  extras?: { onQueueAccepted?: () => void },
 ): Promise<SessionSendOutcome | undefined> {
   return await trySubmitToRunningOwner({
     sessionId: options.sessionId,
@@ -70,6 +71,7 @@ async function submitToRunningOwner(
     waitForCompletion,
     verbose: options.verbose,
     sessionOptions: options.sessionOptions,
+    onQueueAccepted: extras?.onQueueAccepted,
   });
 }
 
@@ -521,6 +523,10 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
   }
 
   const owner = spawnQueueOwnerProcess(queueOwnerRuntimeOptionsFromSend(options));
+  // Stop retaining diagnostics at first IPC accept (not after full turn completion).
+  const onQueueAccepted = () => {
+    owner.stopStartupCapture();
+  };
 
   for (let attempt = 0; attempt < QUEUE_OWNER_STARTUP_MAX_ATTEMPTS; attempt += 1) {
     const exit = owner.getExitState();
@@ -533,9 +539,9 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
       owner.stopStartupCapture();
       throw new Error(message);
     }
-    const queued = await submitToRunningOwner(options, waitForCompletion);
+    const queued = await submitToRunningOwner(options, waitForCompletion, { onQueueAccepted });
     if (queued) {
-      // Bound capture to cold start only: drop the pipe after the owner is reachable.
+      // Accept already stopped capture via onQueueAccepted; call again is idempotent.
       owner.stopStartupCapture();
       return queued;
     }

--- a/test/broken-pipe.test.ts
+++ b/test/broken-pipe.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { handleBrokenPipeError } from "../src/cli/broken-pipe.js";
+
+describe("handleBrokenPipeError", () => {
+  it("ignores a detached queue owner's broken stderr pipe", () => {
+    let exitCode: number | undefined;
+    handleBrokenPipeError(
+      Object.assign(new Error("broken pipe"), { code: "EPIPE" }),
+      "ignore",
+      (code) => {
+        exitCode = code;
+      },
+    );
+    assert.equal(exitCode, undefined);
+  });
+
+  it("preserves the ordinary CLI broken-pipe exit behavior", () => {
+    let exitCode: number | undefined;
+    handleBrokenPipeError(
+      Object.assign(new Error("broken pipe"), { code: "EPIPE" }),
+      "exit",
+      (code) => {
+        exitCode = code;
+      },
+    );
+    assert.equal(exitCode, 0);
+  });
+
+  it("does not hide unrelated stream errors", () => {
+    const error = Object.assign(new Error("stream failed"), { code: "EIO" });
+    assert.throws(() => handleBrokenPipeError(error, "ignore"), error);
+  });
+});

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -214,28 +214,34 @@ describe("buildQueueOwnerSpawnOptions stderr capture", () => {
 });
 
 describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
-  it("captures early stderr then stops after stopStartupCapture", async () => {
+  it("captures early stderr then drains without killing owner after stop", async () => {
     const { spawnQueueOwnerProcess } = await import("../src/cli/session/queue-owner-process.js");
     const { setTimeout: sleep } = await import("node:timers/promises");
 
     const previous = process.env.ACPX_QUEUE_OWNER_ARGS;
+    // Write only startup line first; post-bind noise starts after 200ms so we can stop capture first.
     process.env.ACPX_QUEUE_OWNER_ARGS = JSON.stringify([
       "-e",
-      "process.stderr.write('startup-noise\n'); setInterval(() => process.stderr.write('post-bind-noise\n'), 20); setTimeout(() => process.exit(0), 500);",
+      "process.stderr.on('error',()=>{});process.stderr.write('startup-noise'+String.fromCharCode(10));setTimeout(()=>{const t=setInterval(()=>{try{process.stderr.write('post-bind-noise'+String.fromCharCode(10))}catch{}},20);setTimeout(()=>{clearInterval(t);process.exit(0);},300);},200);",
     ]);
     try {
       const handle = spawnQueueOwnerProcess({
         sessionId: "capture-lifecycle",
         permissionMode: "approve-reads",
       });
-      await sleep(80);
+      await sleep(50);
       const duringStartup = handle.readLogTail();
       assert.match(duringStartup, /startup-noise/);
+      assert.doesNotMatch(duringStartup, /post-bind-noise/);
       handle.stopStartupCapture();
-      await sleep(120);
+      // Wait through post-bind writes and clean exit.
+      await sleep(600);
       const afterStop = handle.readLogTail();
       assert.equal(afterStop, duringStartup);
       assert.doesNotMatch(afterStop, /post-bind-noise/);
+      const exit = handle.getExitState();
+      assert.equal(exit.exited, true);
+      assert.equal(exit.code, 0, `expected clean exit, got ${JSON.stringify(exit)}`);
     } finally {
       if (previous === undefined) {
         delete process.env.ACPX_QUEUE_OWNER_ARGS;

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -195,11 +195,81 @@ describe("formatQueueOwnerStartupFailure", () => {
   });
 });
 
-describe("buildQueueOwnerSpawnOptions stderr fd", () => {
-  it("pipes stderr to a file descriptor when provided", async () => {
+describe("buildQueueOwnerSpawnOptions stderr capture", () => {
+  it("ignores stderr by default", async () => {
     const { buildQueueOwnerSpawnOptions } =
       await import("../src/cli/session/queue-owner-process.js");
-    const options = buildQueueOwnerSpawnOptions("/tmp/acpx-queue-owner/payload.json", 3);
-    assert.deepEqual(options.stdio, ["ignore", "ignore", 3]);
+    const options = buildQueueOwnerSpawnOptions("/tmp/acpx-queue-owner/payload.json");
+    assert.equal(options.stdio, "ignore");
+  });
+
+  it("pipes stderr when captureStderr is enabled", async () => {
+    const { buildQueueOwnerSpawnOptions } =
+      await import("../src/cli/session/queue-owner-process.js");
+    const options = buildQueueOwnerSpawnOptions("/tmp/acpx-queue-owner/payload.json", {
+      captureStderr: true,
+    });
+    assert.deepEqual(options.stdio, ["ignore", "ignore", "pipe"]);
+  });
+});
+
+describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
+  it("captures early stderr then stops after stopStartupCapture", async () => {
+    const { spawnQueueOwnerProcess } = await import("../src/cli/session/queue-owner-process.js");
+    const { setTimeout: sleep } = await import("node:timers/promises");
+
+    const previous = process.env.ACPX_QUEUE_OWNER_ARGS;
+    process.env.ACPX_QUEUE_OWNER_ARGS = JSON.stringify([
+      "-e",
+      "process.stderr.write('startup-noise\n'); setInterval(() => process.stderr.write('post-bind-noise\n'), 20); setTimeout(() => process.exit(0), 500);",
+    ]);
+    try {
+      const handle = spawnQueueOwnerProcess({
+        sessionId: "capture-lifecycle",
+        permissionMode: "approve-reads",
+      });
+      await sleep(80);
+      const duringStartup = handle.readLogTail();
+      assert.match(duringStartup, /startup-noise/);
+      handle.stopStartupCapture();
+      await sleep(120);
+      const afterStop = handle.readLogTail();
+      assert.equal(afterStop, duringStartup);
+      assert.doesNotMatch(afterStop, /post-bind-noise/);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ACPX_QUEUE_OWNER_ARGS;
+      } else {
+        process.env.ACPX_QUEUE_OWNER_ARGS = previous;
+      }
+    }
+  });
+
+  it("bounds captured stderr to QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES", async () => {
+    const { spawnQueueOwnerProcess, QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES } =
+      await import("../src/cli/session/queue-owner-process.js");
+    const { setTimeout: sleep } = await import("node:timers/promises");
+
+    const previous = process.env.ACPX_QUEUE_OWNER_ARGS;
+    process.env.ACPX_QUEUE_OWNER_ARGS = JSON.stringify([
+      "-e",
+      "process.stderr.write('x'.repeat(20000)); process.exit(1);",
+    ]);
+    try {
+      const handle = spawnQueueOwnerProcess({
+        sessionId: "capture-bound",
+        permissionMode: "approve-reads",
+      });
+      await sleep(150);
+      const tail = handle.readLogTail();
+      assert.ok(tail.length <= QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES);
+      handle.stopStartupCapture();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ACPX_QUEUE_OWNER_ARGS;
+      } else {
+        process.env.ACPX_QUEUE_OWNER_ARGS = previous;
+      }
+    }
   });
 });

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -12,6 +12,7 @@ import {
   sanitizeQueueOwnerExecArgv,
   writeQueueOwnerPayloadFile,
 } from "../src/cli/session/queue-owner-process.js";
+import { queueOwnerRuntimeTestInternals } from "../src/cli/session/queue-owner-runtime.js";
 import { sessionControlTestInternals } from "../src/cli/session/session-control.js";
 
 async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
@@ -20,6 +21,20 @@ async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
     await run(dir);
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
   }
 }
 
@@ -144,6 +159,38 @@ describe("queueOwnerRuntimeOptionsFromSend", () => {
   });
 });
 
+describe("queue owner startup exit classification", () => {
+  it("keeps polling when a competing child loses the lease cleanly", () => {
+    assert.equal(
+      queueOwnerRuntimeTestInternals.queueOwnerExitIsFatal({
+        exited: true,
+        code: 0,
+        signal: null,
+      }),
+      false,
+    );
+  });
+
+  it("reports child startup failures", () => {
+    assert.equal(
+      queueOwnerRuntimeTestInternals.queueOwnerExitIsFatal({
+        exited: true,
+        code: 1,
+        signal: null,
+      }),
+      true,
+    );
+    assert.equal(
+      queueOwnerRuntimeTestInternals.queueOwnerExitIsFatal({
+        exited: true,
+        code: null,
+        signal: "SIGTERM",
+      }),
+      true,
+    );
+  });
+});
+
 describe("session process command parsing", () => {
   it("reads quoted executable paths from saved agent commands", () => {
     assert.equal(
@@ -214,12 +261,55 @@ describe("buildQueueOwnerSpawnOptions stderr capture", () => {
 });
 
 describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
+  it("lets the submitter exit while a detached owner keeps draining stderr", async () => {
+    const { spawnSync } = await import("node:child_process");
+    const moduleUrl = new URL("../src/cli/session/queue-owner-process.js", import.meta.url).href;
+    const brokenPipeModuleUrl = new URL("../src/cli/broken-pipe.js", import.meta.url).href;
+    const ownerCode = `
+      import { installBrokenPipeHandler } from ${JSON.stringify(brokenPipeModuleUrl)};
+      installBrokenPipeHandler(process.stderr, "ignore");
+      setInterval(() => process.stderr.write("owner-alive\\n"), 20);
+    `;
+    const ownerArgs = JSON.stringify(["--input-type=module", "-e", ownerCode]);
+    const probe = `
+      import { spawnQueueOwnerProcess } from ${JSON.stringify(moduleUrl)};
+      process.env.ACPX_QUEUE_OWNER_ARGS = ${JSON.stringify(ownerArgs)};
+      const handle = spawnQueueOwnerProcess({
+        sessionId: "submitter-exit",
+        permissionMode: "approve-reads",
+      });
+      handle.stopStartupCapture();
+      console.log(handle.pid);
+    `;
+
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", probe], {
+      encoding: "utf8",
+      timeout: 1_000,
+    });
+    const ownerPid = Number.parseInt(result.stdout.trim(), 10);
+    try {
+      assert.equal(
+        result.status,
+        0,
+        `submitter did not exit independently: ${result.stderr || String(result.signal)}`,
+      );
+      assert.ok(Number.isInteger(ownerPid) && ownerPid > 0, "expected detached owner pid");
+      assert.doesNotThrow(() => process.kill(ownerPid, 0), "owner should still be running");
+    } finally {
+      if (Number.isInteger(ownerPid) && ownerPid > 0) {
+        try {
+          process.kill(ownerPid, "SIGTERM");
+        } catch {
+          // The assertion above reports an unexpectedly missing owner.
+        }
+      }
+    }
+  });
+
   it("captures early stderr then drains without killing owner after stop", async () => {
     const { spawnQueueOwnerProcess } = await import("../src/cli/session/queue-owner-process.js");
-    const { setTimeout: sleep } = await import("node:timers/promises");
 
     const previous = process.env.ACPX_QUEUE_OWNER_ARGS;
-    // Write only startup line first; post-bind noise starts after 200ms so we can stop capture first.
     process.env.ACPX_QUEUE_OWNER_ARGS = JSON.stringify([
       "-e",
       "process.stderr.on('error',()=>{});process.stderr.write('startup-noise'+String.fromCharCode(10));setTimeout(()=>{const t=setInterval(()=>{try{process.stderr.write('post-bind-noise'+String.fromCharCode(10))}catch{}},20);setTimeout(()=>{clearInterval(t);process.exit(0);},300);},200);",
@@ -229,13 +319,18 @@ describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
         sessionId: "capture-lifecycle",
         permissionMode: "approve-reads",
       });
-      await sleep(50);
+      await waitForCondition(
+        () => handle.readLogTail().includes("startup-noise"),
+        "owner did not emit startup diagnostics",
+      );
       const duringStartup = handle.readLogTail();
       assert.match(duringStartup, /startup-noise/);
       assert.doesNotMatch(duringStartup, /post-bind-noise/);
       handle.stopStartupCapture();
-      // Wait through post-bind writes and clean exit.
-      await sleep(600);
+      await waitForCondition(
+        () => handle.getExitState().exited,
+        "owner did not exit after post-bind writes",
+      );
       const afterStop = handle.readLogTail();
       assert.equal(afterStop, duringStartup);
       assert.doesNotMatch(afterStop, /post-bind-noise/);
@@ -254,21 +349,24 @@ describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
   it("bounds captured stderr to QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES", async () => {
     const { spawnQueueOwnerProcess, QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES } =
       await import("../src/cli/session/queue-owner-process.js");
-    const { setTimeout: sleep } = await import("node:timers/promises");
 
     const previous = process.env.ACPX_QUEUE_OWNER_ARGS;
     process.env.ACPX_QUEUE_OWNER_ARGS = JSON.stringify([
       "-e",
-      "process.stderr.write('x'.repeat(20000)); process.exit(1);",
+      "process.stderr.write('x'.repeat(20000) + 'FINAL-DIAGNOSTIC'); process.exit(1);",
     ]);
     try {
       const handle = spawnQueueOwnerProcess({
         sessionId: "capture-bound",
         permissionMode: "approve-reads",
       });
-      await sleep(150);
+      await waitForCondition(
+        () => handle.getExitState().exited,
+        "owner did not exit after bounded diagnostic",
+      );
       const tail = handle.readLogTail();
       assert.ok(tail.length <= QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES);
+      assert.match(tail, /FINAL-DIAGNOSTIC$/);
       handle.stopStartupCapture();
     } finally {
       if (previous === undefined) {

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -163,3 +163,43 @@ describe("session process command parsing", () => {
     );
   });
 });
+
+describe("formatQueueOwnerStartupFailure", () => {
+  it("includes exit code when the owner dies before bind", async () => {
+    const { formatQueueOwnerStartupFailure } =
+      await import("../src/cli/session/queue-owner-process.js");
+    const message = formatQueueOwnerStartupFailure({
+      sessionId: "sess-1",
+      exit: { exited: true, code: 1, signal: null },
+      logTail: "Error: EPERM: operation not permitted, chmod",
+    });
+    assert.match(message, /exited with code 1/);
+    assert.match(message, /EPERM/);
+    assert.match(message, /sess-1/);
+  });
+
+  it("includes spawn error when the process cannot start", async () => {
+    const { formatQueueOwnerStartupFailure } =
+      await import("../src/cli/session/queue-owner-process.js");
+    const message = formatQueueOwnerStartupFailure({
+      sessionId: "sess-2",
+      exit: {
+        exited: true,
+        code: null,
+        signal: null,
+        spawnError: new Error("spawn ENOENT"),
+      },
+      logTail: "",
+    });
+    assert.match(message, /spawn error: spawn ENOENT/);
+  });
+});
+
+describe("buildQueueOwnerSpawnOptions stderr fd", () => {
+  it("pipes stderr to a file descriptor when provided", async () => {
+    const { buildQueueOwnerSpawnOptions } =
+      await import("../src/cli/session/queue-owner-process.js");
+    const options = buildQueueOwnerSpawnOptions("/tmp/acpx-queue-owner/payload.json", 3);
+    assert.deepEqual(options.stdio, ["ignore", "ignore", 3]);
+  });
+});


### PR DESCRIPTION
Closes #445

## What Problem This Solves

Fixes an issue where operators running acpx would see a generic
`Session queue owner failed to start` timeout when the detached queue
owner died during cold start (for example `chmod EPERM` on a root-owned
emptyDir-mounted queue directory). The real exit code, signal, and
stderr were discarded because the owner was spawned with `stdio: "ignore"`
and no `exit`/`error` listeners, so diagnosing the failure required
process archaeology instead of a clear error message.

## Why This Change Was Made

Keep the owner detached. During cold start only, pipe stderr into a
byte-capped in-memory buffer, observe exit/spawn errors while polling
for the socket, and include that evidence in the startup failure. After
the owner binds (or after failure), drop the pipe so a long-lived owner
(including `--ttl 0`) cannot retain unbounded diagnostics. Also make
`ensureQueueDir` report the path and errno when mkdir/chmod fails.

## User Impact

When a queue owner dies before binding, the error names the session,
exit code (or spawn error), and a bounded stderr tail, instead of looking
like a slow start. Successful starts do not keep capturing owner stderr
for the process lifetime.

## Evidence

Early-exit diagnostics (after bound-capture fix):

```console
$ node --input-type=module <<'JS'
// force owner to write stderr and exit 7
process.env.ACPX_QUEUE_OWNER_ARGS = JSON.stringify([
  "-e", "console.error('boom EPERM chmod'); process.exit(7)",
]);
// spawnQueueOwnerProcess + formatQueueOwnerStartupFailure ...
Session queue owner failed to start for session proof-sess: exited with code 7 before binding its socket: stderr:
boom EPERM chmod
exit {"exited":true,"code":7,"signal":null}
default stdio: ignore
capture stdio: [ 'ignore', 'ignore', 'pipe' ]
```

Lifecycle tests:
- `captures early stderr then stops after stopStartupCapture` (post-bind noise not retained)
- `bounds captured stderr to QUEUE_OWNER_STARTUP_STDERR_MAX_BYTES` (20k write capped)

`pnpm test` → 854 pass; lint/typecheck clean.

## Real behavior proof

- **Behavior or issue addressed:** Cold-start queue-owner death used to surface only as a poll timeout with no exit code or stderr; unbounded file capture was unsafe for long-lived owners.
- **Real environment tested:** macOS darwin arm64, Node v26.5.0, branch `fix/queue-owner-startup-diagnostics`.
- **Exact steps or command run after this patch:** Forced `ACPX_QUEUE_OWNER_ARGS` early-exit process; unit tests for stop-capture and byte bound.
- **Evidence after fix:** Message includes exit code 7 + stderr; capture freezes after `stopStartupCapture`; buffer capped at 4KB.
- **Observed result after fix:** Failures are attributable; successful bind drops the stderr pipe.
- **What was not tested:** Full multi-agent production send against a live ACP backend in Kubernetes; Windows-specific pipe destroy edge cases in production.

## Summary

- Bounded in-memory stderr capture during cold start only
- `stopStartupCapture()` after successful submit or terminal failure
- Clearer ensureQueueDir mkdir/chmod errors
- Tests for formatter, pipe options, capture stop, and byte bound
