### PR TITLE
refactor(acp): remove dead isCodexAcpCommand + its duplicate basenameToken

### DIFF
--- a/src/acp/codex-compat.ts
+++ b/src/acp/codex-compat.ts
@@ -1,20 +1,3 @@
-import path from "node:path";
-
-function basenameToken(value: string): string {
-  return path
-    .basename(value)
-    .toLowerCase()
-    .replace(/\.(cmd|exe|bat)$/u, "");
-}
-
-export function isCodexAcpCommand(command: string, args: readonly string[]): boolean {
-  const commandToken = basenameToken(command);
-  if (commandToken === "codex-acp") {
-    return true;
-  }
-  return args.some((arg) => arg.includes("codex-acp"));
-}
-
 export function isLegacyZedCodexAcpInvocation(agentCommand: string): boolean {
   return /@zed-industries\/codex-acp\b/u.test(agentCommand);
 }


### PR DESCRIPTION
## What Problem This Solves

`src/acp/codex-compat.ts` exports `isCodexAcpCommand(command, args)`, but nothing calls it. A repo-wide search (`src`, `test`, `conformance`, `docs`, `examples`, `scripts`) finds the symbol only at its own definition — zero references anywhere, including tests and docs. It is not part of the published API surface either: the package builds `src/cli.ts`, `src/flows.ts`, and `src/runtime.ts` (+ their `.dts`), and none of those graphs import this module's function (no `export *` barrel re-exports it).

It also carries a **private copy of `basenameToken`** that duplicates the canonical `basenameToken` already exported from `src/acp/client-process.ts` (used ~10 places in `src/acp/agent-command.ts`). Since only the dead function used the local copy, the duplicate + its `node:path` import are dead too.

Live codex-acp detection is handled by the sibling export `isLegacyZedCodexAcpInvocation`, which **stays** (used in `src/cli/command-handlers.ts:157`).

## Why This Change Was Made

Debt cleanup: delete a fully-unreferenced exported function and the duplicated helper it dragged along. Net-negative, behavior-preserving, single file. After removal `codex-compat.ts` is just the one live predicate.

## User Impact

None. No runtime, CLI, config, or public-API behavior changes — the removed symbols were reachable from nothing. The `.dts` output is unaffected (the function was never in the entry graphs).

## Evidence

Branched off current `main` (`a518ea9`), Linux, Node 22.22, `pnpm install --frozen-lockfile`.

- **Dead-code proof** — `git grep isCodexAcpCommand` returns only `src/acp/codex-compat.ts:10` (the definition); same for the local `basenameToken` (its only two hits are the dead def + its dead caller).
- `pnpm run typecheck` (`tsgo --noEmit`) → **exit 0** (confirms no dangling reference remains).
- `pnpm run lint` (`oxlint --type-aware --deny-warnings …`) → **exit 0**.
- `oxfmt --check src/acp/codex-compat.ts` → clean.
- **Full test suite** (`pnpm run build && build:test && node --test dist-test/test/*.test.js`) → **848 pass, 0 fail** on this branch. No test referenced the removed symbol, so the count matches `main`; behavior is preserved.

Diff: **−17 lines, 1 file**.

_AI-assisted contribution._


---
_Generated by [Claude Code](https://claude.ai/code/session_0175ARxXkXeE1Ct7fNAEuoJk)_