### PR TITLE
chore(agents): refresh built-in adapter ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
-- Agents/built-ins: refresh the default Pi, Codex, Claude, and Mux adapter ranges. Thanks @kelvinschen.
+- Agents/built-ins: refresh the default Pi, Codex, Claude, and Mux adapter ranges. Thanks @kelvinschen and @TheAngryPit.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
-- Agents/built-ins: bump the default `@agentclientprotocol/codex-acp` package range to `^1.1.4` so fresh built-in Codex launches use the current stable adapter line.
+- Agents/built-ins: refresh the default Pi, Codex, Claude, and Mux adapter ranges. Thanks @kelvinschen.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Agents/built-ins: bump the default `@agentclientprotocol/codex-acp` package range to `^1.1.4` so fresh built-in Codex launches use the current stable adapter line.
+
 ### Breaking
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ acpx codex --file - "extra context"            # explicit stdin + appended args
 acpx codex --no-wait 'draft test migration plan' # enqueue without waiting if session is busy
 acpx codex cancel                               # cooperative cancel of in-flight prompt
 acpx codex set-mode auto                        # session/set_mode (adapter-defined mode id)
-acpx codex set model 'gpt-5.2[high]'            # adapter-advertised model control
+acpx codex set model gpt-5.6-sol                # select the advertised base model
+acpx codex set reasoning_effort max             # set the advertised reasoning effort
 acpx exec 'summarize this repo'                # default agent shortcut (codex)
 acpx codex exec 'what does this repo do?'      # one-shot, no saved session
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Built-ins:
 | `kilocode`   | `npx -y @kilocode/cli acp`                                                  | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | native (`kimi acp`)                                                         | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | native (`kiro-cli-chat acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |
-| `mux`        | `npx -y mux@^0.27.0 acp`                                                    | [Mux](https://mux.coder.com)                                                                                    |
+| `mux`        | `mux acp` via an ACPX-owned npm range                                       | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                                                    | [OpenCode](https://opencode.ai)                                                                                 |
 | `qoder`      | native (`qodercli --acp`)                                                   | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | native (`qwen --acp`)                                                       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |

--- a/agents/Codex.md
+++ b/agents/Codex.md
@@ -3,6 +3,7 @@
 - Built-in name: `codex`
 - Default command: `npx -y @agentclientprotocol/codex-acp`
 - Upstream: https://github.com/agentclientprotocol/codex-acp
-- Runtime controls exposed by current codex-acp releases include ACP modes and an advertised model session config option.
-- Reasoning effort is encoded in advertised Codex model ids such as `gpt-5.2[high]` when the adapter reports those variants.
-- `acpx --model <id> codex ...` and `acpx codex set model <id>` apply the requested model through the advertised config option; legacy adapters that advertise `models` use `session/set_model`.
+- ACPX owns the built-in package range so fresh launches use the repository-selected stable adapter line without requiring a global install.
+- Runtime controls exposed by current codex-acp releases include ACP modes plus separate `model` and `reasoning_effort` session config options.
+- Use the advertised base model id with `acpx --model <id> codex ...` or `acpx codex set model <id>`, then set reasoning effort separately with `acpx codex set reasoning_effort <value>`.
+- Legacy `models` metadata may encode both values in a combined id such as `gpt-5.6-sol[max]`; ACPX uses that form only when the adapter does not advertise the newer model config option.

--- a/agents/Mux.md
+++ b/agents/Mux.md
@@ -1,7 +1,7 @@
 # Mux
 
 - Built-in name: `mux`
-- Default command: `npx -y mux@^0.27.0 acp`
+- Default entrypoint: `mux acp` via an ACPX-owned npm range
 - Upstream: https://mux.coder.com/integrations/acp
 
 `acpx mux` starts coder/mux through its ACP stdio bridge (`mux acp`). `mux acp` auto-starts an in-process mux server, so a separate `mux server` is not required.

--- a/agents/README.md
+++ b/agents/README.md
@@ -16,7 +16,7 @@ Built-in agents:
 - `kilocode -> npx -y @kilocode/cli acp`
 - `kimi -> kimi acp`
 - `kiro -> kiro-cli-chat acp`
-- `mux -> npx -y mux@^0.27.0 acp`
+- `mux -> mux acp` via an ACPX-owned npm range
 - `opencode -> npx -y opencode-ai acp`
 - `qoder -> qodercli --acp`
 - `qwen -> qwen --acp`
@@ -36,7 +36,7 @@ Harness-specific docs in this directory:
 - [Kilocode](Kilocode.md): built-in `kilocode -> npx -y @kilocode/cli acp`
 - [Kimi](Kimi.md): built-in `kimi -> kimi acp`
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli-chat acp`
-- [Mux](Mux.md): built-in `mux -> npx -y mux@^0.27.0 acp`
+- [Mux](Mux.md): built-in `mux -> mux acp` via an ACPX-owned npm range
 - [OpenCode](OpenCode.md): built-in `opencode -> npx -y opencode-ai acp`
 - [Qoder](Qoder.md): built-in `qoder -> qodercli --acp`
 - [Qwen](Qwen.md): built-in `qwen -> qwen --acp`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -25,7 +25,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `kilocode`   | `npx -y @kilocode/cli acp`                     | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | `kimi acp`                                     | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | `kiro-cli-chat acp`                            | [Kiro CLI](https://kiro.dev)                                                                                    |
-| `mux`        | `npx -y mux@^0.27.0 acp`                       | [Mux](https://mux.coder.com)                                                                                    |
+| `mux`        | `mux acp` via an ACPX-owned npm range          | [Mux](https://mux.coder.com)                                                                                    |
 | `opencode`   | `npx -y opencode-ai acp`                       | [OpenCode](https://opencode.ai)                                                                                 |
 | `qoder`      | `qodercli --acp`                               | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                                     |
 | `qwen`       | `qwen --acp`                                   | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                                |
@@ -179,7 +179,7 @@ Configure model/provider settings through fast-agent environment variables, fast
 ### Mux
 
 - Built-in name: `mux`
-- Default command: `npx -y mux@^0.27.0 acp`
+- Default entrypoint: `mux acp` via an ACPX-owned npm range
 - Upstream: https://mux.coder.com/integrations/acp
 
 `acpx mux` starts coder/mux through its ACP stdio bridge (`mux acp`). `mux acp` auto-starts an in-process mux server, so a separate `mux server` is not required.

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -54,8 +54,11 @@ Calls ACP `session/set_config_option` with the literal `<key>` and `<value>`. No
 
 `set model <id>` is a special-case interception. `acpx` prefers an advertised model session config option and updates it through `session/set_config_option`. If an adapter explicitly advertises legacy `models` metadata instead, `acpx` preserves compatibility through `session/set_model`.
 
+Current codex-acp releases advertise the base model and reasoning effort as separate config options.
+
 ```bash
-acpx codex set model 'gpt-5.2[high]'
+acpx codex set model gpt-5.6-sol
+acpx codex set reasoning_effort max
 acpx claude set model claude-sonnet-4-6
 ```
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -95,7 +95,7 @@ Friendly agent names resolve to commands:
 - `kilocode` -> `npx -y @kilocode/cli acp`
 - `kimi` -> `kimi acp`
 - `kiro` -> `kiro-cli-chat acp`
-- `mux` -> `npx -y mux@^0.27.0 acp`
+- `mux` -> `mux acp` via an ACPX-owned npm range
 - `opencode` -> `npx -y opencode-ai acp`
 - `qoder` -> `qodercli --acp`
   Forwards Qoder-native `--allowed-tools` and `--max-turns` startup flags from `acpx` session options.

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -83,7 +83,7 @@ Friendly agent names resolve to commands:
 
 - `pi` -> `npx pi-acp`
 - `openclaw` -> `openclaw acp`
-- `codex` -> `npx -y @agentclientprotocol/codex-acp`
+- `codex` -> `npx -y @agentclientprotocol/codex-acp` (ACPX-owned package range)
 - `claude` -> `npx -y @agentclientprotocol/claude-agent-acp` (ACPX-owned package range)
 - `gemini` -> `gemini --acp`
 - `cursor` -> `cursor-agent acp`
@@ -174,8 +174,8 @@ Behavior:
 ```bash
 acpx codex cancel
 acpx codex set-mode auto
-acpx codex set model gpt-5.2[high]
-acpx codex set model gpt-5.4
+acpx codex set model gpt-5.6-sol
+acpx codex set reasoning_effort max
 ```
 
 Behavior:
@@ -184,7 +184,7 @@ Behavior:
 - `set-mode`: calls ACP `session/set_mode`.
 - `set-mode` mode ids are adapter-defined; unsupported values are rejected by the adapter (often `Invalid params`).
 - `set`: calls ACP `session/set_config_option`.
-- For codex, reasoning effort is selected through advertised ACP model ids when the adapter reports model variants.
+- Current codex-acp releases expose `model` and `reasoning_effort` as separate config options.
 - `--model <id>`: Claude-compatible adapters may consume session creation metadata; other agents must advertise a model config option or legacy `models` metadata.
 - `set model <id>`: uses `session/set_config_option` for advertised model config options and preserves `session/set_model` for explicitly advertised legacy models.
 - `set-mode`/`set` route through queue-owner IPC when active, otherwise reconnect directly.

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const ACP_ADAPTER_PACKAGE_RANGES = {
   pi: "^0.0.26",
-  codex: "^0.0.44",
+  codex: "^1.1.4",
   claude: "^0.37.0",
   mux: "^0.27.0",
 } as const;

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ACP_ADAPTER_PACKAGE_RANGES = {
-  pi: "^0.0.26",
-  codex: "^1.1.4",
-  claude: "^0.37.0",
-  mux: "^0.27.0",
+  pi: "^0.0.31",
+  codex: "^1.1.5",
+  claude: "^0.60.0",
+  mux: "^0.28.0",
 } as const;
 
 type BuiltInAgentPackageSpec = {

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -102,8 +102,8 @@ test("claude built-in uses the current ACP adapter package range", () => {
 });
 
 test("npm-backed built-ins use current adapter package ranges", () => {
-  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^0.0.44");
-  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^0.0.44");
+  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^1.1.4");
+  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^1.1.4");
   assert.equal(AGENT_REGISTRY.pi, "npx pi-acp@^0.0.26");
 });
 

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -60,8 +60,8 @@ test("grok-build built-in runs the Grok Build ACP entrypoint", () => {
 });
 
 test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
-  assert.equal(AGENT_REGISTRY.mux, "npx -y mux@^0.27.0 acp");
-  assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.27.0 acp");
+  assert.equal(AGENT_REGISTRY.mux, "npx -y mux@^0.28.0 acp");
+  assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.28.0 acp");
 });
 
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {
@@ -97,14 +97,14 @@ test("default agent is codex", () => {
 });
 
 test("claude built-in uses the current ACP adapter package range", () => {
-  assert.equal(BUILT_IN_AGENT_PACKAGES.claude.packageRange, "^0.37.0");
-  assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.37.0");
+  assert.equal(BUILT_IN_AGENT_PACKAGES.claude.packageRange, "^0.60.0");
+  assert.equal(AGENT_REGISTRY.claude, "npx -y @agentclientprotocol/claude-agent-acp@^0.60.0");
 });
 
 test("npm-backed built-ins use current adapter package ranges", () => {
-  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^1.1.4");
-  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^1.1.4");
-  assert.equal(AGENT_REGISTRY.pi, "npx pi-acp@^0.0.26");
+  assert.equal(BUILT_IN_AGENT_PACKAGES.codex.packageRange, "^1.1.5");
+  assert.equal(AGENT_REGISTRY.codex, "npx -y @agentclientprotocol/codex-acp@^1.1.5");
+  assert.equal(AGENT_REGISTRY.pi, "npx pi-acp@^0.0.31");
 });
 
 test("resolveInstalledBuiltInAgentLaunch uses a locally installed adapter when available", (t) => {

--- a/test/model-support.test.ts
+++ b/test/model-support.test.ts
@@ -18,7 +18,7 @@ test("Claude ACP model validation warns for unadvertised selectors", () => {
         { modelId: "sonnet", name: "Sonnet" },
       ],
     },
-    agentCommand: "npx -y @agentclientprotocol/claude-agent-acp@^0.37.0",
+    agentCommand: "npx -y @agentclientprotocol/claude-agent-acp@^0.60.0",
     context: "apply",
   });
 


### PR DESCRIPTION
Closes #464

Builds on #461 by @kelvinschen. The contributor's Codex commit is preserved as the first authored commit in this branch; the combined refresh is a separate follow-up commit.

## What Problem This Solves

Fresh ACPX built-in launches use repository-owned npm ranges that currently exclude the latest Pi, Codex, Claude, and Mux adapter lines. Codex is still on a pre-1.0 range even though current releases expose the base model and `reasoning_effort` as separate ACP configuration options.

This leaves users on older adapter behavior unless they override the built-in command themselves.

## Why This Change Was Made

Advance the four centralized source-owned ranges to the current npm releases while preserving ACPX's existing architecture:

- `pi-acp` to `^0.0.31`
- `@agentclientprotocol/codex-acp` to `^1.1.5`
- `@agentclientprotocol/claude-agent-acp` to `^0.60.0`
- `mux` to `^0.28.0`

The change keeps built-in names, command routing, installed-package-first resolution, package-exec fallback, queueing, persistence, cancellation, and reconnect behavior unchanged. It does not add the adapters as ACPX dependencies or modify the package manifest or lockfile.

Codex documentation now reflects the adapter's separate `model` and `reasoning_effort` controls. Stale literal Mux ranges were removed from user documentation while keeping the actual range owned by source and tests.

## User Impact

Fresh Pi, Codex, Claude, and Mux built-in launches resolve the current adapter lines without requiring global adapter installs or manual command overrides.

Existing explicit agent-command overrides continue to work. There is no migration, configuration change, new orchestration layer, or production-runtime mutation.

## Evidence

- Live npm metadata and executable contracts revalidated immediately before publication:
  - Pi `0.0.31`
  - Codex `1.1.5`
  - Claude `0.60.0`
  - Mux `0.28.0`
- Focused registry and model tests: 24/24 passed.
- `pnpm run check`: passed formatting, typecheck, lint, builds, full tests, and coverage.
- `pnpm run mutate`: 402 mutants, 90.55% score, no timeouts; threshold 80%.
- `pnpm run check:docs`: passed.
- Slophammer rules, DRY, and dependency-boundary checks: passed.
- `git diff --check` and complete manual branch diff inspection: passed.
- Isolated ACP initialization reached for all four adapters.
- Session creation reached for Claude and Mux.
- Mux postinstall inspected before execution and constrained to its headless path.
- `package.json` and `pnpm-lock.yaml`: unchanged.
- Deslop pass completed without behavior expansion.
- Structured branch Auto Review: one documentation ambiguity corrected; second pass clean with no accepted or actionable findings.

Successful provider responses remain authentication-gated and are not claimed as end-to-end proof. No credentials were copied, printed, or added to the isolated test environments.

## Architecture And Review Process

The operator defined the engineering workflow, architecture boundaries, release selection, contributor-provenance requirement, and publication gates. The implementation followed a specification-first process: inspect upstream and current source, identify the smallest compatible change, preserve native architecture, prove the supported paths, run deslop, then run structured Auto Review.

This PR is AI-assisted. The operator and agent both reviewed the final diff and validation results. The agent executed the bounded implementation and evidence collection under the operator's architecture and release decisions.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted architecture and implementation transcript</summary>

```text
Project: ACPX built-in adapter refresh
Source: sanitized local Codex coordinator and worker sessions
Scope: architecture decisions, implementation boundaries, validation, and review
Omitted: system/developer prompts, reasoning traces, raw tool output, local paths, environment details, credentials, authentication data, and unrelated work

[operator direction, summarized]
Treat this as upstream ACPX maintenance, not a local fork or runtime patch. Create a clean standalone checkout from openclaw/acpx main in the established external-SSD project workspace. Do not modify the ACPX installed for another user or any production harness.

Use a two-stage engineering process. Stage 1 produces the specification after reading current repository instructions, source, tests, changelog, package metadata, and the existing contributor PR. Stage 2 starts only after that review supports a minimal implementation.

Preserve ACPX's current architecture: ACPX owns the built-in adapter ranges and invokes adapters dynamically. Do not turn the adapters into package dependencies, change the lockfile, add an orchestration layer, or replace the native package-exec path.

[operator engineering method, summarized]
Before writing code, establish the destination outcome and inspect how the current implementation, upstream design, documentation, and existing modifications already work. Do not begin with a workaround and then compound fixes around it.

Use the Karpathy-style sequence the operator established for this workspace:

1. make assumptions, constraints, and non-goals explicit;
2. identify the smallest construction that can satisfy the actual outcome;
3. challenge every proposed abstraction, wrapper, dependency, and file change;
4. anchor implementation to reproducible acceptance criteria;
5. inspect the complete diff for scope drift and accidental behavior changes;
6. prove the supported path before claiming completion;
7. run deslop to remove unnecessary agent-generated complexity;
8. run structured Auto Review only after the implementation is already coherent.

The desired result is not merely code that passes tests. It is the simplest upstream-compatible fix that a maintainer can understand, update, or delete later without inheriting a private architecture.

[agent]
The clean upstream checkout matched main at the handoff point. Source review confirmed that the range policy is centralized in the built-in agent registry. Codex and Claude additionally participate in the installed-package/package-exec resolver; Pi and Mux remain registry command entries. No new abstraction was required.

[operator decision, summarized]
Use current releases rather than stale lower bounds. Revalidate npm latest at implementation time. Preserve the contributor's original Codex commit and authorship, then apply any newer lower bound in a separate commit with the other adapter updates.

[agent]
Live registry metadata established the implementation targets:

- pi-acp 0.0.31
- @agentclientprotocol/codex-acp 1.1.5
- @agentclientprotocol/claude-agent-acp 0.60.0
- mux 0.28.0

The existing Codex PR was kept as the first authored commit. A second commit advanced all four source-owned ranges, updated exact assertions, added one combined changelog entry, and synchronized only the behavior-facing documentation supported by current adapter source and runtime metadata.

[architecture boundary]
The final construction deliberately does not change:

- ACPX agent names or command routing
- installed-package-first and package-exec fallback behavior
- persistent-session, queue-owner, cancellation, or reconnect semantics
- package.json or pnpm-lock.yaml
- production configuration, credentials, or globally installed tools

Literal adapter versions remain in source and tests, not user documentation. Stale Mux literals were replaced with a truthful statement that mux acp is the entrypoint and ACPX owns the npm range.

[supply-chain review]
Each candidate's package metadata, executable contract, engine requirements, lifecycle scripts, and resolved version were reviewed in isolation. Mux's postinstall was inspected before execution and constrained to its headless path, which exits before native rebuild or secondary package execution. Disposable homes and caches kept package and ACP checks separate from operator runtime state.

[runtime proof]
Credential-free ACP initialization was reached for all four adapters:

- Pi initialized and reached its authentication boundary.
- Codex 1.1.5 initialized and exposed separate model and reasoning_effort configuration in package source.
- Claude initialized, created a session, preserved project/local setting-source isolation, and reached authentication during prompt execution.
- Mux initialized, created a session in a canonical temporary Git workspace, and reached provider routing during prompt execution.

Successful provider responses were authentication-gated and were not claimed. No credentials were copied, printed, or added to the test environment.

[verification]
The candidate passed:

- focused registry and model tests: 24/24
- full repository check: formatting, typecheck, lint, builds, tests, and coverage
- mutation testing: 402 mutants, 90.55% score, no timeouts
- documentation build and lint
- Slophammer rules, DRY, and dependency-boundary checks
- git diff checks and complete manual diff inspection

The tracked package manifest and lockfile remained unchanged.

[review process]
The deslop pass identified one stale Claude test command and corrected it without expanding behavior. Branch Auto Review then identified one documentation ambiguity: unversioned Mux examples could be mistaken for the literal runtime command. The wording was corrected without violating ACPX's no-literal-range documentation policy. A second Auto Review pass returned no accepted or actionable findings.

[operator governance, summarized]
Follow the maintainer's public workflow: open a problem-first issue, link a focused PR with Closes #issue, explain user impact and proof, disclose AI assistance, preserve contributor provenance, and include only a reviewed redacted transcript. The operator owns architecture, release selection, scope, and publication decisions; the agent owns bounded implementation and evidence collection.

The final public record should therefore show both layers of authorship accurately: the operator designed the engineering workflow, architecture boundaries, release policy, and review gates; the agent executed the bounded source change and collected proof under that design.
```

</details>
<!-- agent-transcript:end -->
