### PR TITLE
fix(cli): preserve positive timer durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Repo: https://github.com/openclaw/acpx
 
 - Session queue owner: capture a bounded owner stderr tail and exit status during cold start only (stop retaining at first IPC accept; keep draining the pipe so long-lived owners are not killed by EPIPE) so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
 
+- CLI/timers: preserve tiny positive `--timeout` and `--ttl` values as 1 ms instead of disabling timers, and reject delays beyond Node's supported timer range. Thanks @realmehmetali.
+
 ## 2026.7.4 (v0.12.0)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/ACP: add `--no-fs` to disable advertised ACP file read/write capabilities so compatible agents can use their native filesystem implementation. Thanks @zgxkbtl.
 
+- CLI/timers: preserve tiny positive timeout and TTL values from flags or config as 1 ms instead of disabling timers, and reject delays beyond Node's supported timer range. Thanks @realmehmetali.
+
 ### Breaking
 
 - Windows agent launches now require structured `agents.<name>.argv`; unambiguous legacy `command` plus `args` entries migrate automatically, while raw, ambiguous, or directly executable `.sh` commands fail with explicit migration guidance instead of lossy parsing or CreateProcess ENOENT. Existing custom-agent sessions without saved argv must be recreated. Fixes #466. Thanks @MarcelCFritsche.
@@ -33,8 +35,6 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Session queue owner: capture a bounded owner stderr tail and exit status during cold start only (stop retaining at first IPC accept; keep draining the pipe so long-lived owners are not killed by EPIPE) so a dead owner reports the real failure instead of a silent timeout. Thanks @SebTardif.
-
-- CLI/timers: preserve tiny positive `--timeout` and `--ttl` values as 1 ms instead of disabling timers, and reject delays beyond Node's supported timer range. Thanks @realmehmetali.
 
 ## 2026.7.4 (v0.12.0)
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -12,6 +12,7 @@ import type {
   OutputFormat,
   PermissionMode,
 } from "../types.js";
+import { toTimerMilliseconds } from "./timer-duration.js";
 
 export type ResolvedAgentConfig = {
   command: string;
@@ -109,7 +110,11 @@ function parseTtlMs(value: unknown, sourcePath: string): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     throw new Error(`Invalid config ttl in ${sourcePath}: expected non-negative seconds`);
   }
-  return Math.round(value * 1_000);
+  const milliseconds = toTimerMilliseconds(value, true);
+  if (milliseconds === undefined) {
+    throw new Error(`Invalid config ttl in ${sourcePath}: exceeds maximum supported timer delay`);
+  }
+  return milliseconds;
 }
 
 function parseTimeoutMs(value: unknown, sourcePath: string): number | undefined {
@@ -119,7 +124,13 @@ function parseTimeoutMs(value: unknown, sourcePath: string): number | undefined 
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     throw new Error(`Invalid config timeout in ${sourcePath}: expected positive seconds or null`);
   }
-  return Math.round(value * 1_000);
+  const milliseconds = toTimerMilliseconds(value, false);
+  if (milliseconds === undefined) {
+    throw new Error(
+      `Invalid config timeout in ${sourcePath}: exceeds maximum supported timer delay`,
+    );
+  }
+  return milliseconds;
 }
 
 function parseQueueMaxDepth(value: unknown, sourcePath: string): number | undefined {
@@ -669,7 +680,7 @@ export function toConfigDisplay(config: ResolvedAcpxConfig): {
     defaultPermissions: config.defaultPermissions,
     nonInteractivePermissions: config.nonInteractivePermissions,
     authPolicy: config.authPolicy,
-    ttl: Math.round(config.ttlMs / 1_000),
+    ttl: config.ttlMs / 1_000,
     timeout: config.timeoutMs == null ? null : config.timeoutMs / 1_000,
     queueMaxDepth: config.queueMaxDepth,
     format: config.format,

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -21,6 +21,7 @@ import {
   type PermissionMode,
 } from "../types.js";
 import type { ResolvedAcpxConfig } from "./config.js";
+import { toTimerMilliseconds } from "./timer-duration.js";
 
 export type PermissionFlags = {
   approveAll?: boolean;
@@ -154,19 +155,12 @@ export function parseNonInteractivePermissionPolicy(value: string): NonInteracti
   return value as NonInteractivePermissionPolicy;
 }
 
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
-
-function toTimerMilliseconds(seconds: number): number | undefined {
-  const milliseconds = Math.max(1, Math.round(seconds * 1000));
-  return milliseconds <= MAX_TIMER_DELAY_MS ? milliseconds : undefined;
-}
-
 export function parseTimeoutSeconds(value: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new InvalidArgumentError("Timeout must be a positive number of seconds");
   }
-  const milliseconds = toTimerMilliseconds(parsed);
+  const milliseconds = toTimerMilliseconds(parsed, false);
   if (milliseconds === undefined) {
     throw new InvalidArgumentError("Timeout exceeds the maximum supported timer delay");
   }
@@ -178,10 +172,7 @@ export function parseTtlSeconds(value: string): number {
   if (!Number.isFinite(parsed) || parsed < 0) {
     throw new InvalidArgumentError("TTL must be a non-negative number of seconds");
   }
-  if (parsed === 0) {
-    return 0;
-  }
-  const milliseconds = toTimerMilliseconds(parsed);
+  const milliseconds = toTimerMilliseconds(parsed, true);
   if (milliseconds === undefined) {
     throw new InvalidArgumentError("TTL exceeds the maximum supported timer delay");
   }

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -154,12 +154,23 @@ export function parseNonInteractivePermissionPolicy(value: string): NonInteracti
   return value as NonInteractivePermissionPolicy;
 }
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function toTimerMilliseconds(seconds: number): number | undefined {
+  const milliseconds = Math.max(1, Math.round(seconds * 1000));
+  return milliseconds <= MAX_TIMER_DELAY_MS ? milliseconds : undefined;
+}
+
 export function parseTimeoutSeconds(value: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new InvalidArgumentError("Timeout must be a positive number of seconds");
   }
-  return Math.round(parsed * 1000);
+  const milliseconds = toTimerMilliseconds(parsed);
+  if (milliseconds === undefined) {
+    throw new InvalidArgumentError("Timeout exceeds the maximum supported timer delay");
+  }
+  return milliseconds;
 }
 
 export function parseTtlSeconds(value: string): number {
@@ -167,7 +178,14 @@ export function parseTtlSeconds(value: string): number {
   if (!Number.isFinite(parsed) || parsed < 0) {
     throw new InvalidArgumentError("TTL must be a non-negative number of seconds");
   }
-  return Math.round(parsed * 1000);
+  if (parsed === 0) {
+    return 0;
+  }
+  const milliseconds = toTimerMilliseconds(parsed);
+  if (milliseconds === undefined) {
+    throw new InvalidArgumentError("TTL exceeds the maximum supported timer delay");
+  }
+  return milliseconds;
 }
 
 export function parseSessionName(value: string): string {

--- a/src/cli/timer-duration.ts
+++ b/src/cli/timer-duration.ts
@@ -1,0 +1,9 @@
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export function toTimerMilliseconds(seconds: number, allowZero: boolean): number | undefined {
+  if (allowZero && seconds === 0) {
+    return 0;
+  }
+  const milliseconds = Math.max(1, Math.round(seconds * 1000));
+  return milliseconds <= MAX_TIMER_DELAY_MS ? milliseconds : undefined;
+}

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -121,12 +121,16 @@ test("flag parsers reject invalid enum values with actionable messages", () => {
 
 test("numeric flag parsers reject non-finite and out-of-range values", () => {
   assert.equal(parseTimeoutSeconds("1.5"), 1500);
+  assert.equal(parseTimeoutSeconds("0.0001"), 1);
   assert.throws(() => parseTimeoutSeconds("0"), /positive number/);
   assert.throws(() => parseTimeoutSeconds("abc"), /positive number/);
+  assert.throws(() => parseTimeoutSeconds("2147483.648"), /maximum supported timer delay/);
 
   assert.equal(parseTtlSeconds("0"), 0);
+  assert.equal(parseTtlSeconds("0.0001"), 1);
   assert.equal(parseTtlSeconds("2.25"), 2250);
   assert.throws(() => parseTtlSeconds("-1"), /non-negative/);
+  assert.throws(() => parseTtlSeconds("2147483.648"), /maximum supported timer delay/);
 
   assert.equal(parseMaxTurns("2"), 2);
   assert.throws(() => parseMaxTurns("0"), /positive integer/);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { resolveAgentCommandParts, splitCommandLine } from "../src/acp/client-process.js";
-import { initGlobalConfigFile, loadResolvedConfig } from "../src/cli/config.js";
+import { initGlobalConfigFile, loadResolvedConfig, toConfigDisplay } from "../src/cli/config.js";
 
 test("loadResolvedConfig merges global and project config with project priority", async () => {
   await withTempEnv(async ({ homeDir }) => {
@@ -107,6 +107,28 @@ test("loadResolvedConfig merges global and project config with project priority"
     ]);
     assert.equal(config.hasGlobalConfig, true);
     assert.equal(config.hasProjectConfig, true);
+  });
+});
+
+test("loadResolvedConfig normalizes timer values through the CLI timer boundary", async () => {
+  await withTempEnv(async ({ homeDir }) => {
+    const cwd = path.join(homeDir, "workspace");
+    const configPath = path.join(homeDir, ".acpx", "config.json");
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+
+    await fs.writeFile(configPath, `${JSON.stringify({ ttl: 0.0001, timeout: 0.0001 })}\n`);
+    const config = await loadResolvedConfig(cwd);
+    assert.equal(config.ttlMs, 1);
+    assert.equal(config.timeoutMs, 1);
+    assert.equal(toConfigDisplay(config).ttl, 0.001);
+    assert.equal(toConfigDisplay(config).timeout, 0.001);
+
+    await fs.writeFile(configPath, `${JSON.stringify({ ttl: 2_147_483.648 })}\n`);
+    await assert.rejects(loadResolvedConfig(cwd), /ttl.*maximum supported timer delay/u);
+
+    await fs.writeFile(configPath, `${JSON.stringify({ timeout: 2_147_483.648 })}\n`);
+    await assert.rejects(loadResolvedConfig(cwd), /timeout.*maximum supported timer delay/u);
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -4332,15 +4332,24 @@ test("integration: session remains resumable after queue owner exits and agent h
       const sessionId = createdPayload.acpxRecordId;
       assert.equal(typeof sessionId, "string");
 
-      // 2. Send a prompt with a very short TTL so the queue owner exits quickly
+      // 2. Use a positive sub-millisecond TTL. It must floor to 1 ms rather than
+      //    round to the zero sentinel, which would keep the owner alive forever.
       const prompt = await runCli(
-        [...baseAgentArgs(cwd), "--format", "quiet", "--ttl", "1", "prompt", "echo oneshot-done"],
+        [
+          ...baseAgentArgs(cwd),
+          "--format",
+          "quiet",
+          "--ttl",
+          "0.0001",
+          "prompt",
+          "echo oneshot-done",
+        ],
         homeDir,
       );
       assert.equal(prompt.code, 0, prompt.stderr);
       assert.match(prompt.stdout, /oneshot-done/);
 
-      // 3. Wait for the queue owner to exit (it should exit after 1s TTL)
+      // 3. Wait for the queue owner to exit after its 1 ms floored TTL.
       const { lockPath } = queuePaths(homeDir, sessionId as string);
       let ownerPid: number | undefined;
       try {


### PR DESCRIPTION
## Summary

- Preserve positive sub-millisecond `--timeout` and `--ttl` inputs as a 1 ms timer instead of rounding them to the disabled/keep-alive-forever sentinel.
- Reject durations above Node's 2,147,483,647 ms timer ceiling instead of allowing Node to clamp them to an unintended 1 ms timer.
- Add parser regression coverage and an Unreleased changelog entry.

## Root cause

The CLI validated the duration in seconds, then rounded to milliseconds without validating the converted value. A small positive value such as `0.0001` became `0`; downstream, `timeoutMs <= 0` disables the timeout and `ttlMs === 0` means keep alive forever. Oversized finite values also exceeded Node's supported timer range and could be clamped by the runtime.

## Why this matters for frontier AI agents

Frontier AI agent systems depend on precise cancellation and lifecycle semantics. A timeout that silently turns itself off, or an idle TTL that unexpectedly becomes infinite, can strand orchestration capacity and make long-running autonomous workflows difficult to reason about. Keeping these boundary values explicit makes agent infrastructure safer and more predictable.

## Validation

- Required runtime: Node 22.22.0 with pnpm 10.33.2.
- Formatting, typecheck, lint, build, and viewer checks passed.
- `node --test --test-concurrency=4 dist-test/test/*.test.js` — 860 passed, 0 failed.
- Coverage gate — 109 passed; 94.14% statements, 87.36% branches, 96.07% functions, and 94.14% lines.
- Focused parser, lifecycle, compare-command, and built-CLI checks passed.

## Runtime behavior proof

The branch is rebased onto current `origin/main` (`24ddd69`).

- A built CLI run with `--timeout 0.0001` against a mock agent sleeping for 50 ms now exits 3 with `{"jsonrpc":"2.0","id":null,"error":{"code":-32070,"message":"Timed out after 1ms","data":{"acpxCode":"TIMEOUT","origin":"cli","sessionId":"unknown"}}}`.
- The integration lifecycle test now uses `--ttl 0.0001`; the queue owner exits and the session remains resumable. Before this fix, rounding to the zero sentinel would keep the owner alive forever.
- `--timeout 2147483.648` and `--ttl 2147483.648` are explicitly rejected with exit 2 instead of reaching the Node timer clamp.
- Compatibility note for maintainer confirmation: the oversized-value behavior deliberately changes from an unintended near-immediate Node clamp to a clear CLI validation error.

## AI and provenance disclosure

This contribution was prepared with significant AI assistance from OpenAI Codex and was manually scoped, tested, and reviewed. It is based entirely on public repository sources and synthetic test inputs. It contains no private or proprietary code, data, plans, or product-specific examples.

