### PR TITLE
chore(agents): bump codex-acp adapter range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Agents/built-ins: bump the default `@agentclientprotocol/codex-acp` package range to `^1.1.4` so fresh built-in Codex launches use the current stable adapter line.
+
 ### Breaking
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ acpx codex --file - "extra context"            # explicit stdin + appended args
 acpx codex --no-wait 'draft test migration plan' # enqueue without waiting if session is busy
 acpx codex cancel                               # cooperative cancel of in-flight prompt
 acpx codex set-mode auto                        # session/set_mode (adapter-defined mode id)
-acpx codex set model 'gpt-5.2[high]'            # adapter-advertised model control
+acpx codex set model gpt-5.6-sol                # select the advertised base model
+acpx codex set reasoning_effort max             # set the advertised reasoning effort
 acpx exec 'summarize this repo'                # default agent shortcut (codex)
 acpx codex exec 'what does this repo do?'      # one-shot, no saved session
 

--- a/agents/Codex.md
+++ b/agents/Codex.md
@@ -3,6 +3,7 @@
 - Built-in name: `codex`
 - Default command: `npx -y @agentclientprotocol/codex-acp`
 - Upstream: https://github.com/agentclientprotocol/codex-acp
-- Runtime controls exposed by current codex-acp releases include ACP modes and an advertised model session config option.
-- Reasoning effort is encoded in advertised Codex model ids such as `gpt-5.2[high]` when the adapter reports those variants.
-- `acpx --model <id> codex ...` and `acpx codex set model <id>` apply the requested model through the advertised config option; legacy adapters that advertise `models` use `session/set_model`.
+- ACPX owns the built-in package range so fresh launches use the repository-selected stable adapter line without requiring a global install.
+- Runtime controls exposed by current codex-acp releases include ACP modes plus separate `model` and `reasoning_effort` session config options.
+- Use the advertised base model id with `acpx --model <id> codex ...` or `acpx codex set model <id>`, then set reasoning effort separately with `acpx codex set reasoning_effort <value>`.
+- Legacy `models` metadata may encode both values in a combined id such as `gpt-5.6-sol[max]`; ACPX uses that form only when the adapter does not advertise the newer model config option.

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -54,8 +54,11 @@ Calls ACP `session/set_config_option` with the literal `<key>` and `<value>`. No
 
 `set model <id>` is a special-case interception. `acpx` prefers an advertised model session config option and updates it through `session/set_config_option`. If an adapter explicitly advertises legacy `models` metadata instead, `acpx` preserves compatibility through `session/set_model`.
 
+Current codex-acp releases advertise the base model and reasoning effort as separate config options.
+
 ```bash
-acpx codex set model 'gpt-5.2[high]'
+acpx codex set model gpt-5.6-sol
+acpx codex set reasoning_effort max
 acpx claude set model claude-sonnet-4-6
 ```
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -83,7 +83,7 @@ Friendly agent names resolve to commands:
 
 - `pi` -> `npx pi-acp`
 - `openclaw` -> `openclaw acp`
-- `codex` -> `npx -y @agentclientprotocol/codex-acp`
+- `codex` -> `npx -y @agentclientprotocol/codex-acp` (ACPX-owned package range)
 - `claude` -> `npx -y @agentclientprotocol/claude-agent-acp` (ACPX-owned package range)
 - `gemini` -> `gemini --acp`
 - `cursor` -> `cursor-agent acp`
@@ -174,8 +174,8 @@ Behavior:
 ```bash
 acpx codex cancel
 acpx codex set-mode auto
-acpx codex set model gpt-5.2[high]
-acpx codex set model gpt-5.4
+acpx codex set model gpt-5.6-sol
+acpx codex set reasoning_effort max
 ```
 
 Behavior:
@@ -184,7 +184,7 @@ Behavior:
 - `set-mode`: calls ACP `session/set_mode`.
 - `set-mode` mode ids are adapter-defined; unsupported values are rejected by the adapter (often `Invalid params`).
 - `set`: calls ACP `session/set_config_option`.
-- For codex, reasoning effort is selected through advertised ACP model ids when the adapter reports model variants.
+- Current codex-acp releases expose `model` and `reasoning_effort` as separate config options.
 - `--model <id>`: Claude-compatible adapters may consume session creation metadata; other agents must advertise a model config option or legacy `models` metadata.
 - `set model <id>`: uses `session/set_config_option` for advertised model config options and preserves `session/set_model` for explicitly advertised legacy models.
 - `set-mode`/`set` route through queue-owner IPC when active, otherwise reconnect directly.

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.26",
-  codex: "^0.0.44",
+  codex: "^1.1.4",
   claude: "^0.37.0",
   mux: "^0.27.0",
 } as const;

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -102,8 +102,8 @@ test("claude built-in uses the current ACP adapter package range", () => {
 });
 
 test("npm-backed built-ins use current adapter package ranges", () => {
-  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^0.0.44");
-  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^0.0.44");
+  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^1.1.4");
+  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^1.1.4");
   assert.equal(AGENT_REGISTRY.pi, "npx pi-acp@^0.0.26");
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fresh launches of the built-in `codex` agent still select the pre-1.0 `@agentclientprotocol/codex-acp@^0.0.44` range even though the current stable adapter release is 1.1.4. This leaves new built-in Codex sessions on an outdated adapter line.

## Why This Change Was Made

Update the ACPX-owned Codex adapter range to `^1.1.4`, keeping the repository's caret-range convention so compatible future 1.x releases can be selected. The registry assertions, changelog, Codex harness documentation, session-control examples, README, and agent-facing skill documentation are kept in sync.

Current codex-acp releases advertise the base `model` and `reasoning_effort` as separate session config options. The updated examples therefore use `gpt-5.6-sol` and `reasoning_effort=max` separately; bracketed combined ids remain a legacy `models` metadata format.

This does not change CLI or ACP interfaces, configuration or persistence formats, `package.json`, or the lockfile. Existing session records retain their original stored command.

## User Impact

Fresh built-in Codex launches now use the current stable 1.x adapter line without requiring a global adapter install. Existing persisted sessions are unchanged. Codex examples now match the current adapter's separate model and reasoning-effort controls.

## Evidence

- `npm view @agentclientprotocol/codex-acp version dist-tags dependencies --json`: `latest=1.1.4`; SDK dependency remains `@agentclientprotocol/sdk@^1.2.1`.
- `npx -y '@agentclientprotocol/codex-acp@^1.1.4' --version`: `@agentclientprotocol/codex-acp 1.1.4`.
- Focused registry test: 1/1 passed.
- Exact-version ACP initialize conformance: 1/1 passed in 2765 ms.
- Isolated unauthenticated launch reached ACP authentication negotiation and returned structured `detailCode=AUTH_REQUIRED`, as expected.
- Authenticated, deny-all live smoke exited 0 and returned exactly `acpx-codex-1.1.4-ok`.
- Read-only `model/list` through the Codex version resolved by codex-acp 1.1.4 confirmed `gpt-5.6-sol` is advertised with `max` reasoning effort; no prompt or thread was created.
- Node 24: `pnpm run check` passed (860/860 main tests and 109/109 coverage-target tests); `pnpm run check:docs` passed; mock conformance smoke passed.
- Local environment note: the first non-isolated full check found a pre-existing `/tmp/.git`, which changed one temporary-path boundary assertion. The focused repro passed with `TMPDIR=/dev/shm`, and the complete isolated rerun passed without source changes.
- Node 22.23.1: `pnpm run test:coverage` passed; `pnpm run mutate` passed with a 90.55% mutation score (threshold 80%, 0 timeouts).
- Slophammer parity passed: rules available, 0 DRY candidates, and no dependency-boundary findings.
- Documentation refresh: `pnpm run check:docs`, targeted oxfmt/markdownlint for `agents/Codex.md` and `skills/acpx/SKILL.md`, and `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`: clean, no accepted/actionable findings.
- Screenshots: not applicable; this is a non-visual built-in adapter range update.

AI-assisted: implemented and fully tested with Codex. I reviewed the resulting seven-file diff and understand the change.