### PR TITLE
feat(cli): add `agents` and `<agent> models` runtime discovery commands

### DIFF
--- a/agents/Devin.md
+++ b/agents/Devin.md
@@ -1,8 +1,11 @@
 # Devin
 
-- Built-in name: none
-- Raw command: `devin acp`
+- Built-in name: `devin`
+- Launch command: `devin acp`
 - Upstream: https://www.devin.ai
+
+`devin` is a built-in agent, so `acpx devin …` works directly (equivalent to the
+raw `--agent 'devin acp'` form shown below).
 
 ## ACP compatibility contract
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -32,6 +32,8 @@ acpx [global_options] set <key> <value> [-s <name>]
 acpx [global_options] status [-s <name>]
 acpx [global_options] sessions [list | new [--name <name>] | ensure [--name <name>] | close [name] | show [name] | history [name] [--limit <count>] | export [name] --output <path> | import <archive> [--name <name>] [--cwd <dir>]]
 acpx [global_options] config [show | init]
+acpx [global_options] agents
+acpx [global_options] models
 
 acpx [global_options] <agent> [prompt_options] [prompt_text...]
 acpx [global_options] <agent> prompt [prompt_options] [prompt_text...]
@@ -40,6 +42,7 @@ acpx [global_options] <agent> cancel [-s <name>]
 acpx [global_options] <agent> set-mode <mode> [-s <name>]
 acpx [global_options] <agent> set <key> <value> [-s <name>]
 acpx [global_options] <agent> status [-s <name>]
+acpx [global_options] <agent> models
 acpx [global_options] <agent> sessions [list | new [--name <name>] | ensure [--name <name>] | close [name] | show [name] | history [name] [--limit <count>] | export [name] --output <path> | import <archive> [--name <name>] [--cwd <dir>]]
 ```
 
@@ -443,6 +446,41 @@ For ACP `authenticate` handshakes, use either config `auth` entries or explicit
 `ACPX_AUTH_<METHOD_ID>` environment variables such as `ACPX_AUTH_OPENAI_API_KEY`.
 Ambient provider env vars such as `OPENAI_API_KEY` are still passed through to
 child agents, but they do not trigger ACP auth-method selection on their own.
+
+## `agents` and `models` discovery commands
+
+Read-only runtime discovery so tools built on `acpx` enumerate what is reachable
+instead of shipping a hardcoded catalog. Both honor `--format json|quiet|text`.
+
+```bash
+acpx agents                       # <id>\t<launch-command> per line
+acpx agents --format json         # { "agents": [{ "id", "launchCommand", "source" }] }
+acpx agents --format quiet         # one id per line (script-friendly)
+
+acpx <agent> models               # models the agent advertises now (* marks current)
+acpx models                       # models for the default agent
+acpx <agent> models --format json # { "agent", "current", "available": [...] }
+acpx <agent> models --format quiet # one model id per line
+```
+
+`agents`:
+
+- Lists the built-in registry unioned with config-defined agents (`source` is
+  `built-in` or `config`).
+- **Security:** only fixed, public built-in launch commands are printed.
+  Configured commands may embed tokens, credentials, or private paths, so they are
+  redacted — `launchCommand` is `null` in JSON and shown as `(configured)` in text.
+
+`models`:
+
+- Performs a fresh, ephemeral ACP handshake on every call and persists no session,
+  so the list always reflects what the agent advertises right now (never cached or
+  resumed session metadata).
+
+Reserved-name precedence: `agents` and `models` are reserved top-level verbs, but a
+configured agent whose name is literally `agents` or `models` takes precedence — the
+discovery verb is not registered in that case, so `acpx agents …` / `acpx models …`
+keep invoking the configured agent.
 
 ## `--agent` escape hatch
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -87,6 +87,7 @@ Friendly agent names resolve to commands:
 - `claude` -> `npx -y @agentclientprotocol/claude-agent-acp` (ACPX-owned package range)
 - `gemini` -> `gemini --acp`
 - `cursor` -> `cursor-agent acp`
+- `devin` -> `devin acp` (advertises a Windsurf-compatible client identity; see `agents/Devin.md`)
 - `copilot` -> `copilot --acp --stdio`
 - `droid` -> `droid exec --output-format acp` (`factory-droid` and `factorydroid` also resolve to `droid`)
 - `fast-agent` -> `uvx fast-agent-mcp acp`
@@ -108,6 +109,23 @@ Rules:
 - Unknown positional agent tokens are treated as raw agent commands.
 - `--agent <command>` explicitly sets a raw ACP adapter command.
 - Do not combine a positional agent and `--agent` in the same command.
+- `agents` and `models` are reserved top-level verbs (see Discovery below). A configured agent whose name is literally `agents` or `models` still takes precedence — the discovery verb is not registered in that case.
+
+## Discovery
+
+Read-only, no persistent state:
+
+```bash
+acpx agents                 # id<tab>launch-command (built-in specs only)
+acpx agents --format json   # { agents: [{ id, launchCommand, source }] }
+acpx agents --format quiet  # one id per line
+acpx codex models           # models codex advertises now (* marks current)
+acpx models                 # models for the default agent
+acpx codex models --format json   # { agent, current, available }
+```
+
+- `agents` unions the built-in registry with config-defined agents. Configured launch commands are **redacted** (`launchCommand: null`, shown as `(configured)`) because they may embed secrets; only fixed built-in specs are printed.
+- `models` performs a fresh, ephemeral ACP handshake each call and persists no session — the list always reflects what the agent advertises right now.
 
 ## Commands
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -43,6 +43,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   claude: `npx -y @agentclientprotocol/claude-agent-acp@${ACP_ADAPTER_PACKAGE_RANGES.claude}`,
   gemini: "gemini --acp",
   cursor: "cursor-agent acp",
+  devin: "devin acp",
   copilot: "copilot --acp --stdio",
   droid: "droid exec --output-format acp",
   "fast-agent": "uvx fast-agent-mcp acp",

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -41,6 +41,8 @@ const TOP_LEVEL_VERBS = new Set([
   "set",
   "sessions",
   "status",
+  "models",
+  "agents",
   "config",
   "help",
 ]);

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -875,6 +875,64 @@ export async function handleSessionsEnsure(
   printEnsuredSessionByFormat(result.record, result.created, globalFlags.format);
 }
 
+/**
+ * List the models an agent advertises. Ensures a session (which performs the ACP
+ * handshake and records the agent's advertised `available_models` + current
+ * model), then reports them. The list is whatever the agent supports right now —
+ * nothing is hardcoded, so new models appear automatically.
+ */
+export async function handleModels(
+  explicitAgentName: string | undefined,
+  flags: SessionsNewFlags,
+  command: Command,
+  config: ResolvedAcpxConfig,
+): Promise<void> {
+  const globalFlags = resolveGlobalFlags(command, config);
+  const permissionMode = resolvePermissionMode(globalFlags, config.defaultPermissions);
+  const permissionPolicy = await resolvePermissionPolicyFromFlags(globalFlags);
+  const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
+  const { ensureSession } = await loadSessionModule();
+  const result = await ensureSession(
+    buildSessionStartOptions({
+      agent,
+      flags,
+      globalFlags,
+      config,
+      permissionMode,
+      permissionPolicy,
+    }),
+  );
+
+  renderModels(
+    globalFlags.format,
+    agent.agentName,
+    result.record.acpx?.current_model_id ?? null,
+    result.record.acpx?.available_models ?? [],
+  );
+}
+
+function renderModels(
+  format: OutputFormat,
+  agentName: string,
+  current: string | null,
+  available: string[],
+): void {
+  if (emitJsonResult(format, { agent: agentName, current, available })) {
+    return;
+  }
+  if (format === "quiet") {
+    process.stdout.write(available.length ? `${available.join("\n")}\n` : "");
+    return;
+  }
+  if (available.length === 0) {
+    process.stdout.write(`No models advertised by ${agentName}.\n`);
+    return;
+  }
+  for (const id of available) {
+    process.stdout.write(`${id === current ? "* " : "  "}${id}\n`);
+  }
+}
+
 function userContentToText(content: SessionUserContent): string {
   if ("Text" in content) {
     return content.Text;

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -876,9 +876,12 @@ export async function handleSessionsEnsure(
 }
 
 /**
- * List the models an agent advertises. Ensures a session (which performs the ACP
- * handshake and records the agent's advertised `available_models` + current
- * model), then reports them. The list is whatever the agent supports right now —
+ * List the models an agent advertises. Performs a fresh, ephemeral ACP handshake
+ * every call — it spawns the agent, reads the `available_models` +
+ * `current_model_id` it advertises *right now*, then tears the client down
+ * WITHOUT persisting a session record. This deliberately avoids reusing an
+ * existing session (which could report stale, cached model metadata) and creates
+ * no persistent state. The list is whatever the agent supports right now —
  * nothing is hardcoded, so new models appear automatically.
  */
 export async function handleModels(
@@ -891,9 +894,9 @@ export async function handleModels(
   const permissionMode = resolvePermissionMode(globalFlags, config.defaultPermissions);
   const permissionPolicy = await resolvePermissionPolicyFromFlags(globalFlags);
   const agent = resolveAgentInvocation(explicitAgentName, globalFlags, config);
-  const { ensureSession } = await loadSessionModule();
-  const result = await ensureSession(
-    buildSessionStartOptions({
+  const { discoverAgentModels } = await loadSessionModule();
+  const models = await discoverAgentModels({
+    ...buildSessionStartOptions({
       agent,
       flags,
       globalFlags,
@@ -901,14 +904,12 @@ export async function handleModels(
       permissionMode,
       permissionPolicy,
     }),
-  );
+    // Force a fresh, unnamed, non-resumed handshake so the model list is live.
+    name: undefined,
+    resumeSessionId: undefined,
+  });
 
-  renderModels(
-    globalFlags.format,
-    agent.agentName,
-    result.record.acpx?.current_model_id ?? null,
-    result.record.acpx?.available_models ?? [],
-  );
+  renderModels(globalFlags.format, agent.agentName, models.currentModelId, models.availableModels);
 }
 
 function renderModels(
@@ -970,7 +971,11 @@ function conversationHistoryEntries(record: SessionRecord): Array<{
   timestamp: string;
   textPreview: string;
 }> {
-  const entries: Array<{ role: "user" | "assistant"; timestamp: string; textPreview: string }> = [];
+  const entries: Array<{
+    role: "user" | "assistant";
+    timestamp: string;
+    textPreview: string;
+  }> = [];
 
   for (const message of record.messages) {
     if (message === "Resume") {
@@ -985,7 +990,11 @@ function conversationHistoryEntries(record: SessionRecord): Array<{
       if (!text) {
         continue;
       }
-      entries.push({ role: "user", timestamp: record.updated_at, textPreview: text });
+      entries.push({
+        role: "user",
+        timestamp: record.updated_at,
+        textPreview: text,
+      });
       continue;
     }
 
@@ -997,7 +1006,11 @@ function conversationHistoryEntries(record: SessionRecord): Array<{
       if (!text) {
         continue;
       }
-      entries.push({ role: "assistant", timestamp: record.updated_at, textPreview: text });
+      entries.push({
+        role: "assistant",
+        timestamp: record.updated_at,
+        textPreview: text,
+      });
     }
   }
 

--- a/src/cli/command-registration.ts
+++ b/src/cli/command-registration.ts
@@ -278,11 +278,15 @@ export function registerSharedAgentSubcommands(
     await handleSetConfigOption(explicitAgentName, key, value, flags, this, config);
   });
 
-  const modelsCommand = parent.command("models").description(descriptions.models);
-  addSessionNameOption(modelsCommand);
-  modelsCommand.action(async function (this: Command, flags: SessionsNewFlags) {
-    await handleModels(explicitAgentName, flags, this, config);
-  });
+  // `models` performs a fresh ephemeral handshake (no persisted session), so it
+  // takes no session-name option. Skip registering the bare default-agent `models`
+  // verb when a configured agent literally reuses that name — the agent wins.
+  if (explicitAgentName !== undefined || !configHasAgent(config, "models")) {
+    const modelsCommand = parent.command("models").description(descriptions.models);
+    modelsCommand.action(async function (this: Command, flags: SessionsNewFlags) {
+      await handleModels(explicitAgentName, flags, this, config);
+    });
+  }
 
   registerStatusCommand(parent, explicitAgentName, config, descriptions.status);
 }
@@ -356,13 +360,31 @@ export function registerDefaultCommands(program: Command, config: ResolvedAcpxCo
   registerConfigCommand(program, config);
   registerCompareCommand(program, config);
   registerFlowCommand(program, config);
-  registerAgentsCommand(program, config);
+  // Skip the discovery `agents` verb when a configured agent literally reuses that
+  // name — the configured agent (registered earlier) keeps its positional launch.
+  if (!configHasAgent(config, "agents")) {
+    registerAgentsCommand(program, config);
+  }
 }
 
 /**
- * `acpx agents` — list every agent acpx can drive, straight from the built-in
- * registry (plus config overrides). The source of truth for providers, so callers
+ * Whether a configured agent literally reuses a reserved discovery verb name.
+ * When true, that agent takes precedence and the discovery verb is not registered,
+ * so existing `acpx <name> …` invocations keep working.
+ */
+function configHasAgent(config: ResolvedAcpxConfig, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(config.agents ?? {}, name);
+}
+
+/**
+ * `acpx agents` — list every agent acpx can drive: the built-in registry unioned
+ * with any config-defined agents. The source of truth for providers, so callers
  * never hardcode the list.
+ *
+ * Security: only built-in launch commands (fixed, public package specs) are ever
+ * emitted. Configured agent commands can embed tokens, credentials, or private
+ * paths, so they are redacted (`launchCommand: null`, shown as "(configured)") to
+ * keep them out of terminal output, shell history, and downstream automation logs.
  */
 export function registerAgentsCommand(program: Command, config: ResolvedAcpxConfig): void {
   program
@@ -370,18 +392,19 @@ export function registerAgentsCommand(program: Command, config: ResolvedAcpxConf
     .description("List agents acpx can drive (built-in registry + config)")
     .action(async function (this: Command) {
       const globalFlags = resolveGlobalFlags(this, config);
-      const [{ AGENT_REGISTRY }, { emitJsonResult }] = await Promise.all([
+      const [{ AGENT_REGISTRY, listBuiltInAgents }, { emitJsonResult }] = await Promise.all([
         import("../agent-registry.js"),
         import("./output/json-output.js"),
       ]);
-      const overrides = (config as { agents?: Record<string, { command?: string }> }).agents ?? {};
-      const ids = Array.from(
-        new Set([...Object.keys(AGENT_REGISTRY), ...Object.keys(overrides)]),
-      ).toSorted();
+      const configuredAgents = config.agents ?? {};
+      const isConfigured = (id: string): boolean =>
+        Object.prototype.hasOwnProperty.call(configuredAgents, id);
+      const ids = listBuiltInAgents(config.agents).toSorted();
       const agents = ids.map((id) => ({
         id,
-        launchCommand: overrides[id]?.command ?? AGENT_REGISTRY[id] ?? null,
-        source: overrides[id]?.command ? "config" : "built-in",
+        // Redact configured commands (possible secrets); only public built-in specs.
+        launchCommand: isConfigured(id) ? null : (AGENT_REGISTRY[id] ?? null),
+        source: isConfigured(id) ? "config" : "built-in",
       }));
 
       if (emitJsonResult(globalFlags.format, { agents })) {
@@ -392,7 +415,7 @@ export function registerAgentsCommand(program: Command, config: ResolvedAcpxConf
         return;
       }
       for (const a of agents) {
-        process.stdout.write(`${a.id}\t${a.launchCommand ?? "-"}\n`);
+        process.stdout.write(`${a.id}\t${a.launchCommand ?? "(configured)"}\n`);
       }
     });
 }

--- a/src/cli/command-registration.ts
+++ b/src/cli/command-registration.ts
@@ -3,6 +3,7 @@ import { DEFAULT_HISTORY_LIMIT } from "../session/persistence.js";
 import {
   handleCancel,
   handleExec,
+  handleModels,
   handlePrompt,
   handleSessionsClose,
   handleSessionsEnsure,
@@ -28,6 +29,7 @@ import {
   parseNonEmptyValue,
   parsePruneBeforeDate,
   parseSessionName,
+  resolveGlobalFlags,
   type PromptFlags,
   type SessionsExportFlags,
   type SessionsHistoryFlags,
@@ -52,6 +54,7 @@ type SharedSubcommandDescriptions = {
   setMode: string;
   setConfig: string;
   status: string;
+  models: string;
 };
 
 class LocalAttributeOption extends Option {
@@ -275,6 +278,12 @@ export function registerSharedAgentSubcommands(
     await handleSetConfigOption(explicitAgentName, key, value, flags, this, config);
   });
 
+  const modelsCommand = parent.command("models").description(descriptions.models);
+  addSessionNameOption(modelsCommand);
+  modelsCommand.action(async function (this: Command, flags: SessionsNewFlags) {
+    await handleModels(explicitAgentName, flags, this, config);
+  });
+
   registerStatusCommand(parent, explicitAgentName, config, descriptions.status);
 }
 
@@ -304,6 +313,7 @@ export function registerAgentCommand(
     setMode: "Set session mode",
     setConfig: "Set session config option",
     status: "Show local status of current session agent process",
+    models: "List models this agent advertises (live, no hardcoded list)",
   });
 
   registerSessionsCommand(agentCommand, agentName, config);
@@ -339,10 +349,50 @@ export function registerDefaultCommands(program: Command, config: ResolvedAcpxCo
     setMode: `Set session mode for ${config.defaultAgent} by default`,
     setConfig: `Set session config option for ${config.defaultAgent} by default`,
     status: `Show local status for ${config.defaultAgent} by default`,
+    models: `List models for ${config.defaultAgent} by default (live)`,
   });
 
   registerSessionsCommand(program, undefined, config);
   registerConfigCommand(program, config);
   registerCompareCommand(program, config);
   registerFlowCommand(program, config);
+  registerAgentsCommand(program, config);
+}
+
+/**
+ * `acpx agents` — list every agent acpx can drive, straight from the built-in
+ * registry (plus config overrides). The source of truth for providers, so callers
+ * never hardcode the list.
+ */
+export function registerAgentsCommand(program: Command, config: ResolvedAcpxConfig): void {
+  program
+    .command("agents")
+    .description("List agents acpx can drive (built-in registry + config)")
+    .action(async function (this: Command) {
+      const globalFlags = resolveGlobalFlags(this, config);
+      const [{ AGENT_REGISTRY }, { emitJsonResult }] = await Promise.all([
+        import("../agent-registry.js"),
+        import("./output/json-output.js"),
+      ]);
+      const overrides = (config as { agents?: Record<string, { command?: string }> }).agents ?? {};
+      const ids = Array.from(
+        new Set([...Object.keys(AGENT_REGISTRY), ...Object.keys(overrides)]),
+      ).toSorted();
+      const agents = ids.map((id) => ({
+        id,
+        launchCommand: overrides[id]?.command ?? AGENT_REGISTRY[id] ?? null,
+        source: overrides[id]?.command ? "config" : "built-in",
+      }));
+
+      if (emitJsonResult(globalFlags.format, { agents })) {
+        return;
+      }
+      if (globalFlags.format === "quiet") {
+        process.stdout.write(`${ids.join("\n")}${ids.length ? "\n" : ""}`);
+        return;
+      }
+      for (const a of agents) {
+        process.stdout.write(`${a.id}\t${a.launchCommand ?? "-"}\n`);
+      }
+    });
 }

--- a/src/cli/session/session-management.ts
+++ b/src/cli/session/session-management.ts
@@ -41,17 +41,13 @@ type CreatedSessionState = {
   requestedModelResponse?: Awaited<ReturnType<AcpClient["setSessionModel"]>>;
 };
 
-async function createSessionRecordWithClient(
+function buildSessionRecordFromState(
   client: AcpClient,
+  createdState: CreatedSessionState,
   options: SessionCreateOptions,
-): Promise<SessionRecord> {
-  const cwd = absolutePath(options.cwd);
-  await withTimeout(client.start(), options.timeoutMs);
-  const createdState = options.resumeSessionId
-    ? await resumeSessionRecordWithClient(client, options, cwd)
-    : await createFreshSessionState(client, options, cwd);
+  cwd: string,
+): SessionRecord {
   const { sessionId, agentSessionId } = createdState;
-
   const lifecycle = client.getAgentLifecycleSnapshot();
   const now = isoNow();
   const record: SessionRecord = {
@@ -79,9 +75,68 @@ async function createSessionRecordWithClient(
 
   persistSessionOptions(record, options.sessionOptions);
   applyCreatedSessionModelState(record, createdState, options.sessionOptions?.model);
+  return record;
+}
+
+async function createSessionRecordWithClient(
+  client: AcpClient,
+  options: SessionCreateOptions,
+): Promise<SessionRecord> {
+  const cwd = absolutePath(options.cwd);
+  await withTimeout(client.start(), options.timeoutMs);
+  const createdState = options.resumeSessionId
+    ? await resumeSessionRecordWithClient(client, options, cwd)
+    : await createFreshSessionState(client, options, cwd);
+
+  const record = buildSessionRecordFromState(client, createdState, options, cwd);
 
   await writeSessionRecord(record);
   return record;
+}
+
+/**
+ * Read the models an agent advertises via a fresh, ephemeral ACP handshake.
+ * Spawns the agent, performs `initialize` + `session/new`, extracts the advertised
+ * model state, then tears the client down. It NEVER writes a session record — this
+ * is a read-only discovery path that leaves no persistent local state and never
+ * reuses (potentially stale) persisted session metadata.
+ */
+export async function discoverAgentModels(
+  options: SessionCreateOptions,
+): Promise<{ currentModelId: string | null; availableModels: string[] }> {
+  const client = new AcpClient({
+    agentCommand: options.agentCommand,
+    cwd: absolutePath(options.cwd),
+    mcpServers: options.mcpServers,
+    permissionMode: options.permissionMode,
+    nonInteractivePermissions: options.nonInteractivePermissions,
+    permissionPolicy: options.permissionPolicy,
+    authCredentials: options.authCredentials,
+    authPolicy: options.authPolicy,
+    terminal: options.terminal,
+    verbose: options.verbose,
+    sessionOptions: options.sessionOptions,
+  });
+
+  try {
+    return await withInterrupt(
+      async () => {
+        const cwd = absolutePath(options.cwd);
+        await withTimeout(client.start(), options.timeoutMs);
+        const createdState = await createFreshSessionState(client, options, cwd);
+        const record = buildSessionRecordFromState(client, createdState, options, cwd);
+        return {
+          currentModelId: record.acpx?.current_model_id ?? null,
+          availableModels: record.acpx?.available_models ?? [],
+        };
+      },
+      async () => {
+        await client.close();
+      },
+    );
+  } finally {
+    await client.close();
+  }
 }
 
 function applyCreatedSessionModelState(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2339,7 +2339,10 @@ test("sessions import --cwd overrides the destination cwd without replacing glob
       homeDir,
     );
     assert.equal(imported.code, 0, imported.stderr);
-    const payload = JSON.parse(imported.stdout) as { record_id?: string; cwd?: string };
+    const payload = JSON.parse(imported.stdout) as {
+      record_id?: string;
+      cwd?: string;
+    };
     assert.equal(payload.cwd, destinationCwd);
     assert.equal(typeof payload.record_id, "string");
 
@@ -2803,7 +2806,12 @@ async function withTempHome(run: (homeDir: string) => Promise<void>): Promise<vo
   try {
     await run(tempHome);
   } finally {
-    await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    await fs.rm(tempHome, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50,
+    });
   }
 }
 
@@ -3012,5 +3020,225 @@ test("agents quiet format prints one id per line", async () => {
     const lines = new Set(result.stdout.trim().split("\n"));
     assert.ok(lines.has("codex"));
     assert.ok(lines.has("claude"));
+  });
+});
+
+async function writeAcpxConfig(homeDir: string, config: unknown): Promise<void> {
+  await fs.mkdir(path.join(homeDir, ".acpx"), { recursive: true });
+  await fs.writeFile(
+    path.join(homeDir, ".acpx", "config.json"),
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+test("agents redacts configured launch commands but keeps built-in specs", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAcpxConfig(homeDir, {
+      agents: {
+        // Overrides a built-in name AND embeds a secret that must never surface.
+        cursor: { command: "cursor-agent acp --token=SUPERSECRET" },
+        // Config-only agent.
+        myagent: {
+          command: "./bin/custom-acp",
+          args: ["--api-key=ALSOSECRET"],
+        },
+      },
+    });
+
+    const result = await runCli(["--format", "json", "agents"], homeDir);
+    assert.equal(result.code, 0, result.stderr);
+    assert.ok(
+      !result.stdout.includes("SUPERSECRET") && !result.stdout.includes("ALSOSECRET"),
+      "configured launch commands (possible secrets) must be redacted from `agents` output",
+    );
+
+    const payload = JSON.parse(result.stdout.trim()) as {
+      agents: { id: string; launchCommand: string | null; source: string }[];
+    };
+    const byId = new Map(payload.agents.map((agent) => [agent.id, agent]));
+
+    // Built-in, not overridden → public spec is surfaced.
+    assert.equal(byId.get("codex")?.source, "built-in");
+    assert.equal(byId.get("codex")?.launchCommand, AGENT_REGISTRY.codex);
+
+    // Overridden built-in → marked config, command redacted.
+    assert.equal(byId.get("cursor")?.source, "config");
+    assert.equal(byId.get("cursor")?.launchCommand, null);
+
+    // Config-only agent → listed, marked config, command redacted.
+    assert.equal(byId.get("myagent")?.source, "config");
+    assert.equal(byId.get("myagent")?.launchCommand, null);
+  });
+});
+
+test("agents text format shows (configured) for config agents", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAcpxConfig(homeDir, {
+      agents: { myagent: { command: "./bin/custom-acp --token=SECRET" } },
+    });
+    const result = await runCli(["agents"], homeDir);
+    assert.equal(result.code, 0, result.stderr);
+    assert.ok(!result.stdout.includes("SECRET"), "must not leak configured command");
+    assert.match(result.stdout, /^myagent\t\(configured\)$/m);
+  });
+});
+
+test("a configured agent named `agents` takes precedence over the discovery verb", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeAcpxConfig(homeDir, {
+      agents: { agents: { command: MOCK_AGENT_COMMAND } },
+    });
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "agents-session",
+      acpSessionId: "agents-session",
+      agentCommand: MOCK_AGENT_COMMAND,
+      cwd,
+      closed: false,
+    });
+
+    // The agent subcommand path only exists if `agents` resolved to the configured
+    // agent, not the discovery verb (which has no `sessions` subcommand).
+    const result = await runCli(
+      ["--cwd", cwd, "--format", "quiet", "agents", "sessions", "--local"],
+      homeDir,
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /agents-session/);
+  });
+});
+
+test("<agent> models reports the live advertised model list", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeAcpxConfig(homeDir, {
+      agents: {
+        codex: { command: `${MOCK_AGENT_COMMAND} --advertise-models` },
+      },
+    });
+
+    const result = await runCli(
+      ["--cwd", cwd, "--approve-all", "--format", "json", "codex", "models"],
+      homeDir,
+      { timeoutMs: 20000 },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim()) as {
+      agent: string;
+      current: string | null;
+      available: string[];
+    };
+    assert.equal(payload.agent, "codex");
+    assert.equal(payload.current, "default-model");
+    assert.deepEqual(payload.available, [
+      "default-model",
+      "fast-model",
+      "smart-model",
+      "gpt-5.4",
+      "gpt-5.2",
+    ]);
+  });
+});
+
+test("<agent> models persists no session record (ephemeral handshake)", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeAcpxConfig(homeDir, {
+      agents: {
+        codex: { command: `${MOCK_AGENT_COMMAND} --advertise-models` },
+      },
+    });
+
+    const result = await runCli(
+      ["--cwd", cwd, "--approve-all", "--format", "quiet", "codex", "models"],
+      homeDir,
+      { timeoutMs: 20000 },
+    );
+    assert.equal(result.code, 0, result.stderr);
+
+    let recordCount = 0;
+    try {
+      const entries = await fs.readdir(path.join(homeDir, ".acpx", "sessions"));
+      recordCount = entries.filter((name) => name.endsWith(".json")).length;
+    } catch {
+      recordCount = 0;
+    }
+    assert.equal(recordCount, 0, "models discovery must not write a session record");
+  });
+});
+
+test("<agent> models ignores stale persisted models and uses a fresh handshake", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    const modelAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-models`;
+    await writeAcpxConfig(homeDir, {
+      agents: { codex: { command: modelAgentCommand } },
+    });
+    // A pre-existing session with stale, cached model metadata for this cwd/agent.
+    await writeSessionRecord(homeDir, {
+      acpxRecordId: "codex-stale",
+      acpSessionId: "codex-stale",
+      agentCommand: modelAgentCommand,
+      cwd,
+      closed: false,
+      acpx: {
+        current_model_id: "stale-old-model",
+        available_models: ["stale-old-model"],
+      },
+    });
+
+    const result = await runCli(
+      ["--cwd", cwd, "--approve-all", "--format", "json", "codex", "models"],
+      homeDir,
+      { timeoutMs: 20000 },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim()) as {
+      current: string | null;
+      available: string[];
+    };
+    assert.ok(
+      !payload.available.includes("stale-old-model"),
+      "models must reflect the live handshake, not stale persisted metadata",
+    );
+    assert.deepEqual(payload.available, [
+      "default-model",
+      "fast-model",
+      "smart-model",
+      "gpt-5.4",
+      "gpt-5.2",
+    ]);
+    assert.equal(payload.current, "default-model");
+  });
+});
+
+test("<agent> models quiet format prints one model id per line", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    await writeAcpxConfig(homeDir, {
+      agents: {
+        codex: { command: `${MOCK_AGENT_COMMAND} --advertise-models` },
+      },
+    });
+
+    const result = await runCli(
+      ["--cwd", cwd, "--approve-all", "--format", "quiet", "codex", "models"],
+      homeDir,
+      { timeoutMs: 20000 },
+    );
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(result.stdout.trim().split("\n"), [
+      "default-model",
+      "fast-model",
+      "smart-model",
+      "gpt-5.4",
+      "gpt-5.2",
+    ]);
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2987,3 +2987,30 @@ async function fileExists(filePath: string): Promise<boolean> {
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
+
+test("agents --format json lists the built-in registry", async () => {
+  await withTempHome(async (homeDir) => {
+    const result = await runCli(["--format", "json", "agents"], homeDir);
+    assert.equal(result.code, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim()) as {
+      agents: { id: string; launchCommand: string | null; source: string }[];
+    };
+    const ids = new Set(payload.agents.map((agent) => agent.id));
+    for (const id of Object.keys(AGENT_REGISTRY)) {
+      assert.ok(ids.has(id), `agents output missing built-in agent ${id}`);
+    }
+    const codex = payload.agents.find((agent) => agent.id === "codex");
+    assert.equal(codex?.launchCommand, AGENT_REGISTRY.codex);
+    assert.equal(codex?.source, "built-in");
+  });
+});
+
+test("agents quiet format prints one id per line", async () => {
+  await withTempHome(async (homeDir) => {
+    const result = await runCli(["--format", "quiet", "agents"], homeDir);
+    assert.equal(result.code, 0, result.stderr);
+    const lines = new Set(result.stdout.trim().split("\n"));
+    assert.ok(lines.has("codex"));
+    assert.ok(lines.has("claude"));
+  });
+});


### PR DESCRIPTION
## What

Two read-only discovery commands so tools built on top of `acpx` can enumerate what's reachable **at runtime** instead of shipping a hardcoded catalog:

| Command | Purpose |
|---|---|
| `acpx agents` | List every agent `acpx` can drive — built-in `AGENT_REGISTRY` unioned with config `agents`. |
| `acpx <agent> models` (and default-agent `acpx models`) | List the models an agent advertises **right now**, via a fresh ACP handshake. |

Both honor the global `--format json|quiet|text` flag.

## Why

I maintain a downstream voice assistant that presents the user a **live model/provider picker** — it must reflect exactly what the user has installed, with zero baked-in lists that go stale the day a new GPT/Gemini/Claude ships. Putting discovery inside `acpx` keeps that logic in one place for everyone. Nothing is hardcoded.

## Behavior

```console
$ acpx agents
claude    npx -y @agentclientprotocol/claude-agent-acp@^0.37.0
codex     npx -y @agentclientprotocol/codex-acp@...
cursor    cursor-agent acp
devin     devin acp
my-agent  (configured)          # configured commands are redacted, see Security
...

$ acpx agents --format json
{ "agents": [ { "id": "claude", "launchCommand": "npx -y …", "source": "built-in" },
              { "id": "my-agent", "launchCommand": null, "source": "config" }, ... ] }

$ acpx cursor models
* composer-1
  gpt-5
  ...

$ acpx cursor models --format json
{ "agent": "cursor", "current": "composer-1", "available": ["composer-1", "gpt-5", ...] }
```

`--format quiet` prints one id per line (script-friendly).

## Implementation notes

- `agents` unions `AGENT_REGISTRY` with config-defined agents via `listBuiltInAgents`; `source` is `built-in` or `config`.
- `handleModels` performs a **fresh, ephemeral** ACP handshake (`discoverAgentModels`) each call — reads `available_models` + `current_model_id`, then tears the client down **without writing a session record**.
- `agents` / `models` added to `TOP_LEVEL_VERBS` so they resolve before lazy agent-token registration, **but** a configured agent literally named `agents`/`models` still wins (the discovery verb is not registered in that case).
- Also registers `devin acp` in the built-in registry, with harness docs synced.

## Review follow-up — addresses @clawsweeper

All findings from the Codex review are resolved. Verified against the built `dist/cli.js` with a mock ACP agent.

- ✅ **[P1] Reserved names could intercept custom agents** (`cli-core.ts`) — a configured agent literally named `agents` or `models` now takes precedence; the discovery verb is skipped in that case. Compat test + live proof below.
- ✅ **[P1] Raw configured launch commands leaked** (`command-registration.ts`) — configured commands are **never printed**. Only fixed, public built-in specs are emitted; config agents report `launchCommand: null` (`(configured)` in text). Secret-canary test confirms no leak.
- ✅ **[P1] `models` reused a persisted session / stale metadata** (`command-handlers.ts`) — replaced `ensureSession` with `discoverAgentModels`: a fresh handshake that persists **no** session record. Ephemeral + fresh-vs-stale tests.
- ✅ **[P2] Devin harness docs unsynced** — `agents/Devin.md` (built-in name `devin`) and `skills/acpx/SKILL.md` registry entry updated; `docs/CLI.md` documents both commands + precedence.
- ✅ **Bonus (self-review):** the previous config-override read was wrong-typed (`overrides[id]?.command` against `Record<string,string>`) and silently dropped every override + mislabeled `source`. Fixed by the redaction rewrite.

### Captured proof (built `dist/cli.js`, mock agent)

Secret redaction — config agent `secret-agent` = `./bin/x --token=SUPERSECRET_LEAK_CANARY`:

```console
$ acpx agents            # config agents redacted
codex          (configured)
devin          devin acp
secret-agent   (configured)
$ acpx --format json agents | grep SUPERSECRET   # → no match ✅
```

Live models via fresh handshake:

```console
$ acpx codex models
* default-model
  fast-model
  smart-model
$ acpx --format json codex models
{"agent":"codex","current":"default-model","available":["default-model","fast-model","smart-model", ...]}
# session records written after `models`: 0  ✅ (ephemeral, no persistent state)
```

Reserved-name precedence — configured agent literally named `agents`:

```console
$ acpx agents sessions --local    # resolves to the AGENT (discovery verb has no `sessions`)
[]   # exit 0 ✅ — configured agent wins
```

## Tests

Adds `agents` redaction + `source` labeling, reserved-name compatibility, and full `models` coverage: live list, `--format json`, `--format quiet`, ephemeral (no session record persisted), and fresh-vs-stale handshake (ignores cached model metadata). `node --test dist-test/test/cli.test.js` → **93/93 pass**. `oxfmt --check`, `tsc --noEmit`, `oxlint --type-aware --deny-warnings`, and `tsdown` build all pass.

## Try it now

Published as an unscoped fork on npm while this PR is open:

```bash
bunx acpx-iris@0.12.2 agents
bunx acpx-iris@0.12.2 --format json agents
bunx acpx-iris@0.12.2 cursor models
```

(Source is identical to this PR; the only delta on the published package is `name`/`version` in `package.json`.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
