### PR TITLE
chore(skills): sync autoreview from canonical

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -7,7 +7,7 @@ description: "Pre-commit/ship code review: Codex default; optional Claude or Pi.
 
 Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
 
-Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `high` reasoning by default, then retries once with `gpt-5.6-terra` only when the account cannot access Sol. Claude review is optional and uses `claude-fable-5` by default.
+Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `high` reasoning by default, then retries once with `gpt-5.6-terra` only when the account cannot access Sol. Claude review is optional and uses `claude-fable-5` with `max` effort by default.
 
 For user-visible behavior, pair autoreview with `behavior-validator`. Autoreview is source-aware and judges the change bundle; behavior validation is source-blind and judges the running product or tool against a behavior contract. A clean autoreview is not proof that a UI, CLI, API, or generated artifact works from the user's perspective.
 
@@ -30,16 +30,17 @@ Use when:
 - If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
 - For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
 - Never switch or override the requested review engine/model except for the documented Codex Sol-to-Terra account-access fallback. Capacity, rate-limit, and unrelated failures keep the same engine/model.
+- Claude's implicit refusal-based model switching is disabled for review. If Fable refuses the bundle, retry Fable once in a fresh session, then explicitly retry with `claude-opus-4-8` at `max` effort after the second refusal. Other selected Claude models fail on refusal.
 - Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
 - Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other runnable engines pass raw output through.
 - Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
 - Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
 - Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
 - Reviewer subprocesses preserve engine authentication and non-credentialed proxy variables needed by headless or restricted-network environments while stripping process-injection, Git override, and credentialed proxy values.
-- Review bundles fail closed before engine invocation when tracked or untracked paths look sensitive, patch text looks secret-like, or a Git diff exceeds the bundle limit. Redact/split the change; never accept a truncated patch as complete review proof.
+- Review bundles fail closed before engine invocation when tracked or untracked paths look sensitive or patch text looks secret-like. Safe large diffs are scanned in full, sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
 - For regression provenance, keep roles separate: blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
 - If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
-- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
+- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one validated bundle, calls the selected engine once for normal inputs or once per complete bounded chunk for oversized inputs, validates the structured results, and stops.
 - Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
 - Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
 - Multi-reviewer panels are opt-in only. Use them when explicitly requested or when risk justifies the extra spend; the main agent still verifies every accepted finding before fixing.
@@ -189,6 +190,29 @@ clean `main` against `origin/main` is usually an empty diff after push. For a
 small stack, review each commit explicitly or review the branch before merging
 with `--base`.
 
+## Oversized Bundles
+
+The helper scans the full patch before partitioning it. A safe bundle that fits
+the aggregate prompt limit remains one integrated review pass. Larger bundles
+are split at bundle sections and file boundaries where possible; an oversized
+single-file block is split at line boundaries with repeated file/hunk context
+and an absolute new- or old-file line offset. Untracked snapshots use
+injection-safe source-line records so continuation passes retain reportable
+locations. A single physical diff line split across passes also retains its
+original addition, deletion, or context marker.
+Every original bundle byte appears exactly once across the pass sequence, and
+all validated reports are merged before required-finding and exit-status checks.
+The helper caps one run at eight bounded passes so an unexpectedly huge branch
+cannot create unbounded model calls; split still-larger work into coherent review
+targets.
+
+Chunking makes large-diff review usable, but it cannot give one model call every
+cross-file implementation detail. For architecture-heavy changes, still prefer
+a coherent branch or PR shape whose semantic decision surface fits one pass.
+Removing verified non-authoritative generated noise remains useful, but never
+drop lockfiles, generated clients, policies, manifests, schemas, or other
+independently semantic artifacts merely to shrink the review.
+
 ## Parallel Closeout
 
 Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
@@ -280,6 +304,10 @@ CLI flags and environment variables override these defaults. Pi does not get a b
 
 Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
 
+Claude's CLI reference warns that `--help` does not list every supported flag. The helper capability-checks isolation through empty-print validation with the exact review flags, and verifies the same parser rejects an unknown control flag; it does not infer support from help text or early-exit version behavior.
+
+[Anthropic's Fable model-switching guidance](https://support.claude.com/en/articles/15363606-why-claude-switched-models-in-your-conversation-with-fable-5) explains that flagged Fable requests normally rerun on Opus. Autoreview disables the implicit switch so it can retry Fable once first; only a second refusal triggers the explicit `claude-opus-4-8`/`max` fallback, which is reported in the reviewer label.
+
 [OpenAI's model guidance](https://developers.openai.com/api/docs/guides/latest-model) identifies Sol as the GPT-5.6 frontier-capability route and documents `max` support. Autoreview keeps `high` as its default; use `max` only for the hardest quality-first reviews after comparing its latency and cost with `xhigh` on representative changes.
 
 Examples matching current `main` behavior:
@@ -298,6 +326,10 @@ Examples matching current `main` behavior:
 "$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
 "$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
 
+# Bedrock panel: the isolated Codex reviewer stages the named amazon-bedrock profile;
+# its model/effort defaults come from that profile, while Claude keeps its normal auth.
+"$AUTOREVIEW" --panel --codex-profile bedrock --claude-auth subscription
+
 # Pi with explicit model and thinking level
 "$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
 
@@ -314,35 +346,41 @@ Store persistent personal defaults in your shell startup file or launcher
 environment. For repository-local defaults, use an existing local environment
 loader such as an untracked `.envrc`; the helper does not write a config file.
 
-| Variable                           | Purpose                                                                                                                          |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTOREVIEW_MODEL`                 | Override the built-in default `--model` for all engines                                                                          |
-| `AUTOREVIEW_THINKING`              | Default `--thinking` for all engines                                                                                             |
-| `AUTOREVIEW_FALLBACK_MODEL`        | Default Claude `--fallback-model` chain                                                                                          |
-| `AUTOREVIEW_<ENGINE>_MODEL`        | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                      |
-| `AUTOREVIEW_<ENGINE>_THINKING`     | Per-engine thinking override                                                                                                     |
-| `AUTOREVIEW_CODEX_CONFIG`          | Safe Codex model/response tuning overrides, semicolon-separated, e.g. `service_tier="fast"`; capability-bearing keys fail closed |
-| `AUTOREVIEW_CODEX_SPEED`           | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier    |
-| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain                                                                                                       |
-| `AUTOREVIEW_PROVIDER_ENV_ALLOW`    | Comma-separated custom Pi/OpenCode credential variable names; names must end in a recognized credential suffix                   |
+| Variable                            | Purpose                                                                                                                          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTOREVIEW_REVIEWERS`              | Default comma-separated reviewer panel, for example `codex,claude`                                                               |
+| `AUTOREVIEW_MODEL`                  | Override the built-in default `--model` for all engines                                                                          |
+| `AUTOREVIEW_THINKING`               | Default `--thinking` for all engines                                                                                             |
+| `AUTOREVIEW_FALLBACK_MODEL`         | Default Claude `--fallback-model` chain                                                                                          |
+| `AUTOREVIEW_<ENGINE>_MODEL`         | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                      |
+| `AUTOREVIEW_<ENGINE>_THINKING`      | Per-engine thinking override                                                                                                     |
+| `AUTOREVIEW_CODEX_CONFIG`           | Safe Codex model/response tuning overrides, semicolon-separated, e.g. `service_tier="fast"`; capability-bearing keys fail closed |
+| `AUTOREVIEW_CODEX_SPEED`            | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier    |
+| `AUTOREVIEW_CODEX_PROFILE`          | Named Codex config profile staged into the isolated runtime; currently supports `amazon-bedrock` with env credentials            |
+| `AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA` | Disable Codex CLI strict schema enforcement; automatically disabled for non-OpenAI profiles                                      |
+| `AUTOREVIEW_CLAUDE_AUTH`            | `default` preserves API/provider env; `subscription` ignores it and uses the Claude Code login                                   |
+| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL`  | Claude-only fallback chain                                                                                                       |
+| `AUTOREVIEW_PROVIDER_ENV_ALLOW`     | Comma-separated custom Pi/OpenCode credential variable names; names must end in a recognized credential suffix                   |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Pi maps thinking to `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Pi maps thinking to `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored. Use `--claude-auth subscription` when ambient API or third-party provider variables would otherwise take precedence over the stored Claude Code login.
 
 ## Review engine isolation
 
 When autoreview runs inside the repository under review, external reviewer CLIs must not load project-local trust or configuration that the branch controls.
 
-| Engine       | Isolation flags                                                                                                                                                                                  | Reference                                                                   |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| **codex**    | Auth-only config overrides, isolated workspace, `exec --ignore-user-config --ignore-rules --skip-git-repo-check`, plus read-only sandbox                                                         | Codex CLI `exec --help`                                                     |
-| **claude**   | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*`; auto-memory and filesystem/shell tools disabled; empty external workspace; WebSearch by default (`v2.1.169+`) | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)  |
-| **droid**    | Fails closed: current CLI cannot disable both project instructions and all tools                                                                                                                 | Droid CLI `exec --help` and `--list-tools`                                  |
-| **copilot**  | Fails closed: repository read tools also expose ignored files outside the reviewed bundle                                                                                                        | GitHub Copilot CLI command reference                                        |
-| **pi**       | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                                          | Pi CLI `--help`; requires Pi `v0.79.0+`                                     |
-| **opencode** | Fails closed: project/global config isolation and private-network fetch denial are not both proven                                                                                               | OpenCode CLI contract                                                       |
-| **cursor**   | Fails closed: documented read permissions can target absolute host paths and no proven repository-only filesystem sandbox is exposed                                                             | Cursor CLI [permissions](https://cursor.com/docs/cli/reference/permissions) |
+| Engine       | Isolation flags                                                                                                                                                                                                                                   | Reference                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **codex**    | Auth-only config overrides, isolated workspace, `exec --ignore-user-config --ignore-rules --skip-git-repo-check`, plus read-only sandbox; profiled runs load only the sanitized runtime profile and disable process tools                         | Codex CLI `exec --help`                                                     |
+| **claude**   | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*`; subscription auth uses an empty settings source; auto-memory and filesystem/shell tools disabled; empty external workspace; WebSearch by default (`v2.1.169+`) | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)  |
+| **droid**    | Fails closed: current CLI cannot disable both project instructions and all tools                                                                                                                                                                  | Droid CLI `exec --help` and `--list-tools`                                  |
+| **copilot**  | Fails closed: repository read tools also expose ignored files outside the reviewed bundle                                                                                                                                                         | GitHub Copilot CLI command reference                                        |
+| **pi**       | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                                                                                           | Pi CLI `--help`; requires Pi `v0.79.0+`                                     |
+| **opencode** | Fails closed: project/global config isolation and private-network fetch denial are not both proven                                                                                                                                                | OpenCode CLI contract                                                       |
+| **cursor**   | Fails closed: documented read permissions can target absolute host paths and no proven repository-only filesystem sandbox is exposed                                                                                                              | Cursor CLI [permissions](https://cursor.com/docs/cli/reference/permissions) |
 
-Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication usable without forwarding unrelated user configuration. Codex runs in an empty temporary workspace: the validated bundle is its sole repository input, ignored files and linked-worktree metadata remain unreadable, and the zero project-doc budget keeps workspace instructions out of the prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; autoreview supplies WebSearch by default, permits only explicitly domain-constrained WebFetch rules, and exposes no filesystem or shell tools. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. Droid, Copilot, Cursor, and OpenCode fail closed because their current CLI contracts cannot isolate untrusted review input from host, project, or private-network trust surfaces.
+Codex `--ignore-user-config` skips normal user config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication usable without forwarding unrelated user configuration. When `--codex-profile` is selected, autoreview stages only model, reasoning, service-tier, and built-in Amazon Bedrock region fields into the isolated Codex home; hooks, MCP servers, commands, paths, and unrelated settings are dropped. Profile runs omit `--ignore-user-config` so Codex can load that isolated profile, and force shell, code-mode, and multi-agent execution tools off so Bedrock credentials remain unavailable to model-controlled processes. Bedrock reviews accept `AWS_BEARER_TOKEN_BEDROCK` or static AWS credential environment variables. File-backed AWS named profiles are rejected because the isolated reviewer home intentionally cannot expose `~/.aws`, SSO caches, or credential processes. Codex runs in an empty temporary workspace: the validated bundle is its sole repository input, ignored files and linked-worktree metadata remain unreadable, and the zero project-doc budget keeps workspace instructions out of the prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; subscription-auth reviews also disable user settings so a settings `env` block cannot restore API or provider routing. Autoreview supplies WebSearch by default, permits only explicitly domain-constrained WebFetch rules, and exposes no filesystem or shell tools. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. Droid, Copilot, Cursor, and OpenCode fail closed because their current CLI contracts cannot isolate untrusted review input from host, project, or private-network trust surfaces.
+
+Codex `0.134.0+` profiles use a separate `$CODEX_HOME/<name>.config.toml` file selected by `--profile <name>`; legacy `[profiles.<name>]` tables are no longer read. See [Codex advanced configuration](https://learn.chatgpt.com/docs/config-file/config-advanced#profiles).
 
 Codex uses a named permission profile that grants read access only to an empty temporary workspace. This is narrower than repository-root access, which would expose ignored credentials, and narrower than the legacy `read-only` sandbox, which permits reads across the host filesystem.
 
@@ -386,12 +424,15 @@ The helper:
 - recognizes `--engine droid`, `copilot`, `cursor`, and `opencode` only to fail closed with isolation errors; runnable engines are `codex`, `claude`, and `pi`; default is `AUTOREVIEW_ENGINE` or `codex`
 - resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
 - use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
+- scans safe Git patches in full, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
 - should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
 - writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
 - supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
 - supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
-- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
-- uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, plus `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- supports opt-in review panels with `--panel` / `--reviewers`, an `AUTOREVIEW_REVIEWERS` personal default, per-engine `--model` / `--thinking`, and Claude `--fallback-model`
+- uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, plus `claude=claude-fable-5` with `max` effort; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- supports isolated `--codex-profile` / `AUTOREVIEW_CODEX_PROFILE` routing for sanitized built-in Amazon Bedrock profiles, automatically drops Codex CLI schema enforcement for those non-OpenAI runs, and disables model-controlled process tools so provider credentials remain outside the model-visible tool boundary
+- supports `--claude-auth subscription` / `AUTOREVIEW_CLAUDE_AUTH=subscription` to prefer Claude Code login over ambient API/provider env; Fable refusal handling is a transparent Fable retry followed by an explicit `claude-opus-4-8`/`max` fallback after the second refusal
 - gives Codex the bundle in an empty workspace with web search available; Claude receives the bundle plus WebSearch by default and optional domain-constrained WebFetch, and Pi receives the bundle with no tools
 - runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP and auto-memory disabled, no filesystem/shell tools, an empty external workspace, and `--fallback-model` when set
 - refuses Droid, Copilot, Cursor, and OpenCode reviews until their CLIs expose the required project, filesystem, and network isolation

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -269,6 +269,13 @@ POWERSHELL_ENV_REFERENCE_PATTERN = re.compile(
 )
 MAX_BUNDLE_TEXT_BYTES = 180_000
 MAX_REVIEW_PROMPT_BYTES = 512_000
+MAX_REVIEW_CHUNK_CONTEXT_BYTES = 64_000
+MAX_REVIEW_PASSES = 8
+
+
+class ReviewChunk(NamedTuple):
+    content: str
+    context: str = ""
 SECRET_PLACEHOLDER_VALUES = {
     "changeme",
     "dummy",
@@ -646,6 +653,7 @@ DEFAULT_MODEL_BY_ENGINE = {
 DEFAULT_CODEX_ACCESS_FALLBACK_MODEL = "gpt-5.6-terra"
 DEFAULT_THINKING_BY_ENGINE = {
     "codex": "high",
+    "claude": "max",
 }
 THINKING_LEVELS_BY_ENGINE = {
     "codex": {"none", "minimal", "low", "medium", "high", "xhigh", "max"},
@@ -656,8 +664,51 @@ THINKING_LEVELS_BY_ENGINE = {
     "opencode": {"minimal", "low", "medium", "high", "max"},
     "cursor": set(),
 }
+CODEX_PROFILE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+SAFE_CODEX_PROFILE_SCALAR_KEYS = {
+    "model",
+    "model_provider",
+    "model_reasoning_effort",
+    "service_tier",
+}
+CODEX_BEDROCK_ENV_KEYS = {
+    "AWS_ACCESS_KEY_ID",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+}
+CLAUDE_SUBSCRIPTION_ENV_EXCLUDES = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_AWS_API_KEY",
+    "ANTHROPIC_AWS_BASE_URL",
+    "ANTHROPIC_AWS_WORKSPACE_ID",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_BEDROCK_BASE_URL",
+    "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+    "ANTHROPIC_FOUNDRY_BASE_URL",
+    "ANTHROPIC_FOUNDRY_RESOURCE",
+    "ANTHROPIC_VERTEX_BASE_URL",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+    "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "CLAUDE_CODE_USE_MANTLE",
+    "CLAUDE_CODE_USE_VERTEX",
+}
 CLAUDE_SAFE_MODE_MIN_VERSION = (2, 1, 169)
 CLAUDE_FABLE_MIN_VERSION = (2, 1, 170)
+CLAUDE_ISOLATION_PROBE_CONTROL_FLAG = "--autoreview-invalid-control"
+CLAUDE_EMPTY_PRINT_DIAGNOSTIC = (
+    "Input must be provided either through stdin or as a prompt argument when using --print"
+)
 # Pi's reviewed-repo trust override first appears in the current
 # @earendil-works/pi-coding-agent 0.79.0 CLI line. Older legacy binaries can
 # ignore unknown flags, so the Pi engine must fail closed below this floor.
@@ -5142,7 +5193,7 @@ def validate_review_patch(
     label: str,
     paths: list[str],
     patch: str,
-    limit: int = MAX_BUNDLE_TEXT_BYTES,
+    limit: int | None = None,
 ) -> str:
     blocked = [
         f"{display_escape(rel, 500)} ({risk})"
@@ -5157,7 +5208,7 @@ def validate_review_patch(
             f"{details}{more}"
         )
     patch_bytes = len(patch.encode("utf-8"))
-    if patch_bytes > limit:
+    if limit is not None and patch_bytes > limit:
         raise SystemExit(
             f"{label} is too large to review safely "
             f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
@@ -5372,12 +5423,20 @@ def local_bundle(repo: Path) -> tuple[str, bool]:
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--stat"),
         unstaged_patch,
     ]
-    input_truncated = len(staged_patch) > 180_000 or len(unstaged_patch) > 180_000
+    input_truncated = False
     if untracked:
         parts.append("# Untracked Files")
         for rel, content, truncated in untracked_snapshots:
             input_truncated = input_truncated or truncated
-            parts.append(f"## {rel}\n{content}")
+            records = literal_lf_lines(content) or [""]
+            parts.append(
+                "# Untracked File\n"
+                f"path: {json.dumps(rel)}\n"
+                + "\n".join(
+                    f"source-line {line_number}: {json.dumps(record)}"
+                    for line_number, record in enumerate(records, start=1)
+                )
+            )
     return "\n\n".join(parts), input_truncated
 
 
@@ -5591,7 +5650,7 @@ def branch_bundle(repo: Path, base_ref: str) -> tuple[str, bool]:
             ),
             branch_patch,
         ]
-    ), len(branch_patch) > 180_000
+    ), False
 
 
 def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
@@ -5663,7 +5722,7 @@ def commit_bundle(repo: Path, commit_ref: str) -> tuple[str, bool]:
             ),
             commit_patch,
         ]
-    ), len(commit_patch) > 180_000
+    ), False
 
 
 def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
@@ -5772,14 +5831,381 @@ def review_scope_policy() -> str:
     ).strip()
 
 
-def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+def utf8_size(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def split_utf8_fragment(
+    text: str,
+    limit: int,
+    first_limit: int | None = None,
+) -> list[str]:
+    current_limit = first_limit or limit
+    if min(limit, current_limit) < 4:
+        raise SystemExit("review chunk byte limit is too small")
+    fragments: list[str] = []
+    current: list[str] = []
+    current_bytes = 0
+    for character in text:
+        character_bytes = utf8_size(character)
+        if current and current_bytes + character_bytes > current_limit:
+            fragments.append("".join(current))
+            current = []
+            current_bytes = 0
+            current_limit = limit
+        current.append(character)
+        current_bytes += character_bytes
+    if current:
+        fragments.append("".join(current))
+    return fragments
+
+
+def review_bundle_units(bundle: str) -> list[str]:
+    section_boundaries = {
+        "# Git Status\n",
+        "# Staged Diff\n",
+        "# Unstaged Diff\n",
+        "# Untracked Files\n",
+        "# Untracked File\n",
+        "# Branch Diff\n",
+        "# Commit Diff\n",
+    }
+    units: list[str] = []
+    current: list[str] = []
+    for line in literal_lf_lines(bundle):
+        boundary = line.startswith("diff --git ") or line in section_boundaries
+        if boundary and current:
+            units.append("".join(current))
+            current = []
+        current.append(line)
+    if current:
+        units.append("".join(current))
+    return units
+
+
+def literal_lf_lines(text: str) -> list[str]:
+    parts = text.split("\n")
+    lines = [part + "\n" for part in parts[:-1]]
+    if parts[-1]:
+        lines.append(parts[-1])
+    return lines
+
+
+def update_review_chunk_context(
+    context: list[str],
+    line: str,
+    next_new_line: int | None,
+    next_old_line: int | None,
+    in_hunk: bool,
+) -> tuple[int | None, int | None, bool]:
+    if line.startswith("diff --git "):
+        context[:] = [line]
+        return None, None, False
+    if line == "# Untracked File\n":
+        context[:] = [line]
+        return None, None, False
+    if context == ["# Untracked File\n"] and line.startswith("path: "):
+        context.append(line)
+        return None, None, False
+    if not context:
+        return next_new_line, next_old_line, in_hunk
+    if context[0] == "# Untracked File\n":
+        match = re.match(r"^source-line (\d+): ", line)
+        if match:
+            return int(match.group(1)) + 1, None, False
+        return next_new_line, None, False
+    if not in_hunk and line.startswith(("--- ", "+++ ")):
+        header_prefix = line[:4]
+        context[:] = [entry for entry in context if not entry.startswith(header_prefix)]
+        context.append(line)
+        return next_new_line, next_old_line, False
+    if line.startswith("@@ "):
+        context[:] = [entry for entry in context if not entry.startswith("@@ ")]
+        context.append(line)
+        match = re.match(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
+        if not match:
+            return None, None, True
+        return int(match.group(2)), int(match.group(1)), True
+    if in_hunk and line.startswith(" "):
+        return increment_line(next_new_line), increment_line(next_old_line), True
+    if in_hunk and line.startswith("+"):
+        return increment_line(next_new_line), next_old_line, True
+    if in_hunk and line.startswith("-"):
+        return next_new_line, increment_line(next_old_line), True
+    return next_new_line, next_old_line, in_hunk
+
+
+def increment_line(line: int | None) -> int | None:
+    return line + 1 if line is not None else None
+
+
+def compact_review_chunk_context(context: list[str]) -> list[str]:
+    if not context or context[0] == "# Untracked File\n":
+        return list(context)
+    new_header = next((entry for entry in context if entry.startswith("+++ ")), None)
+    old_header = next((entry for entry in context if entry.startswith("--- ")), None)
+    hunk_header = next((entry for entry in context if entry.startswith("@@ ")), None)
+    path_header = new_header if new_header and new_header != "+++ /dev/null\n" else old_header
+    compact = [path_header or context[0]]
+    if hunk_header:
+        compact.append(hunk_header)
+    return compact
+
+
+def review_chunk_context(
+    context: list[str],
+    next_new_line: int | None,
+    next_old_line: int | None,
+    *,
+    continued_line: bool = False,
+    diff_line_marker: str | None = None,
+) -> str:
+    lines = compact_review_chunk_context(context)
+    if context and context[0] == "# Untracked File\n" and next_new_line is not None:
+        lines.append(f"[Continuation begins at untracked source line {next_new_line}.]\n")
+    elif (
+        next_new_line is not None
+        and next_new_line >= 1
+        and next_old_line is not None
+        and next_old_line >= 1
+        and next_new_line != next_old_line
+    ):
+        lines.append(
+            f"[Continuation position: new-file line {next_new_line}; "
+            f"old-file line {next_old_line}.]\n"
+        )
+    elif next_new_line is not None and next_new_line >= 1:
+        lines.append(f"[Continuation begins at new-file line {next_new_line}.]\n")
+    elif next_old_line is not None and next_old_line >= 1:
+        lines.append(
+            f"[Continuation begins at old-file line {next_old_line}; "
+            "use this positive line for deleted content.]\n"
+        )
+    if continued_line:
+        if diff_line_marker:
+            lines.append(
+                "[The change content below continues a unified-diff line whose "
+                f"original marker is `{diff_line_marker}`.]\n"
+            )
+        else:
+            lines.append("[The change content below continues the preceding long line.]\n")
+    text = "".join(lines)
+    if utf8_size(text) > MAX_REVIEW_CHUNK_CONTEXT_BYTES:
+        raise SystemExit(
+            "review continuation context exceeds the bounded prompt allowance; "
+            "shorten the changed path or split the review target"
+        )
+    return text
+
+
+def split_oversized_review_unit(
+    unit: str,
+    limit: int,
+    first_limit: int | None = None,
+) -> list[ReviewChunk]:
+    chunks: list[ReviewChunk] = []
+    current: list[str] = []
+    current_bytes = 0
+    current_context = ""
+    context: list[str] = []
+    next_new_line: int | None = None
+    next_old_line: int | None = None
+    in_hunk = False
+
+    def current_limit() -> int:
+        return first_limit if not chunks and first_limit is not None else limit
+
+    def flush() -> None:
+        nonlocal current, current_bytes, current_context
+        if current:
+            chunks.append(ReviewChunk("".join(current), current_context))
+            current = []
+            current_bytes = 0
+            current_context = ""
+
+    for line in literal_lf_lines(unit):
+        line_bytes = utf8_size(line)
+        diff_line_marker = line[0] if in_hunk and line.startswith(("+", "-", " ")) else None
+        untracked_source_line = None
+        if context and context[0] == "# Untracked File\n":
+            match = re.match(r"^source-line (\d+): ", line)
+            if match:
+                untracked_source_line = int(match.group(1))
+        chunk_limit = current_limit()
+        if current and current_bytes + line_bytes > chunk_limit:
+            if line_bytes <= limit:
+                flush()
+                chunk_limit = current_limit()
+            else:
+                remaining_line_bytes = chunk_limit - current_bytes
+                if remaining_line_bytes < 4:
+                    flush()
+                    chunk_limit = current_limit()
+                else:
+                    fragments = split_utf8_fragment(
+                        line,
+                        limit,
+                        first_limit=remaining_line_bytes,
+                    )
+                    current.append(fragments[0])
+                    flush()
+                    continued_context = review_chunk_context(
+                        context,
+                        untracked_source_line or next_new_line,
+                        next_old_line,
+                        continued_line=True,
+                        diff_line_marker=diff_line_marker,
+                    )
+                    chunks.extend(
+                        ReviewChunk(fragment, continued_context)
+                        for fragment in fragments[1:-1]
+                    )
+                    if len(fragments) > 1:
+                        current = [fragments[-1]]
+                        current_bytes = utf8_size(fragments[-1])
+                        current_context = continued_context
+                    next_new_line, next_old_line, in_hunk = update_review_chunk_context(
+                        context,
+                        line,
+                        next_new_line,
+                        next_old_line,
+                        in_hunk,
+                    )
+                    continue
+        if line_bytes > chunk_limit:
+            flush()
+            fragments = split_utf8_fragment(
+                line,
+                limit,
+                first_limit=chunk_limit,
+            )
+            for index, fragment in enumerate(fragments[:-1]):
+                chunks.append(
+                    ReviewChunk(
+                        fragment,
+                        review_chunk_context(
+                            context,
+                            untracked_source_line or next_new_line,
+                            next_old_line,
+                            continued_line=index > 0,
+                            diff_line_marker=diff_line_marker,
+                        ),
+                    )
+                )
+            current = [fragments[-1]]
+            current_bytes = utf8_size(fragments[-1])
+            current_context = review_chunk_context(
+                context,
+                untracked_source_line or next_new_line,
+                next_old_line,
+                continued_line=len(fragments) > 1,
+                diff_line_marker=diff_line_marker,
+            )
+            next_new_line, next_old_line, in_hunk = update_review_chunk_context(
+                context,
+                line,
+                next_new_line,
+                next_old_line,
+                in_hunk,
+            )
+            continue
+        if not current:
+            current_context = review_chunk_context(context, next_new_line, next_old_line)
+        current.append(line)
+        current_bytes += line_bytes
+        next_new_line, next_old_line, in_hunk = update_review_chunk_context(
+            context,
+            line,
+            next_new_line,
+            next_old_line,
+            in_hunk,
+        )
+    flush()
+    return chunks
+
+
+def split_review_bundle(bundle: str, limit: int) -> list[ReviewChunk]:
+    if utf8_size(bundle) <= limit:
+        return [ReviewChunk(bundle)]
+    chunks: list[ReviewChunk] = []
+    pending: ReviewChunk | None = None
+
+    def flush_pending() -> None:
+        nonlocal pending
+        if pending is not None:
+            chunks.append(pending)
+            pending = None
+
+    for unit in review_bundle_units(bundle):
+        unit_bytes = utf8_size(unit)
+        pending_bytes = utf8_size(pending.content) if pending else 0
+        remaining = limit - pending_bytes
+        if pending and unit_bytes <= remaining:
+            pending = ReviewChunk(pending.content + unit, pending.context)
+            continue
+        if pending and remaining >= 256:
+            first_line = literal_lf_lines(unit)[0]
+            if utf8_size(first_line) > remaining and utf8_size(first_line) <= limit:
+                flush_pending()
+                pieces = split_oversized_review_unit(unit, limit)
+                chunks.extend(pieces[:-1])
+                pending = pieces[-1]
+                continue
+            pieces = split_oversized_review_unit(
+                unit,
+                limit,
+                first_limit=remaining,
+            )
+            first, *rest = pieces
+            pending = ReviewChunk(pending.content + first.content, pending.context)
+            flush_pending()
+            if rest:
+                chunks.extend(rest[:-1])
+                pending = rest[-1]
+            continue
+        flush_pending()
+        if unit_bytes <= limit:
+            pending = ReviewChunk(unit)
+            continue
+        pieces = split_oversized_review_unit(unit, limit)
+        chunks.extend(pieces[:-1])
+        pending = pieces[-1]
+    flush_pending()
+    if "".join(chunk.content for chunk in chunks) != bundle:
+        raise SystemExit("internal error: review bundle chunking omitted or reordered input")
+    return chunks
+
+
+def render_review_prompt(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    chunk: ReviewChunk,
+    extra_prompt: str,
+    datasets: str,
+    chunk_position: tuple[int, int] | None = None,
+) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
     branch = current_branch(repo)
     require_no_secret_values("current branch", branch)
     if target_ref:
         require_no_secret_values("review target ref", target_ref)
     scope_policy = review_scope_policy()
-    prompt = textwrap.dedent(
+    chunk_policy = ""
+    if chunk_position:
+        index, total = chunk_position
+        chunk_policy = textwrap.dedent(
+            f"""
+            Oversized review bundle chunk: {index}/{total}
+            - The complete validated change is distributed across all {total} chunks.
+            - Original change bytes appear exactly once across the chunk sequence.
+            - Continuation context may repeat file and hunk headers; it is not extra change content.
+            - Report every actionable defect demonstrated by this chunk. Reports from all chunks are merged after every pass finishes.
+            """
+        ).strip()
+        if chunk.context:
+            chunk_policy += "\n\n# Continuation Context\n" + chunk.context
+    instructions = textwrap.dedent(
         f"""
         You are a senior code reviewer. Review the provided git change bundle only.
 
@@ -5790,7 +6216,9 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
         - Do not modify files.
         - Do not invoke nested reviewers or review tools.
         - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
-        - You may use read-only tools and web search to inspect files, dependency contracts, upstream docs, current behavior, and security implications.
+        - The review sandbox is intentionally empty. The change bundle and explicit prompt or datasets are the only reviewed-repository source. Read-only tools cannot access unchanged repository files.
+        - You may use read-only tools and web search to inspect external dependency contracts, upstream docs, current public behavior, and security implications.
+        - Do not report a missing import, symbol, definition, call site, config entry, or other unchanged context solely because it is absent from the change bundle. Such a finding requires direct proof in the bundle or explicit datasets.
         - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
         - Report only actionable defects introduced or exposed by this change.
         - Prefer high-signal findings over style feedback.
@@ -5803,18 +6231,31 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
 
         Review target: {target_line}
         Current branch: {branch}
-        Repository root: .
+        Review sandbox: . (intentionally contains no reviewed repository files)
 
         {scope_policy}
+
+        {chunk_policy}
 
         {extra_prompt}
 
         {datasets}
 
         # Change Bundle
-        {bundle}
         """
     ).strip()
+    return instructions + "\n" + chunk.content
+
+
+def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+    prompt = render_review_prompt(
+        repo,
+        target,
+        target_ref,
+        ReviewChunk(bundle),
+        extra_prompt,
+        datasets,
+    )
     prompt_bytes = len(prompt.encode("utf-8"))
     if prompt_bytes > MAX_REVIEW_PROMPT_BYTES:
         raise SystemExit(
@@ -5822,6 +6263,81 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
             "reduce the change, prompt files, or datasets"
         )
     return prompt
+
+
+def build_review_prompts(
+    repo: Path,
+    target: str,
+    target_ref: str | None,
+    bundle: str,
+    extra_prompt: str,
+    datasets: str,
+) -> list[str]:
+    full_prompt = render_review_prompt(
+        repo,
+        target,
+        target_ref,
+        ReviewChunk(bundle),
+        extra_prompt,
+        datasets,
+    )
+    if utf8_size(full_prompt) <= MAX_REVIEW_PROMPT_BYTES:
+        return [full_prompt]
+
+    empty_chunk_prompt = render_review_prompt(
+        repo,
+        target,
+        target_ref,
+        ReviewChunk(""),
+        extra_prompt,
+        datasets,
+        (999_999, 999_999),
+    )
+    content_limit = (
+        MAX_REVIEW_PROMPT_BYTES
+        - utf8_size(empty_chunk_prompt)
+        - MAX_REVIEW_CHUNK_CONTEXT_BYTES
+        - 4_096
+    )
+    if content_limit < 16_000:
+        raise SystemExit(
+            "review prompt files and datasets leave too little room for change chunks; "
+            "reduce the extra review context"
+        )
+    if utf8_size(bundle) > content_limit * MAX_REVIEW_PASSES:
+        raise SystemExit(
+            f"review bundle requires more than {MAX_REVIEW_PASSES} bounded passes; "
+            "reduce or split the change before review"
+        )
+
+    for _attempt in range(4):
+        chunks = split_review_bundle(bundle, content_limit)
+        if len(chunks) > MAX_REVIEW_PASSES:
+            raise SystemExit(
+                f"review bundle requires {len(chunks)} bounded passes; "
+                f"limit {MAX_REVIEW_PASSES}; reduce or split the change before review"
+            )
+        prompts = [
+            render_review_prompt(
+                repo,
+                target,
+                target_ref,
+                chunk,
+                extra_prompt,
+                datasets,
+                (index, len(chunks)),
+            )
+            for index, chunk in enumerate(chunks, start=1)
+        ]
+        largest = max(utf8_size(prompt) for prompt in prompts)
+        if largest <= MAX_REVIEW_PROMPT_BYTES:
+            return prompts
+        content_limit -= largest - MAX_REVIEW_PROMPT_BYTES + 1_024
+        if content_limit < 16_000:
+            break
+    raise SystemExit(
+        "unable to partition the review bundle within the aggregate prompt limit"
+    )
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -5958,6 +6474,134 @@ def codex_source_home(repo: Path) -> Path | None:
     )
 
 
+def codex_profile_name(args: argparse.Namespace) -> str | None:
+    raw = (getattr(args, "codex_profile", None) or "").strip()
+    if not raw:
+        return None
+    if not CODEX_PROFILE_NAME_PATTERN.fullmatch(raw):
+        raise SystemExit(
+            f"invalid Codex profile: {raw!r}; use letters, numbers, hyphens, or underscores"
+        )
+    return raw
+
+
+def codex_engine_env(
+    args: argparse.Namespace,
+    repo: Path,
+    extra_paths: list[Path] | None = None,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    env = safe_engine_env(
+        repo,
+        extra_paths,
+        extra,
+        engine="codex",
+    )
+    if codex_profile_name(args) is not None:
+        for key in CODEX_BEDROCK_ENV_KEYS:
+            value = os.environ.get(key)
+            if value is not None:
+                env[key] = value
+    return env
+
+
+def prepare_codex_runtime_profile(
+    args: argparse.Namespace,
+    repo: Path,
+    runtime_codex_home: Path,
+) -> bool:
+    """Stage a capability-free Bedrock profile into the isolated Codex home."""
+    profile = codex_profile_name(args)
+    if profile is None:
+        return False
+    source_home = codex_source_home(repo)
+    if source_home is None:
+        raise SystemExit(f"Codex profile {profile!r} requires an external CODEX_HOME")
+    source_path = source_home / f"{profile}.config.toml"
+    try:
+        resolved_source = source_path.resolve(strict=True)
+    except OSError as exc:
+        raise SystemExit(f"Codex profile not found: {source_path}") from exc
+    if not resolved_source.is_file() or not external_env_path(
+        repo,
+        str(resolved_source),
+    ):
+        raise SystemExit(
+            "Codex profile must be a file outside the reviewed repository: "
+            f"{source_path}"
+        )
+    config = load_codex_auth_config(resolved_source)
+    provider = config.get("model_provider")
+    if provider != "amazon-bedrock":
+        raise SystemExit(
+            f"Codex profile {profile!r} uses unsupported model_provider={provider!r}; "
+            "autoreview profiles currently support amazon-bedrock only"
+        )
+
+    safe_scalars: dict[str, str] = {}
+    for key in SAFE_CODEX_PROFILE_SCALAR_KEYS:
+        value = config.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            raise SystemExit(f"Codex profile {profile!r} has invalid {key}")
+        safe_scalars[key] = value.strip()
+    if "model" not in safe_scalars:
+        raise SystemExit(f"Codex profile {profile!r} must select a model")
+    effort = safe_scalars.get("model_reasoning_effort")
+    if effort is not None and effort not in THINKING_LEVELS_BY_ENGINE["codex"]:
+        raise SystemExit(
+            f"Codex profile {profile!r} has invalid "
+            f"model_reasoning_effort={effort!r}"
+        )
+    service_tier = safe_scalars.get("service_tier")
+    if service_tier is not None and service_tier not in {"fast", "flex", "default"}:
+        raise SystemExit(f"Codex profile {profile!r} has invalid service_tier={service_tier!r}")
+
+    aws: dict[str, str] = {}
+    providers = config.get("model_providers")
+    if isinstance(providers, dict):
+        bedrock = providers.get("amazon-bedrock")
+        if isinstance(bedrock, dict) and isinstance(bedrock.get("aws"), dict):
+            profile_value = bedrock["aws"].get("profile")
+            if profile_value is not None:
+                raise SystemExit(
+                    f"Codex profile {profile!r} uses unsupported file-backed "
+                    "amazon-bedrock.aws.profile authentication; use "
+                    "AWS_BEARER_TOKEN_BEDROCK or static AWS credential environment variables"
+                )
+            for key in ("region",):
+                value = bedrock["aws"].get(key)
+                if value is None:
+                    continue
+                if not isinstance(value, str) or not value.strip():
+                    raise SystemExit(
+                        f"Codex profile {profile!r} has invalid "
+                        f"amazon-bedrock.aws.{key}"
+                    )
+                aws[key] = value.strip()
+
+    lines = [
+        f"{key} = {json.dumps(safe_scalars[key])}"
+        for key in ("model", "model_provider", "model_reasoning_effort", "service_tier")
+        if key in safe_scalars
+    ]
+    if aws:
+        lines.extend(["", "[model_providers.amazon-bedrock.aws]"])
+        lines.extend(
+            f"{key} = {json.dumps(aws[key])}"
+            for key in ("region",)
+            if key in aws
+        )
+    runtime_codex_home.mkdir(parents=True, exist_ok=True)
+    # Codex >= 0.134 loads --profile NAME from NAME.config.toml. The legacy
+    # [profiles.NAME] table in config.toml is no longer read.
+    runtime_profile = runtime_codex_home / f"{profile}.config.toml"
+    runtime_profile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    runtime_profile.chmod(0o600)
+    return True
+
+
 def codex_auth_config_flags(repo: Path, *, force_file: bool = False) -> list[str]:
     codex_home = codex_source_home(repo)
     if codex_home is None:
@@ -6034,15 +6678,50 @@ def prepare_codex_runtime_auth(
     return True
 
 
-def codex_exec_isolation_flags() -> list[str]:
-    return ["--ignore-user-config", "--ignore-rules", "--skip-git-repo-check"]
+def codex_exec_isolation_flags(*, load_runtime_profile: bool = False) -> list[str]:
+    flags = ["--ignore-rules", "--skip-git-repo-check"]
+    # Codex applies --ignore-user-config to both config.toml and a selected
+    # NAME.config.toml profile. Profile runs already use a fresh CODEX_HOME
+    # containing only the sanitized profile staged by autoreview, so keep that
+    # layer enabled while continuing to ignore rules and repository config.
+    if not load_runtime_profile:
+        flags.insert(0, "--ignore-user-config")
+    return flags
 
 
-def claude_review_isolation_flags() -> list[str]:
+def codex_profile_tool_isolation_flags(profile: str | None) -> list[str]:
+    if profile is None:
+        return []
+    # Bedrock credentials must remain available to Codex's provider client but
+    # inaccessible to model-controlled process tools. Disable every execution
+    # path that could inspect the reviewer process environment; the validated
+    # review bundle and server-side web search remain available to the model.
+    return [
+        "-c",
+        "features.shell_tool=false",
+        "-c",
+        "features.code_mode=false",
+        "-c",
+        "features.code_mode_only=false",
+        "-c",
+        "features.multi_agent=false",
+        "-c",
+        "features.enable_fanout=false",
+    ]
+
+
+def claude_review_isolation_flags(
+    args: argparse.Namespace | None = None,
+) -> list[str]:
+    setting_sources = (
+        ""
+        if args is not None and claude_auth_mode(args) == "subscription"
+        else "user"
+    )
     return [
         "--safe-mode",
         "--setting-sources",
-        "user",
+        setting_sources,
         "--strict-mcp-config",
         "--disallowedTools",
         "mcp__*",
@@ -6068,12 +6747,38 @@ def parse_cli_version(text: str) -> tuple[int, int, int] | None:
     return tuple(int(part) for part in match.groups())
 
 
+def claude_auth_mode(args: argparse.Namespace) -> str:
+    mode = (getattr(args, "claude_auth", None) or "default").strip().lower()
+    if mode not in {"default", "subscription"}:
+        raise SystemExit(
+            f"invalid Claude auth mode: {mode!r} (valid: default, subscription)"
+        )
+    return mode
+
+
+def claude_engine_env(
+    args: argparse.Namespace,
+    repo: Path,
+    extra_paths: list[Path] | None = None,
+) -> dict[str, str]:
+    env = safe_engine_env(
+        repo,
+        extra_paths,
+        engine="claude",
+        extra={"CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK": "1"},
+    )
+    if claude_auth_mode(args) == "subscription":
+        for key in CLAUDE_SUBSCRIPTION_ENV_EXCLUDES:
+            env.pop(key, None)
+    return env
+
+
 def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> None:
     claude_bin = resolve_command(args.claude_bin, repo)
-    engine_env = safe_engine_env(
+    engine_env = claude_engine_env(
+        args,
         repo,
         [Path(claude_bin).parent],
-        engine="claude",
     )
     temp_root = safe_temp_root(repo)
     result = run([claude_bin, "--version"], temp_root, check=False, env=engine_env)
@@ -6091,13 +6796,53 @@ def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> N
             f"claude engine requires Claude Code >= {format_version(minimum_version)} "
             f"{version_reason} (found {format_version(version)})"
         )
-    help_result = run([claude_bin, "--help"], temp_root, check=False, env=engine_env)
-    help_text = f"{help_result.stdout}\n{help_result.stderr}"
-    required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools", "--tools"]
-    missing = [flag for flag in required_flags if flag not in help_text]
-    if help_result.returncode != 0 or missing:
-        detail = ", ".join(missing) if missing else "--help failed"
-        raise SystemExit(f"claude engine requires Claude Code isolation flags missing from --help: {detail}")
+    probe_command = [
+        claude_bin,
+        *claude_review_isolation_flags(args),
+        "--tools",
+        "",
+    ]
+    control_probe = run(
+        [
+            claude_bin,
+            CLAUDE_ISOLATION_PROBE_CONTROL_FLAG,
+            *probe_command[1:],
+            "--print",
+        ],
+        temp_root,
+        input_text="",
+        check=False,
+        env=engine_env,
+    )
+    control_detail = f"{control_probe.stderr}\n{control_probe.stdout}".strip()
+    if (
+        control_probe.returncode == 0
+        or CLAUDE_ISOLATION_PROBE_CONTROL_FLAG not in control_detail
+        or "unknown option" not in control_detail.lower()
+        or CLAUDE_EMPTY_PRINT_DIAGNOSTIC in control_detail
+    ):
+        suffix = f": {control_detail}" if control_detail else ""
+        raise SystemExit(
+            "claude engine could not verify that the capability probe rejects unknown flags"
+            f"{suffix}"
+        )
+    isolation_probe = run(
+        [*probe_command, "--print"],
+        temp_root,
+        input_text="",
+        check=False,
+        env=engine_env,
+    )
+    isolation_detail = f"{isolation_probe.stderr}\n{isolation_probe.stdout}".strip()
+    if (
+        isolation_probe.returncode == 0
+        or CLAUDE_EMPTY_PRINT_DIAGNOSTIC not in isolation_detail
+    ):
+        suffix = f": {isolation_detail}" if isolation_detail else ""
+        raise SystemExit(
+            "claude engine requires Claude Code isolation flags rejected by capability probe"
+            f"{suffix}"
+        )
 
 
 def ensure_pi_isolation_supported(args: argparse.Namespace, repo: Path) -> str:
@@ -6190,6 +6935,24 @@ def codex_speed_override(args: argparse.Namespace) -> str | None:
     return f'service_tier="{speed}"'
 
 
+def codex_uses_non_openai_provider(args: argparse.Namespace) -> bool:
+    """Return whether Codex is routed through a known non-OpenAI provider."""
+    return codex_profile_name(args) is not None
+
+
+def codex_no_output_schema_requested(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "codex_no_output_schema", False)) or env_truthy(
+        "AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA"
+    )
+
+
+def codex_use_output_schema(args: argparse.Namespace) -> bool:
+    """Return whether to enforce Codex structured output at the CLI layer."""
+    if codex_no_output_schema_requested(args):
+        return False
+    return not codex_uses_non_openai_provider(args)
+
+
 def codex_error_messages(result: subprocess.CompletedProcess[str]) -> list[str]:
     messages: list[str] = []
     for stream, accept_plain_text in (
@@ -6271,17 +7034,30 @@ def codex_command(
         cmd.extend(["-c", speed_override])
     cmd.extend(codex_config_isolation_flags(review_root, runtime_root))
     cmd.extend(codex_auth_config_flags(source_repo, force_file=force_file_auth))
+    profile = codex_profile_name(args)
+    if profile is not None:
+        cmd.extend(codex_profile_tool_isolation_flags(profile))
+        cmd.extend(["--profile", profile])
     cmd.append("exec")
     if args.stream_engine_output:
         cmd.append("--json")
+    use_output_schema = codex_use_output_schema(args)
     cmd.extend(
         [
-            *codex_exec_isolation_flags(),
+            *codex_exec_isolation_flags(load_runtime_profile=profile is not None),
             "--ephemeral",
             "-C",
             str(review_root),
-            "--output-schema",
-            str(schema_path),
+        ]
+    )
+    # OpenAI-compatible relays (Amazon Bedrock's Responses shim) hang when a strict
+    # JSON schema runs alongside a tool-using turn (openai/codex#15451). The prompt
+    # already embeds the schema and demands one JSON object, so we drop the flag for
+    # those providers and parse the fenced/plain JSON from the last message instead.
+    if use_output_schema:
+        cmd.extend(["--output-schema", str(schema_path)])
+    cmd.extend(
+        [
             "--output-last-message",
             str(output_path),
             "-",
@@ -6336,10 +7112,11 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             ):
                 path.mkdir(parents=True, exist_ok=True)
             file_auth_linked = prepare_codex_runtime_auth(repo, runtime_codex_home)
+            profile_staged = prepare_codex_runtime_profile(args, repo, runtime_codex_home)
             source_codex_home = codex_source_home(repo)
             active_codex_home = (
                 runtime_codex_home
-                if file_auth_linked or source_codex_home is None
+                if file_auth_linked or profile_staged or source_codex_home is None
                 else source_codex_home
             )
             for index, model in enumerate(models):
@@ -6361,10 +7138,10 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     label="codex",
                     stream_output=args.stream_engine_output,
                     stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
-                    env=safe_engine_env(
+                    env=codex_engine_env(
+                        args,
                         repo,
                         [Path(cmd[0]).parent],
-                        engine="codex",
                         extra={
                             "HOME": str(runtime_home),
                             "USERPROFILE": str(runtime_home),
@@ -6409,11 +7186,39 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
     raise AssertionError("unreachable")
 
 
-def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
-    ensure_claude_isolation_supported(args, repo)
+def claude_refusal_detected(output: str) -> bool:
+    try:
+        parsed = json.loads(output)
+        events = parsed if isinstance(parsed, list) else [parsed]
+    except json.JSONDecodeError:
+        events = []
+        for line in output.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            events.extend(event if isinstance(event, list) else [event])
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("subtype") in {
+            "model_refusal_fallback",
+            "model_refusal_no_fallback",
+        }:
+            return True
+        if event.get("terminal_reason") == "model_refusal":
+            return True
+    return False
+
+
+def run_claude_once(
+    args: argparse.Namespace,
+    repo: Path,
+    prompt: str,
+) -> subprocess.CompletedProcess[str]:
     cmd = [
         resolve_command(args.claude_bin, repo),
-        *claude_review_isolation_flags(),
+        *claude_review_isolation_flags(args),
         "--print",
         "--no-session-persistence",
         "--output-format",
@@ -6445,16 +7250,70 @@ def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
             label="claude",
             stream_output=args.stream_engine_output,
             stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
-            env=safe_engine_env(
+            env=claude_engine_env(
+                args,
                 repo,
                 [Path(cmd[0]).parent],
-                engine="claude",
             ),
             resolve_root=repo,
         )
-    if result.returncode != 0:
-        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
-    return result.stdout
+    return result
+
+
+def claude_uses_fable_model(model: str | None) -> bool:
+    return model == "fable" or bool(model and model.startswith("claude-fable-5"))
+
+
+def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    ensure_claude_isolation_supported(args, repo)
+    args.actual_model = None
+    args.actual_thinking = None
+    for attempt in (1, 2):
+        result = run_claude_once(args, repo, prompt)
+        output = f"{result.stdout}\n{result.stderr}"
+        if claude_refusal_detected(output):
+            if not claude_uses_fable_model(args.model):
+                raise SystemExit(
+                    f"claude engine refused the requested model {args.model!r}"
+                )
+            if attempt == 1:
+                print(
+                    f"claude model {args.model} refused the review; "
+                    "retrying Fable once in a fresh session",
+                    file=sys.stderr,
+                )
+                continue
+            break
+        if result.returncode != 0:
+            raise SystemExit(
+                f"claude engine failed ({result.returncode})\n"
+                f"{result.stderr or result.stdout}"
+            )
+        return result.stdout
+
+    fallback_args = copy.copy(args)
+    fallback_args.model = "claude-opus-4-8"
+    fallback_args.thinking = "max"
+    fallback_args.fallback_model = None
+    print(
+        f"claude model {args.model} refused the review twice; "
+        "retrying with allowed fallback claude-opus-4-8 at max effort",
+        file=sys.stderr,
+    )
+    fallback_result = run_claude_once(fallback_args, repo, prompt)
+    fallback_output = f"{fallback_result.stdout}\n{fallback_result.stderr}"
+    if claude_refusal_detected(fallback_output):
+        raise SystemExit(
+            "claude engine fallback claude-opus-4-8 also refused the review"
+        )
+    if fallback_result.returncode != 0:
+        raise SystemExit(
+            f"claude engine fallback failed ({fallback_result.returncode})\n"
+            f"{fallback_result.stderr or fallback_result.stdout}"
+        )
+    args.actual_model = fallback_args.model
+    args.actual_thinking = fallback_args.thinking
+    return fallback_result.stdout
 
 
 def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
@@ -7199,11 +8058,21 @@ if "--version" in args or "-v" in args:
 if "--help" in args or "-h" in args:
     print("--safe-mode\n--setting-sources\n--strict-mcp-config\n--disallowedTools\n--tools\n--print\n--json-schema")
     raise SystemExit(0)
+if "--autoreview-invalid-control" in args:
+    print("error: unknown option '--autoreview-invalid-control'", file=sys.stderr)
+    raise SystemExit(1)
+stdin = sys.stdin.read()
+if "--print" in args and not stdin:
+    print(
+        "Error: Input must be provided either through stdin or as a prompt argument when using --print",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 record = os.environ["AUTOREVIEW_FAKE_RECORD"]
 Path(record).write_text(json.dumps({
     "argv": args,
     "cwd": os.getcwd(),
-    "stdin": sys.stdin.read(),
+    "stdin": stdin,
     "auto_memory_disabled": os.environ.get("CLAUDE_CODE_DISABLE_AUTO_MEMORY"),
 }))
 report = {
@@ -8132,17 +9001,35 @@ def env_truthy(name: str) -> bool:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Bundle-driven AI code review.")
+    reviewer_selection_explicit = any(
+        argument in {"--engine", "--panel", "--reviewers"}
+        or any(
+            argument.startswith(f"{option}=")
+            for option in ("--engine", "--reviewers")
+        )
+        for argument in sys.argv[1:]
+    )
+    claude_auth_explicit = any(
+        argument == "--claude-auth" or argument.startswith("--claude-auth=")
+        for argument in sys.argv[1:]
+    )
+    parser = argparse.ArgumentParser(
+        description="Bundle-driven AI code review.",
+        allow_abbrev=False,
+    )
     parser.add_argument("--mode", choices=["auto", "local", "uncommitted", "branch", "commit"], default="auto")
     parser.add_argument("--base")
     parser.add_argument("--commit", default="HEAD")
     parser.add_argument("--engine", choices=ENGINE_CHOICES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
-    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,pi or codex:gpt-5.6-sol:high.")
+    parser.add_argument(
+        "--reviewers",
+        help="Comma-separated review panel, e.g. codex,claude,pi or codex:gpt-5.6-sol:high. Env default: AUTOREVIEW_REVIEWERS.",
+    )
     parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
     parser.add_argument(
         "--model",
         action="append",
-        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.6-sol with an access-only gpt-5.6-terra retry, claude=claude-fable-5.",
+        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.6-sol/high with an access-only gpt-5.6-terra retry, claude=claude-fable-5/max.",
     )
     parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh, max. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high. Pi: off, minimal, low, medium, high, xhigh. OpenCode: minimal, low, medium, high, max. Cursor: none.")
     parser.add_argument(
@@ -8162,7 +9049,23 @@ def parse_args() -> argparse.Namespace:
         choices=["fast", "flex", "default"],
         help="Codex service tier: fast (priority processing), flex, or default. Env default: AUTOREVIEW_CODEX_SPEED. Silently standard when the model catalog does not list the tier.",
     )
+    parser.add_argument(
+        "--codex-profile",
+        default=os.environ.get("AUTOREVIEW_CODEX_PROFILE", "").strip() or None,
+        help="Codex profile to stage into the isolated reviewer runtime. Currently supports amazon-bedrock profiles. Env default: AUTOREVIEW_CODEX_PROFILE.",
+    )
+    parser.add_argument(
+        "--codex-no-output-schema",
+        action="store_true",
+        help="Do not pass --output-schema to codex exec; rely on the prompt-embedded schema and parse JSON from the final message. Auto-enabled for non-OpenAI providers (e.g. model_provider=amazon-bedrock), which hang when a strict schema runs with tool calls (openai/codex#15451). Env default: AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA.",
+    )
     parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    parser.add_argument(
+        "--claude-auth",
+        choices=["default", "subscription"],
+        default=os.environ.get("AUTOREVIEW_CLAUDE_AUTH", "default"),
+        help="Claude authentication source: default preserves provider env; subscription ignores API/provider routing env and uses Claude Code login. Env default: AUTOREVIEW_CLAUDE_AUTH.",
+    )
     parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
     parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
     parser.add_argument(
@@ -8229,6 +9132,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--self-test-heartbeat-metrics", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
+    args.reviewer_selection_explicit = reviewer_selection_explicit
+    args.claude_auth_explicit = claude_auth_explicit
     args.engine = normalize_engine(args.engine)
     if args.cursor_allow_workspace_instructions is None:
         args.cursor_allow_workspace_instructions = env_truthy("AUTOREVIEW_CURSOR_ALLOW_WORKSPACE_INSTRUCTIONS")
@@ -8316,6 +9221,18 @@ def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
     return engine, model, thinking
 
 
+def parse_reviewer_list(
+    value: str,
+    source: str,
+) -> list[tuple[str, str | None, str | None]]:
+    tokens = [token.strip() for token in value.split(",") if token.strip()]
+    if not tokens:
+        raise SystemExit(f"{source} must select at least one reviewer")
+    if len(tokens) == 1 and tokens[0] == "all":
+        tokens = list(ALL_REVIEWERS)
+    return [parse_reviewer_token(token) for token in tokens]
+
+
 def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     global_model, model_by_engine = parse_keyed_options(args.model, "model")
     global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
@@ -8324,21 +9241,24 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
     env_global_thinking, env_thinking_by_engine = env_defaults_for("thinking")
     env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback-model")
     reviewers: list[tuple[str, str | None, str | None]] = []
-    if args.reviewers:
-        tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
-        if len(tokens) == 1 and tokens[0] == "all":
-            tokens = list(ALL_REVIEWERS)
-        reviewers = [parse_reviewer_token(token) for token in tokens]
+    if args.reviewers is not None:
+        reviewers = parse_reviewer_list(args.reviewers, "--reviewers")
     elif args.panel:
         engines = [args.engine]
         for engine in ("codex", "claude"):
             if engine not in engines:
                 engines.append(engine)
         reviewers = [(engine, None, None) for engine in engines]
+    elif not getattr(args, "reviewer_selection_explicit", False) and (
+        env_reviewers := os.environ.get("AUTOREVIEW_REVIEWERS", "").strip()
+    ):
+        reviewers = parse_reviewer_list(env_reviewers, "AUTOREVIEW_REVIEWERS")
     else:
         reviewers = [(args.engine, None, None)]
 
     selected_engines = {engine for engine, _, _ in reviewers}
+    codex_profile = codex_profile_name(args)
+    claude_auth = claude_auth_mode(args)
     fallback_engines = set(fallback_by_engine) | set(env_fallback_by_engine)
     unused_fallback_engines = fallback_engines - selected_engines
     if unused_fallback_engines:
@@ -8354,6 +9274,19 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
         raise SystemExit("--codex-config is only supported for codex; no codex reviewer selected")
     if getattr(args, "codex_speed", None) and "codex" not in selected_engines:
         raise SystemExit("--codex-speed is only supported for codex; no codex reviewer selected")
+    if codex_profile is not None and "codex" not in selected_engines:
+        raise SystemExit("--codex-profile is only supported for codex; no codex reviewer selected")
+    if codex_no_output_schema_requested(args) and "codex" not in selected_engines:
+        raise SystemExit(
+            "--codex-no-output-schema is only supported for codex; "
+            "no codex reviewer selected"
+        )
+    if (
+        claude_auth != "default"
+        and "claude" not in selected_engines
+        and getattr(args, "claude_auth_explicit", False)
+    ):
+        raise SystemExit("--claude-auth is only supported for claude; no claude reviewer selected")
 
     seen: set[str] = set()
     result: list[argparse.Namespace] = []
@@ -8367,7 +9300,11 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or global_model
             or env_model_by_engine.get(engine)
             or env_global_model
-            or DEFAULT_MODEL_BY_ENGINE.get(engine)
+            or (
+                None
+                if engine == "codex" and codex_profile is not None
+                else DEFAULT_MODEL_BY_ENGINE.get(engine)
+            )
         )
         thinking = (
             inline_thinking
@@ -8375,7 +9312,11 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
             or global_thinking
             or env_thinking_by_engine.get(engine)
             or env_global_thinking
-            or DEFAULT_THINKING_BY_ENGINE.get(engine)
+            or (
+                None
+                if engine == "codex" and codex_profile is not None
+                else DEFAULT_THINKING_BY_ENGINE.get(engine)
+            )
         )
         if engine == "claude":
             fallback_model = (
@@ -8384,7 +9325,7 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
                 or env_fallback_by_engine.get(engine)
                 or env_global_fallback
             )
-        elif engine == "codex" and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
+        elif engine == "codex" and codex_profile is None and model == DEFAULT_MODEL_BY_ENGINE["codex"]:
             fallback_model = DEFAULT_CODEX_ACCESS_FALLBACK_MODEL
         else:
             fallback_model = None
@@ -8403,12 +9344,20 @@ def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
 
 def reviewer_label(args: argparse.Namespace) -> str:
     parts = [args.engine]
-    if args.model:
-        parts.append(f"model={args.model}")
-    if getattr(args, "fallback_model", None):
+    profile = codex_profile_name(args) if args.engine == "codex" else None
+    if profile is not None:
+        parts.append(f"profile={profile}")
+    actual_model = getattr(args, "actual_model", None)
+    model = actual_model or args.model
+    if model:
+        parts.append(f"model={model}")
+    if actual_model:
+        parts.append(f"refusal-fallback-from={args.model}")
+    if not actual_model and getattr(args, "fallback_model", None):
         parts.append(f"fallback={args.fallback_model}")
-    if args.thinking:
-        parts.append(f"thinking={args.thinking}")
+    thinking = getattr(args, "actual_thinking", None) or args.thinking
+    if thinking:
+        parts.append(f"thinking={thinking}")
     return " ".join(parts)
 
 
@@ -8468,6 +9417,19 @@ def merge_panel_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, 
     }
 
 
+def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    report = merge_panel_reports(reports)
+    summary = ", ".join(
+        f"{label}: {len(chunk_report['findings'])} finding(s)"
+        for label, chunk_report in reports
+    )
+    report["overall_explanation"] = bounded_field(
+        f"Chunked review complete. {summary}.",
+        3000,
+    )
+    return report
+
+
 def run_panel(
     args: argparse.Namespace,
     reviewers: list[argparse.Namespace],
@@ -8475,16 +9437,18 @@ def run_panel(
     prompt: str,
     changed_paths: set[str],
     input_truncated: bool,
+    required: list[str] | None = None,
 ) -> dict[str, Any]:
     reports: list[tuple[str, dict[str, Any]]] = []
     failures: list[str] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(reviewers)) as executor:
-        future_by_label = {
-            executor.submit(run_reviewer, reviewer, repo, prompt, changed_paths, [], input_truncated): reviewer_label(reviewer)
+        reviewer_by_future = {
+            executor.submit(run_reviewer, reviewer, repo, prompt, changed_paths, [], input_truncated): reviewer
             for reviewer in reviewers
         }
-        for future in concurrent.futures.as_completed(future_by_label):
-            label = future_by_label[future]
+        for future in concurrent.futures.as_completed(reviewer_by_future):
+            reviewer = reviewer_by_future[future]
+            label = reviewer_label(reviewer)
             try:
                 reports.append((label, future.result()))
             except SystemExit as exc:
@@ -8508,13 +9472,19 @@ def run_panel(
         raise SystemExit("autoreview panel produced no reports")
     reports.sort(key=lambda item: item[0])
     report = merge_panel_reports(reports)
-    validate_report(report, repo, changed_paths, args.require_finding)
+    validate_report(
+        report,
+        repo,
+        changed_paths,
+        args.require_finding if required is None else required,
+    )
     return report
 
 
 def reviewer_test_args(**overrides: Any) -> argparse.Namespace:
     defaults = {
         "reviewers": None,
+        "reviewer_selection_explicit": False,
         "panel": False,
         "engine": "codex",
         "model": None,
@@ -8522,6 +9492,10 @@ def reviewer_test_args(**overrides: Any) -> argparse.Namespace:
         "fallback_model": None,
         "codex_config": None,
         "codex_speed": None,
+        "codex_profile": None,
+        "codex_no_output_schema": False,
+        "claude_auth": "default",
+        "claude_auth_explicit": False,
         "tools": True,
     }
     defaults.update(overrides)
@@ -8554,6 +9528,10 @@ def self_test_config_defaults() -> None:
         "AUTOREVIEW_FALLBACK_MODEL",
         "AUTOREVIEW_CODEX_CONFIG",
         "AUTOREVIEW_CODEX_SPEED",
+        "AUTOREVIEW_CODEX_PROFILE",
+        "AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA",
+        "AUTOREVIEW_CLAUDE_AUTH",
+        "AUTOREVIEW_REVIEWERS",
         *(
             f"AUTOREVIEW_{engine.upper()}_{suffix}"
             for engine in ENGINES
@@ -8583,6 +9561,75 @@ def self_test_config_defaults() -> None:
         default_claude = reviewer_args(reviewer_test_args(engine="claude"))[0]
         if default_claude.model != "claude-fable-5":
             raise SystemExit(f"self-test config defaults failed: default claude model={default_claude.model!r}")
+        if default_claude.thinking != "max":
+            raise SystemExit(f"self-test config defaults failed: default claude thinking={default_claude.thinking!r}")
+        os.environ["AUTOREVIEW_REVIEWERS"] = "codex,claude"
+        env_panel = reviewer_args(reviewer_test_args(engine="pi"))
+        if [reviewer.engine for reviewer in env_panel] != ["codex", "claude"]:
+            raise SystemExit("self-test config defaults failed: AUTOREVIEW_REVIEWERS was not applied")
+        os.environ["AUTOREVIEW_REVIEWERS"] = "all"
+        env_all = reviewer_args(reviewer_test_args())
+        if [reviewer.engine for reviewer in env_all] != list(ALL_REVIEWERS):
+            raise SystemExit("self-test config defaults failed: AUTOREVIEW_REVIEWERS=all was not expanded")
+        os.environ["AUTOREVIEW_REVIEWERS"] = ","
+        try:
+            reviewer_args(reviewer_test_args())
+            raise SystemExit("self-test config defaults failed: empty env reviewer panel accepted")
+        except SystemExit as error:
+            if "must select at least one reviewer" not in str(error):
+                raise
+        os.environ["AUTOREVIEW_REVIEWERS"] = "codex,claude"
+        explicit_engine = reviewer_args(
+            reviewer_test_args(
+                engine="claude",
+                reviewer_selection_explicit=True,
+            )
+        )
+        if [reviewer.engine for reviewer in explicit_engine] != ["claude"]:
+            raise SystemExit("self-test config defaults failed: explicit --engine did not override env reviewers")
+        os.environ["AUTOREVIEW_REVIEWERS"] = "pi"
+        explicit_panel = reviewer_args(reviewer_test_args(panel=True))
+        if [reviewer.engine for reviewer in explicit_panel] != ["codex", "claude"]:
+            raise SystemExit("self-test config defaults failed: explicit --panel did not override env reviewers")
+        os.environ.pop("AUTOREVIEW_REVIEWERS")
+        subscription_claude = reviewer_args(
+            reviewer_test_args(engine="claude", claude_auth="subscription")
+        )[0]
+        if subscription_claude.claude_auth != "subscription":
+            raise SystemExit("self-test config defaults failed: Claude subscription auth was not preserved")
+        try:
+            reviewer_args(
+                reviewer_test_args(
+                    engine="codex",
+                    claude_auth="subscription",
+                    claude_auth_explicit=True,
+                )
+            )
+            raise SystemExit("self-test config defaults failed: --claude-auth accepted without Claude reviewer")
+        except SystemExit as error:
+            if "only supported for claude" not in str(error):
+                raise
+        env_subscription_without_claude = reviewer_args(
+            reviewer_test_args(engine="codex", claude_auth="subscription")
+        )
+        if [reviewer.engine for reviewer in env_subscription_without_claude] != ["codex"]:
+            raise SystemExit(
+                "self-test config defaults failed: Claude auth env default "
+                "affected non-Claude reviewer selection"
+            )
+        bedrock = reviewer_args(reviewer_test_args(engine="codex", codex_profile="bedrock"))[0]
+        if bedrock.model is not None or bedrock.thinking is not None or bedrock.fallback_model is not None:
+            raise SystemExit("self-test config defaults failed: Codex profile should own model defaults")
+        bedrock_override = reviewer_args(
+            reviewer_test_args(
+                engine="codex",
+                codex_profile="bedrock",
+                model=["explicit-model"],
+                thinking=["xhigh"],
+            )
+        )[0]
+        if bedrock_override.model != "explicit-model" or bedrock_override.thinking != "xhigh":
+            raise SystemExit("self-test config defaults failed: CLI should override Codex profile defaults")
         os.environ["AUTOREVIEW_MODEL"] = "env-global-model"
         os.environ["AUTOREVIEW_CODEX_MODEL"] = "env-codex-model"
         os.environ["AUTOREVIEW_THINKING"] = "low"
@@ -8669,6 +9716,36 @@ def self_test_config_defaults() -> None:
         except SystemExit as error:
             if "only supported for codex" not in str(error):
                 raise
+    # codex --output-schema opt-out: on by default; explicit flag / env / a
+    # non-OpenAI profile (e.g. amazon-bedrock, which deadlocks on
+    # schema+tools per openai/codex#15451) all disable it.
+    with preserve_env(
+        ["AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA", "AUTOREVIEW_REVIEWERS"]
+    ):
+        if not codex_use_output_schema(reviewer_test_args(engine="codex")):
+            raise SystemExit("self-test config defaults failed: output-schema should default ON for codex")
+        if codex_use_output_schema(reviewer_test_args(engine="codex", codex_no_output_schema=True)):
+            raise SystemExit("self-test config defaults failed: --codex-no-output-schema should disable output-schema")
+        bedrock = reviewer_test_args(engine="codex", codex_profile="bedrock")
+        if codex_use_output_schema(bedrock):
+            raise SystemExit("self-test config defaults failed: non-OpenAI provider should auto-disable output-schema")
+        try:
+            reviewer_args(
+                reviewer_test_args(
+                    engine="claude",
+                    codex_no_output_schema=True,
+                )
+            )
+            raise SystemExit(
+                "self-test config defaults failed: --codex-no-output-schema "
+                "accepted without Codex reviewer"
+            )
+        except SystemExit as error:
+            if "only supported for codex" not in str(error):
+                raise
+        os.environ["AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA"] = "1"
+        if codex_use_output_schema(reviewer_test_args(engine="codex")):
+            raise SystemExit("self-test config defaults failed: AUTOREVIEW_CODEX_NO_OUTPUT_SCHEMA=1 should disable output-schema")
     print("self-test config defaults: ok")
 
 
@@ -8679,6 +9756,7 @@ def self_test_fallback_scope() -> None:
         "AUTOREVIEW_CODEX_MODEL",
         "AUTOREVIEW_CLAUDE_FALLBACK_MODEL",
         "AUTOREVIEW_CODEX_FALLBACK_MODEL",
+        "AUTOREVIEW_REVIEWERS",
     ]
     with preserve_env(keys):
         for key in keys:
@@ -8894,7 +9972,7 @@ def main() -> int:
     extra_prompt, prompt_truncated = load_extra_prompt(args, repo)
     datasets, datasets_truncated = load_datasets(args, repo)
     input_truncated = bundle_truncated or prompt_truncated or datasets_truncated
-    prompt = build_prompt(
+    prompts = build_review_prompts(
         repo,
         target,
         target_ref,
@@ -8903,7 +9981,7 @@ def main() -> int:
         datasets,
     )
     changed_paths = review_paths(repo, target, target_ref, args.commit)
-    print(f"bundle: {len(prompt)} chars")
+    print(f"bundle: {utf8_size(bundle)} bytes; review passes: {len(prompts)}")
     if source_tree_snapshot(repo) != review_source_snapshot:
         raise SystemExit(
             "source changed while the review bundle was being created; "
@@ -8914,19 +9992,42 @@ def main() -> int:
     if args.parallel_tests:
         tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
     try:
-        if len(reviewers) == 1:
-            report = run_reviewer(
-                reviewers[0],
-                repo,
-                prompt,
-                changed_paths,
-                args.require_finding,
-                input_truncated,
-            )
-            label = "autoreview"
+        chunk_reports: list[tuple[str, dict[str, Any]]] = []
+        for index, prompt in enumerate(prompts, start=1):
+            if len(prompts) > 1:
+                print(
+                    f"review pass: {index}/{len(prompts)} "
+                    f"({utf8_size(prompt)} prompt bytes)"
+                )
+            required = args.require_finding if len(prompts) == 1 else []
+            if len(reviewers) == 1:
+                chunk_report = run_reviewer(
+                    reviewers[0],
+                    repo,
+                    prompt,
+                    changed_paths,
+                    required,
+                    input_truncated,
+                )
+            else:
+                chunk_report = run_panel(
+                    args,
+                    reviewers,
+                    repo,
+                    prompt,
+                    changed_paths,
+                    input_truncated,
+                    required,
+                )
+            chunk_reports.append((f"chunk {index}/{len(prompts)}", chunk_report))
+        if len(chunk_reports) == 1:
+            report = chunk_reports[0][1]
         else:
-            report = run_panel(args, reviewers, repo, prompt, changed_paths, input_truncated)
-            label = "autoreview panel"
+            report = merge_chunk_reports(chunk_reports)
+            validate_report(report, repo, changed_paths, args.require_finding)
+        label = "autoreview panel" if len(reviewers) > 1 else "autoreview"
+        if len(chunk_reports) > 1:
+            label += " chunked"
     finally:
         tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
 

--- a/.agents/skills/autoreview/scripts/autoreview_test.py
+++ b/.agents/skills/autoreview/scripts/autoreview_test.py
@@ -157,6 +157,32 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             ("cursor", "auto", None),
         )
 
+    def test_claude_auth_env_does_not_block_explicit_non_claude_engine(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"AUTOREVIEW_CLAUDE_AUTH": "subscription"},
+            clear=False,
+        ):
+            with mock.patch.object(sys, "argv", ["autoreview", "--engine", "cursor"]):
+                reviewers = AUTOREVIEW.reviewer_args(AUTOREVIEW.parse_args())
+        self.assertEqual([reviewer.engine for reviewer in reviewers], ["cursor"])
+
+    def test_explicit_claude_auth_rejects_non_claude_engine(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "autoreview",
+                "--engine",
+                "cursor",
+                "--claude-auth",
+                "subscription",
+            ],
+        ):
+            args = AUTOREVIEW.parse_args()
+        with self.assertRaisesRegex(SystemExit, "only supported for claude"):
+            AUTOREVIEW.reviewer_args(args)
+
     def test_cursor_agent_keyed_option_normalizes_to_cursor(self) -> None:
         self.assertEqual(
             AUTOREVIEW.parse_keyed_options(["cursor-agent=auto"], "model"),

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -91,7 +91,11 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             bundle, truncated = self.helper["local_bundle"](repo)
 
-            self.assertIn("## image.bin\n[binary file omitted]", bundle)
+            self.assertIn(
+                '# Untracked File\npath: "image.bin"\n'
+                'source-line 1: "[binary file omitted]"',
+                bundle,
+            )
             self.assertTrue(truncated)
 
     def test_local_bundle_rejects_non_utf8_untracked_text(self) -> None:
@@ -122,7 +126,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ):
                 bundle, truncated = self.helper["local_bundle"](repo)
 
-            self.assertIn("## notes.txt\nreview me", bundle)
+            expected_record = json.dumps("review me" + os.linesep)
+            self.assertIn(
+                '# Untracked File\npath: "notes.txt"\n'
+                f"source-line 1: {expected_record}",
+                bundle,
+            )
             self.assertFalse(truncated)
             self.assertEqual(reads, 1)
 
@@ -214,6 +223,202 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.helper["codex_config_overrides"](args),
             args.codex_config,
         )
+
+    def test_codex_command_selects_profile_and_drops_strict_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            runtime = root / "runtime"
+            with mock.patch.dict(
+                self.helper["codex_command"].__globals__,
+                {"resolve_command": lambda *_args: "/usr/bin/codex"},
+            ):
+                command = self.helper["codex_command"](
+                    argparse.Namespace(
+                        codex_bin="codex",
+                        web_search=False,
+                        codex_config=None,
+                        thinking=None,
+                        codex_speed=None,
+                        codex_profile="bedrock",
+                        codex_no_output_schema=False,
+                        stream_engine_output=False,
+                    ),
+                    repo,
+                    root / "review",
+                    runtime,
+                    root / "schema.json",
+                    root / "output.json",
+                    None,
+                )
+
+        profile_index = command.index("--profile")
+        self.assertEqual(command[profile_index + 1], "bedrock")
+        self.assertLess(profile_index, command.index("exec"))
+        self.assertNotIn("--ignore-user-config", command)
+        self.assertIn("--ignore-rules", command)
+        for override in (
+            "features.shell_tool=false",
+            "features.code_mode=false",
+            "features.code_mode_only=false",
+            "features.multi_agent=false",
+            "features.enable_fanout=false",
+        ):
+            self.assertIn(override, command)
+        self.assertNotIn("--output-schema", command)
+
+    def test_codex_command_ignores_user_config_without_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            with mock.patch.dict(
+                self.helper["codex_command"].__globals__,
+                {"resolve_command": lambda *_args: "/usr/bin/codex"},
+            ):
+                command = self.helper["codex_command"](
+                    argparse.Namespace(
+                        codex_bin="codex",
+                        web_search=False,
+                        codex_config=None,
+                        thinking=None,
+                        codex_speed=None,
+                        codex_profile=None,
+                        codex_no_output_schema=False,
+                        stream_engine_output=False,
+                    ),
+                    repo,
+                    root / "review",
+                    root / "runtime",
+                    root / "schema.json",
+                    root / "output.json",
+                    "gpt-5.6-sol",
+                )
+
+        self.assertIn("--ignore-user-config", command)
+        self.assertNotIn("features.shell_tool=false", command)
+
+    def test_codex_bedrock_credentials_require_a_profile(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["AWS_BEARER_TOKEN_BEDROCK"] = "test-token"
+                os.environ["AWS_PROFILE"] = "review-profile"
+                standard = self.helper["codex_engine_env"](
+                    argparse.Namespace(codex_profile=None),
+                    repo,
+                )
+                bedrock = self.helper["codex_engine_env"](
+                    argparse.Namespace(codex_profile="bedrock"),
+                    repo,
+                )
+
+                self.assertNotIn("AWS_BEARER_TOKEN_BEDROCK", standard)
+                self.assertNotIn("AWS_PROFILE", standard)
+                self.assertEqual(
+                    bedrock["AWS_BEARER_TOKEN_BEDROCK"],
+                    "test-token",
+                )
+                self.assertNotIn("AWS_PROFILE", bedrock)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_explicit_reviewer_selection_overrides_environment_panel(self) -> None:
+        args = self.helper["reviewer_test_args"](
+            engine="claude",
+            reviewer_selection_explicit=True,
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"AUTOREVIEW_REVIEWERS": "pi"},
+            clear=False,
+        ):
+            reviewers = self.helper["reviewer_args"](args)
+
+        self.assertEqual([reviewer.engine for reviewer in reviewers], ["claude"])
+
+    def test_environment_reviewer_list_rejects_empty_and_expands_all(self) -> None:
+        args = self.helper["reviewer_test_args"]()
+        with mock.patch.dict(
+            os.environ,
+            {"AUTOREVIEW_REVIEWERS": ","},
+            clear=False,
+        ), self.assertRaisesRegex(SystemExit, "must select at least one reviewer"):
+            self.helper["reviewer_args"](args)
+
+        with mock.patch.dict(
+            os.environ,
+            {"AUTOREVIEW_REVIEWERS": "all"},
+            clear=False,
+        ):
+            reviewers = self.helper["reviewer_args"](args)
+
+        self.assertEqual(
+            [reviewer.engine for reviewer in reviewers],
+            list(self.helper["ALL_REVIEWERS"]),
+        )
+
+    def test_reviewer_selection_flags_reject_prefix_abbreviations(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--engi", "claude"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("unrecognized arguments: --engi claude", result.stderr)
+
+    def test_run_codex_profile_uses_none_model_as_one_valid_attempt(self) -> None:
+        observed_models: list[str | None] = []
+
+        def fake_command(
+            _args: argparse.Namespace,
+            _source_repo: Path,
+            _review_root: Path,
+            _runtime_root: Path,
+            _schema_path: Path,
+            _output_path: Path,
+            model: str | None,
+            *,
+            force_file_auth: bool = False,
+        ) -> list[str]:
+            self.assertFalse(force_file_auth)
+            observed_models.append(model)
+            return ["/usr/bin/codex"]
+
+        result = subprocess.CompletedProcess(
+            args=["/usr/bin/codex"],
+            returncode=0,
+            stdout="profile-output",
+            stderr="",
+        )
+        args = argparse.Namespace(
+            tools=True,
+            model=None,
+            fallback_model=None,
+            stream_engine_output=False,
+            codex_profile="bedrock",
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["run_codex"].__globals__,
+                {
+                    "prepare_codex_runtime_auth": lambda *_args: False,
+                    "prepare_codex_runtime_profile": lambda *_args: True,
+                    "codex_source_home": lambda *_args: None,
+                    "codex_command": fake_command,
+                    "codex_engine_env": lambda *_args, **_kwargs: {},
+                    "run_with_heartbeat": lambda *_args, **_kwargs: result,
+                },
+            ):
+                output = self.helper["run_codex"](args, repo, "review")
+
+        self.assertEqual(output, "profile-output")
+        self.assertEqual(observed_models, [None])
 
     def test_untracked_files_respect_trusted_global_excludes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -364,6 +569,338 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_review_patch_limit_counts_utf8_bytes(self) -> None:
         with self.assertRaisesRegex(SystemExit, r"12 bytes; limit 10"):
             self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "界" * 4, 10)
+
+    def test_review_patch_accepts_large_content_without_explicit_limit(self) -> None:
+        patch = (
+            "diff --git a/safe.txt b/safe.txt\n"
+            "--- a/safe.txt\n"
+            "+++ b/safe.txt\n"
+            "@@ -0,0 +1,100000 @@\n"
+            + "+safe review content\n" * 100_000
+        )
+
+        self.assertEqual(
+            self.helper["validate_review_patch"](
+                "local staged diff",
+                ["safe.txt"],
+                patch,
+            ),
+            patch,
+        )
+
+    def test_review_bundle_chunking_preserves_every_byte_and_diff_context(self) -> None:
+        bundle = (
+            "# Commit Diff\n\n"
+            "diff --git a/safe.txt b/safe.txt\n"
+            "--- a/safe.txt\n"
+            "+++ b/safe.txt\n"
+            "@@ -0,0 +1,200 @@\n"
+            + "+safe review content\n" * 200
+        )
+
+        chunks = self.helper["split_review_bundle"](bundle, 300)
+
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual("".join(chunk.content for chunk in chunks), bundle)
+        self.assertTrue(all(len(chunk.content.encode("utf-8")) <= 300 for chunk in chunks))
+        self.assertTrue(
+            any(
+                "+++ b/safe.txt" in chunk.context
+                and "@@ -0,0 +1,200 @@" in chunk.context
+                and "Continuation begins at new-file line" in chunk.context
+                for chunk in chunks[1:]
+            )
+        )
+
+    def test_untracked_markdown_headings_do_not_create_bundle_boundaries(self) -> None:
+        bundle = (
+            "# Untracked Files\n\n"
+            "# Untracked File\n"
+            'path: "notes.md"\n'
+            'source-line 1: "# title\\n"\n'
+            'source-line 2: "## section\\n"\n\n'
+            "# Untracked File\n"
+            'path: "todo.md"\n'
+            'source-line 1: "# next\\n"'
+        )
+
+        units = self.helper["review_bundle_units"](bundle)
+
+        self.assertEqual(len(units), 3)
+        self.assertIn(r'source-line 2: "## section\n"', units[1])
+        self.assertEqual("".join(units), bundle)
+
+    def test_unicode_line_separators_do_not_create_bundle_boundaries(self) -> None:
+        bundle = (
+            "# Untracked Files\n\n"
+            "# Untracked File\n"
+            'path: "notes.txt"\n'
+            'source-line 1: "before\u2028diff --git a/fake b/fake"\n\n'
+            "diff --git a/real.txt b/real.txt\n"
+            "--- a/real.txt\n"
+            "+++ b/real.txt\n"
+        )
+
+        units = self.helper["review_bundle_units"](bundle)
+
+        self.assertEqual(len(units), 3)
+        self.assertIn("\u2028diff --git a/fake b/fake", units[1])
+        self.assertEqual("".join(units), bundle)
+
+    def test_diff_source_prefixes_do_not_replace_file_context(self) -> None:
+        context: list[str] = []
+        next_new_line = None
+        next_old_line = None
+        in_hunk = False
+        lines = (
+            "diff --git a/safe.txt b/safe.txt\n",
+            "--- a/safe.txt\n",
+            "+++ b/safe.txt\n",
+            "@@ -10,2 +10,3 @@\n",
+            "+++ added source beginning with pluses\n",
+            "--- deleted source beginning with minuses\n",
+            " context\n",
+        )
+
+        for line in lines:
+            next_new_line, next_old_line, in_hunk = self.helper[
+                "update_review_chunk_context"
+            ](
+                context,
+                line,
+                next_new_line,
+                next_old_line,
+                in_hunk,
+            )
+
+        self.assertEqual(next_new_line, 12)
+        self.assertEqual(next_old_line, 12)
+        self.assertIn("--- a/safe.txt\n", context)
+        self.assertIn("+++ b/safe.txt\n", context)
+        self.assertNotIn("--- deleted source beginning with minuses\n", context)
+
+    def test_hunk_header_that_fits_fresh_chunk_is_not_split(self) -> None:
+        unit = (
+            "diff --git a/abcdefghijk b/abcdefghijk\n"
+            "--- a/abcdefghijk\n"
+            "+++ b/abcdefghijk\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, 85)
+
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(any("@@ -1 +1 @@\n" in chunk.content for chunk in chunks))
+        self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+
+    def test_long_diff_line_continuations_keep_their_original_marker(self) -> None:
+        for marker in ("+", "-", " "):
+            with self.subTest(marker=marker):
+                unit = (
+                    "diff --git a/large.txt b/large.txt\n"
+                    "--- a/large.txt\n"
+                    "+++ b/large.txt\n"
+                    "@@ -1 +1 @@\n"
+                    f"{marker}{'x' * 400}\n"
+                )
+
+                chunks = self.helper["split_oversized_review_unit"](unit, 140)
+
+                self.assertTrue(
+                    any(
+                        f"original marker is `{marker}`" in chunk.context
+                        for chunk in chunks[1:]
+                    )
+                )
+                self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+
+    def test_modified_file_deletion_context_keeps_old_and_new_offsets(self) -> None:
+        context: list[str] = []
+        next_new_line = None
+        next_old_line = None
+        in_hunk = False
+        for line in (
+            "diff --git a/safe.txt b/safe.txt\n",
+            "--- a/safe.txt\n",
+            "+++ b/safe.txt\n",
+            "@@ -10,3 +10,2 @@\n",
+            "-first deleted line\n",
+        ):
+            next_new_line, next_old_line, in_hunk = self.helper[
+                "update_review_chunk_context"
+            ](
+                context,
+                line,
+                next_new_line,
+                next_old_line,
+                in_hunk,
+            )
+
+        rendered = self.helper["review_chunk_context"](
+            context,
+            next_new_line,
+            next_old_line,
+        )
+
+        self.assertIn("new-file line 10", rendered)
+        self.assertIn("old-file line 11", rendered)
+
+    def test_multiple_long_line_tails_pack_into_following_chunks(self) -> None:
+        limit = 200
+        unit = (
+            "diff --git a/large.txt b/large.txt\n"
+            "--- a/large.txt\n"
+            "+++ b/large.txt\n"
+            "@@ -1,5 +1,5 @@\n"
+            + ("+" + "x" * 205 + "\n") * 5
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, limit)
+        minimum_chunks = (len(unit.encode("utf-8")) + limit - 1) // limit
+
+        self.assertLessEqual(len(chunks), minimum_chunks + 1)
+        self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+        self.assertTrue(all(len(chunk.content.encode("utf-8")) <= limit for chunk in chunks))
+
+    def test_untracked_continuation_context_keeps_source_line(self) -> None:
+        unit = (
+            "# Untracked File\n"
+            'path: "notes.txt"\n'
+            'source-line 1: "short\\n"\n'
+            f'source-line 2: "{"x" * 300}"\n'
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, 120)
+
+        self.assertGreater(len(chunks), 2)
+        self.assertTrue(
+            any(
+                "Continuation begins at untracked source line 2" in chunk.context
+                for chunk in chunks[1:]
+            )
+        )
+        self.assertEqual("".join(chunk.content for chunk in chunks), unit)
+
+    def test_deleted_file_continuation_uses_positive_old_line(self) -> None:
+        unit = (
+            "diff --git a/removed.txt b/removed.txt\n"
+            "--- a/removed.txt\n"
+            "+++ /dev/null\n"
+            "@@ -40,50 +0,0 @@\n"
+            + "-deleted content\n" * 50
+        )
+
+        chunks = self.helper["split_oversized_review_unit"](unit, 180)
+
+        deletion_contexts = [
+            chunk.context for chunk in chunks[1:] if "old-file line" in chunk.context
+        ]
+        self.assertTrue(deletion_contexts)
+        self.assertTrue(all("line 0" not in context for context in deletion_contexts))
+        self.assertTrue(all("--- a/removed.txt" in context for context in deletion_contexts))
+
+    def test_long_complete_context_is_retained_or_rejected(self) -> None:
+        path = "nested/" + "x" * 10_000 + ".txt"
+        context = [
+            f'diff --git "a/{path}" "b/{path}"\n',
+            f'--- "a/{path}"\n',
+            f'+++ "b/{path}"\n',
+            "@@ -1 +1 @@\n",
+        ]
+
+        rendered = self.helper["review_chunk_context"](context, 2, 2)
+
+        self.assertIn(f'+++ "b/{path}"', rendered)
+        self.assertIn("@@ -1 +1 @@", rendered)
+        self.assertIn("Continuation begins at new-file line 2", rendered)
+
+    def test_review_bundle_packs_oversized_unit_tails_globally(self) -> None:
+        limit = 1_000
+        units = []
+        for index in range(5):
+            header = (
+                f"diff --git a/file-{index}.txt b/file-{index}.txt\n"
+                f"--- a/file-{index}.txt\n"
+                f"+++ b/file-{index}.txt\n"
+                "@@ -0,0 +1 @@\n"
+            )
+            body = "+" + "x" * (1_100 - len(header.encode("utf-8")) - 2) + "\n"
+            units.append(header + body)
+        bundle = "".join(units)
+
+        chunks = self.helper["split_review_bundle"](bundle, limit)
+
+        self.assertEqual(len(chunks), 6)
+        self.assertEqual("".join(chunk.content for chunk in chunks), bundle)
+        self.assertTrue(all(len(chunk.content.encode("utf-8")) <= limit for chunk in chunks))
+
+    def test_large_bundle_stays_single_pass_until_prompt_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            prompts = self.helper["build_review_prompts"](
+                repo,
+                "commit",
+                "HEAD",
+                "# Commit Diff\n" + "safe review content\n" * 18_000,
+                "",
+                "",
+            )
+
+        self.assertEqual(len(prompts), 1)
+
+    def test_bundle_above_prompt_limit_uses_complete_bounded_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            prompts = self.helper["build_review_prompts"](
+                repo,
+                "commit",
+                "HEAD",
+                "# Commit Diff\n" + "safe review content\n" * 35_000,
+                "",
+                "",
+            )
+
+        self.assertGreater(len(prompts), 1)
+        self.assertTrue(
+            all(
+                len(prompt.encode("utf-8"))
+                <= self.helper["MAX_REVIEW_PROMPT_BYTES"]
+                for prompt in prompts
+            )
+        )
+        self.assertTrue(all("Oversized review bundle chunk:" in prompt for prompt in prompts))
+
+    def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            bundle = "# Commit Diff\n+Markdown hard break  \n+\n"
+            prompt = self.helper["render_review_prompt"](
+                repo,
+                "commit",
+                "HEAD",
+                self.helper["ReviewChunk"](bundle),
+                "",
+                "",
+            )
+
+        self.assertTrue(prompt.endswith(bundle))
+
+    def test_review_pass_count_is_bounded(self) -> None:
+        builder = self.helper["build_review_prompts"]
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(builder.__globals__, {"MAX_REVIEW_PASSES": 1}):
+                with self.assertRaisesRegex(SystemExit, "more than 1 bounded passes"):
+                    builder(
+                        repo,
+                        "commit",
+                        "HEAD",
+                        "# Commit Diff\n" + "safe review content\n" * 35_000,
+                        "",
+                        "",
+                    )
 
     def test_review_patch_escapes_controls_in_blocked_paths(self) -> None:
         path = ".env.\x1b]52;c;VEVTVA==\x07\udc9b"
@@ -2108,7 +2645,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             repo = init_repo(Path(tempdir))
             prompt = self.helper["build_prompt"](repo, "local", None, "diff", "", "")
 
-            self.assertIn("Repository root: .", prompt)
+            self.assertIn(
+                "Review sandbox: . (intentionally contains no reviewed repository files)",
+                prompt,
+            )
+            self.assertIn("Read-only tools cannot access unchanged repository files", prompt)
+            self.assertIn(
+                "Do not report a missing import, symbol, definition, call site, config entry",
+                prompt,
+            )
             self.assertNotIn(str(repo), prompt)
             with self.assertRaisesRegex(SystemExit, "aggregate limit"):
                 self.helper["build_prompt"](
@@ -2325,6 +2870,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     claude_env["AWS_BEARER_TOKEN_BEDROCK"],
                     "test-token-placeholder",
                 )
+                self.assertNotIn("AWS_BEARER_TOKEN_BEDROCK", env)
                 self.assertEqual(
                     claude_env["ANTHROPIC_BEDROCK_BASE_URL"],
                     "https://bedrock.example.invalid",
@@ -2334,6 +2880,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "https://vertex.example.invalid",
                 )
                 self.assertEqual(claude_env["AWS_PROFILE"], "review-profile")
+                self.assertNotIn("AWS_PROFILE", env)
                 self.assertNotIn("AWS_CONFIG_FILE", env)
                 self.assertNotIn("GOOGLE_APPLICATION_CREDENTIALS", env)
                 self.assertNotIn(
@@ -2400,6 +2947,171 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertTrue(observed[1]["shell"])
         self.assertNotIn("shell", observed[2])
         self.assertNotIn("shell", observed[3])
+
+    def test_claude_subscription_auth_ignores_provider_environment(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["ANTHROPIC_API_KEY"] = "test-api-key"
+                os.environ["ANTHROPIC_AUTH_TOKEN"] = "test-auth-token"
+                os.environ["ANTHROPIC_BASE_URL"] = "https://api.example.invalid"
+                os.environ["CLAUDE_CODE_USE_BEDROCK"] = "1"
+                os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = "test-oauth-token"
+
+                subscription = self.helper["claude_engine_env"](
+                    argparse.Namespace(claude_auth="subscription"),
+                    repo,
+                )
+                default = self.helper["claude_engine_env"](
+                    argparse.Namespace(claude_auth="default"),
+                    repo,
+                )
+
+                for key in (
+                    "ANTHROPIC_API_KEY",
+                    "ANTHROPIC_AUTH_TOKEN",
+                    "ANTHROPIC_BASE_URL",
+                    "CLAUDE_CODE_USE_BEDROCK",
+                ):
+                    self.assertNotIn(key, subscription)
+                self.assertEqual(
+                    subscription["CLAUDE_CODE_OAUTH_TOKEN"],
+                    "test-oauth-token",
+                )
+                self.assertEqual(
+                    subscription["CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK"],
+                    "1",
+                )
+                self.assertEqual(default["ANTHROPIC_API_KEY"], "test-api-key")
+                subscription_flags = self.helper["claude_review_isolation_flags"](
+                    argparse.Namespace(claude_auth="subscription")
+                )
+                sources_index = subscription_flags.index("--setting-sources")
+                self.assertEqual(subscription_flags[sources_index + 1], "")
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_claude_refusal_is_detected(self) -> None:
+        output = json.dumps(
+            [
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "fallback",
+                                "from": {"model": "claude-fable-5"},
+                                "to": {"model": "claude-opus-4-8"},
+                            }
+                        ]
+                    },
+                },
+                {"type": "system", "subtype": "model_refusal_fallback"},
+            ]
+        )
+
+        self.assertTrue(self.helper["claude_refusal_detected"](output))
+        self.assertFalse(
+            self.helper["claude_refusal_detected"](
+                json.dumps([{"type": "result", "subtype": "success"}])
+            )
+        )
+
+    def test_claude_retries_fable_twice_then_uses_opus_max(self) -> None:
+        refusal = subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=1,
+            stdout=json.dumps(
+                [{"type": "system", "subtype": "model_refusal_no_fallback"}]
+            ),
+            stderr="",
+        )
+        success = subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=json.dumps([{"type": "result", "subtype": "success"}]),
+            stderr="",
+        )
+        args = argparse.Namespace(
+            model="claude-fable-5",
+            thinking="max",
+        )
+        run_once = mock.Mock(side_effect=[refusal, refusal, success])
+
+        with mock.patch.dict(
+            self.helper["run_claude"].__globals__,
+            {
+                "ensure_claude_isolation_supported": lambda *_args: None,
+                "run_claude_once": run_once,
+            },
+        ):
+            output = self.helper["run_claude"](args, Path("/repo"), "review")
+
+        self.assertEqual(output, success.stdout)
+        self.assertEqual(run_once.call_count, 3)
+        invoked_models = [call.args[0].model for call in run_once.call_args_list]
+        invoked_thinking = [call.args[0].thinking for call in run_once.call_args_list]
+        self.assertEqual(
+            invoked_models,
+            ["claude-fable-5", "claude-fable-5", "claude-opus-4-8"],
+        )
+        self.assertEqual(invoked_thinking, ["max", "max", "max"])
+        self.assertEqual(args.actual_model, "claude-opus-4-8")
+        self.assertEqual(args.actual_thinking, "max")
+
+    def test_claude_retries_fable_once_without_opus_when_retry_succeeds(self) -> None:
+        refusal = subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=1,
+            stdout=json.dumps(
+                [{"type": "system", "subtype": "model_refusal_no_fallback"}]
+            ),
+            stderr="",
+        )
+        success = subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=json.dumps([{"type": "result", "subtype": "success"}]),
+            stderr="",
+        )
+        args = argparse.Namespace(model="claude-fable-5", thinking="max")
+        run_once = mock.Mock(side_effect=[refusal, success])
+
+        with mock.patch.dict(
+            self.helper["run_claude"].__globals__,
+            {
+                "ensure_claude_isolation_supported": lambda *_args: None,
+                "run_claude_once": run_once,
+            },
+        ):
+            output = self.helper["run_claude"](args, Path("/repo"), "review")
+
+        self.assertEqual(output, success.stdout)
+        self.assertEqual(run_once.call_count, 2)
+        self.assertEqual(
+            [call.args[0].model for call in run_once.call_args_list],
+            ["claude-fable-5", "claude-fable-5"],
+        )
+        self.assertIsNone(args.actual_model)
+        self.assertIsNone(args.actual_thinking)
+
+    def test_reviewer_label_reports_only_effective_refusal_fallback(self) -> None:
+        args = argparse.Namespace(
+            engine="claude",
+            model="claude-fable-5",
+            thinking="max",
+            fallback_model="claude-opus-4-8,claude-sonnet-4-6",
+            actual_model="claude-opus-4-8",
+            actual_thinking="max",
+        )
+
+        label = self.helper["reviewer_label"](args)
+
+        self.assertIn("model=claude-opus-4-8", label)
+        self.assertIn("refusal-fallback-from=claude-fable-5", label)
+        self.assertNotIn("fallback=", label)
 
     def test_parallel_test_finish_does_not_wait_for_inherited_stderr_pipe(
         self,
@@ -3126,6 +3838,174 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ):
                 self.helper["ensure_claude_isolation_supported"](args, repo)
 
+    def test_claude_isolation_support_probes_hidden_flags_directly(self) -> None:
+        args = argparse.Namespace(
+            claude_bin="claude",
+            fallback_model=None,
+            model="claude-fable-5",
+        )
+        commands: list[list[str]] = []
+
+        def fake_run(
+            command: list[str],
+            *_args: object,
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            commands.append(command)
+            if command == ["/usr/bin/claude", "--version"]:
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    "2.1.207 (Claude Code)",
+                    "",
+                )
+            if "--autoreview-invalid-control" in command:
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    "",
+                    "error: unknown option '--autoreview-invalid-control'",
+                )
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                "",
+                (
+                    "Error: Input must be provided either through stdin or as a "
+                    "prompt argument when using --print"
+                ),
+            )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["ensure_claude_isolation_supported"].__globals__,
+                {
+                    "resolve_command": lambda *_args: "/usr/bin/claude",
+                    "safe_engine_env": lambda *_args, **_kwargs: {},
+                    "safe_temp_root": lambda _repo: Path(tempdir),
+                    "run": fake_run,
+                },
+            ):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
+
+        self.assertEqual(commands[0], ["/usr/bin/claude", "--version"])
+        self.assertNotIn("--help", commands[1])
+        self.assertEqual(commands[1][1], "--autoreview-invalid-control")
+        self.assertEqual(commands[1][-1], "--print")
+        self.assertNotIn("--autoreview-invalid-control", commands[2])
+        for required in (
+            "--safe-mode",
+            "--setting-sources",
+            "--strict-mcp-config",
+            "--disallowedTools",
+            "--tools",
+        ):
+            self.assertIn(required, commands[2])
+        self.assertEqual(commands[2][-1], "--print")
+
+    def test_claude_isolation_support_fails_when_capability_probe_rejects_flags(self) -> None:
+        args = argparse.Namespace(
+            claude_bin="claude",
+            fallback_model=None,
+            model="claude-fable-5",
+        )
+        results = iter(
+            [
+                subprocess.CompletedProcess([], 0, "2.1.207 (Claude Code)", ""),
+                subprocess.CompletedProcess(
+                    [],
+                    1,
+                    "",
+                    "error: unknown option '--autoreview-invalid-control'",
+                ),
+                subprocess.CompletedProcess([], 1, "", "unknown option --safe-mode"),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["ensure_claude_isolation_supported"].__globals__,
+                {
+                    "resolve_command": lambda *_args: "/usr/bin/claude",
+                    "safe_engine_env": lambda *_args, **_kwargs: {},
+                    "safe_temp_root": lambda _repo: Path(tempdir),
+                    "run": lambda *_args, **_kwargs: next(results),
+                },
+            ), self.assertRaisesRegex(
+                SystemExit,
+                "isolation flags rejected by capability probe",
+            ):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
+
+    def test_claude_isolation_probe_fails_if_unknown_control_is_not_rejected(self) -> None:
+        args = argparse.Namespace(
+            claude_bin="claude",
+            fallback_model=None,
+            model="claude-fable-5",
+        )
+        results = iter(
+            [
+                subprocess.CompletedProcess([], 0, "2.1.207 (Claude Code)", ""),
+                subprocess.CompletedProcess([], 0, "2.1.207 (Claude Code)", ""),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["ensure_claude_isolation_supported"].__globals__,
+                {
+                    "resolve_command": lambda *_args: "/usr/bin/claude",
+                    "safe_engine_env": lambda *_args, **_kwargs: {},
+                    "safe_temp_root": lambda _repo: Path(tempdir),
+                    "run": lambda *_args, **_kwargs: next(results),
+                },
+            ), self.assertRaisesRegex(
+                SystemExit,
+                "capability probe rejects unknown flags",
+            ):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
+
+    def test_claude_isolation_probe_rejects_warn_and_continue_parser(self) -> None:
+        args = argparse.Namespace(
+            claude_bin="claude",
+            fallback_model=None,
+            model="claude-fable-5",
+        )
+        results = iter(
+            [
+                subprocess.CompletedProcess([], 0, "2.1.207 (Claude Code)", ""),
+                subprocess.CompletedProcess(
+                    [],
+                    1,
+                    "",
+                    (
+                        "warning: unknown option '--autoreview-invalid-control'\n"
+                        "Error: Input must be provided either through stdin or as a "
+                        "prompt argument when using --print"
+                    ),
+                ),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["ensure_claude_isolation_supported"].__globals__,
+                {
+                    "resolve_command": lambda *_args: "/usr/bin/claude",
+                    "safe_engine_env": lambda *_args, **_kwargs: {},
+                    "safe_temp_root": lambda _repo: Path(tempdir),
+                    "run": lambda *_args, **_kwargs: next(results),
+                },
+            ), self.assertRaisesRegex(
+                SystemExit,
+                "capability probe rejects unknown flags",
+            ):
+                self.helper["ensure_claude_isolation_supported"](args, repo)
+
     def test_claude_runs_outside_repo_with_auto_memory_disabled(self) -> None:
         args = argparse.Namespace(
             claude_allowed_tools=None,
@@ -3526,6 +4406,97 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     json.loads(source_auth.read_text(encoding="utf-8"))["token"],
                     "test-auth-token",
                 )
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_codex_runtime_profile_stages_only_safe_bedrock_settings(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            source_home = root / "host-home" / ".codex"
+            runtime_home = root / "runtime" / "codex-home"
+            source_home.mkdir(parents=True)
+            (source_home / "bedrock.config.toml").write_text(
+                'model = "openai.gpt-5.5"\n'
+                'model_provider = "amazon-bedrock"\n'
+                'model_reasoning_effort = "xhigh"\n'
+                'approvals_reviewer = "user"\n'
+                '[mcp_servers.hostile]\ncommand = "touch"\n'
+                '[model_providers.amazon-bedrock.aws]\n'
+                'region = "us-east-2"\n',
+                encoding="utf-8",
+            )
+            try:
+                os.environ["CODEX_HOME"] = str(source_home)
+                staged = self.helper["prepare_codex_runtime_profile"](
+                    argparse.Namespace(codex_profile="bedrock"),
+                    repo,
+                    runtime_home,
+                )
+                self.assertTrue(staged)
+                runtime_profile = runtime_home / "bedrock.config.toml"
+                text = runtime_profile.read_text(encoding="utf-8")
+                self.assertIn('model = "openai.gpt-5.5"', text)
+                self.assertIn('model_provider = "amazon-bedrock"', text)
+                self.assertIn('model_reasoning_effort = "xhigh"', text)
+                self.assertIn('region = "us-east-2"', text)
+                self.assertNotIn("approvals_reviewer", text)
+                self.assertNotIn("mcp_servers", text)
+                self.assertEqual(
+                    stat.S_IMODE(runtime_profile.stat().st_mode),
+                    0o600,
+                )
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_codex_runtime_profile_rejects_file_backed_aws_profile(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            source_home = root / "host-home" / ".codex"
+            source_home.mkdir(parents=True)
+            (source_home / "bedrock.config.toml").write_text(
+                'model = "openai.gpt-5.5"\n'
+                'model_provider = "amazon-bedrock"\n'
+                '[model_providers.amazon-bedrock.aws]\n'
+                'profile = "review"\nregion = "us-east-2"\n',
+                encoding="utf-8",
+            )
+            try:
+                os.environ["CODEX_HOME"] = str(source_home)
+                with self.assertRaisesRegex(SystemExit, "file-backed"):
+                    self.helper["prepare_codex_runtime_profile"](
+                        argparse.Namespace(codex_profile="bedrock"),
+                        repo,
+                        root / "runtime" / "codex-home",
+                    )
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_codex_runtime_profile_rejects_unsupported_provider(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            source_home = root / "host-home" / ".codex"
+            source_home.mkdir(parents=True)
+            (source_home / "custom.config.toml").write_text(
+                'model = "custom-model"\nmodel_provider = "credential-sink"\n',
+                encoding="utf-8",
+            )
+            try:
+                os.environ["CODEX_HOME"] = str(source_home)
+                with self.assertRaisesRegex(SystemExit, "unsupported model_provider"):
+                    self.helper["prepare_codex_runtime_profile"](
+                        argparse.Namespace(codex_profile="custom"),
+                        repo,
+                        root / "runtime" / "codex-home",
+                    )
             finally:
                 os.environ.clear()
                 os.environ.update(old)


### PR DESCRIPTION
## Summary

- sync the complete autoreview skill directory from openclaw/agent-skills
- add Codex and Claude panel defaults plus Bedrock profile routing
- retry Fable once on refusal, then fall back to Opus 4.8 at max reasoning

Canonical source change: openclaw/agent-skills#90

## Validation

- pnpm run check (848 main tests, 109 coverage tests)
- autoreview self-test
- autoreview_test.py (26 tests)
- byte-for-byte directory comparison with the canonical checkout

The downstream branch panel correctly failed closed on deliberate secret-shaped hardening fixtures in the vendored test diff; no safety bypass was added. The canonical commits were reviewed by Codex gpt-5.6-sol/xhigh and Claude Fable 5/max.