### PR TITLE
Add Junie as a built-in agent (`junie --acp true`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Repo: https://github.com/openclaw/acpx
 ### Changes
 
 - Agents/built-ins: refresh the default Pi, Codex, Claude, and Mux adapter ranges. Thanks @kelvinschen and @TheAngryPit.
+- Agents/built-ins: add JetBrains Junie as a built-in agent via `junie --acp true`.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Built-ins:
 | `fast-agent` | `uvx fast-agent-mcp acp`                                                    | [fast-agent](https://fast-agent.ai)                                                                             |
 | `grok-build` | native (`grok agent stdio`)                                                 | [Grok Build](https://docs.x.ai/build/overview)                                                                  |
 | `iflow`      | native (`iflow --experimental-acp`)                                         | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                              |
+| `junie`      | native (`junie --acp true`)                                                 | [JetBrains Junie CLI](https://www.jetbrains.com/junie/)                                                         |
 | `kilocode`   | `npx -y @kilocode/cli acp`                                                  | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | native (`kimi acp`)                                                         | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | native (`kiro-cli-chat acp`)                                                | [Kiro CLI](https://kiro.dev)                                                                                    |

--- a/agents/Junie.md
+++ b/agents/Junie.md
@@ -1,0 +1,14 @@
+# Junie
+
+- Built-in name: `junie`
+- Default command: `junie --acp true`
+- Upstream: [JetBrains Junie](https://www.jetbrains.com/junie/)
+
+`acpx junie` launches the locally installed JetBrains Junie CLI in ACP stdio mode (`junie --acp true`). Junie must already be installed and authenticated; `acpx` never downloads or installs Junie for you. See the Junie CLI install and authentication docs for setup.
+
+```bash
+acpx junie exec "review the current changes"
+acpx --cwd /path/to/project junie exec "analyze this project"
+```
+
+If `junie` is not installed or not on `PATH`, `acpx` fails with the standard `acpx` missing-command error. Install the Junie CLI from [JetBrains Junie](https://www.jetbrains.com/junie/) and authenticate before using it with `acpx`.

--- a/agents/README.md
+++ b/agents/README.md
@@ -13,6 +13,7 @@ Built-in agents:
 - `fast-agent -> uvx fast-agent-mcp acp`
 - `grok-build -> grok agent stdio`
 - `iflow -> iflow --experimental-acp`
+- `junie -> junie --acp true`
 - `kilocode -> npx -y @kilocode/cli acp`
 - `kimi -> kimi acp`
 - `kiro -> kiro-cli-chat acp`
@@ -33,6 +34,7 @@ Harness-specific docs in this directory:
 - [fast-agent](FastAgent.md): built-in `fast-agent -> uvx fast-agent-mcp acp`
 - [Grok Build](GrokBuild.md): built-in `grok-build -> grok agent stdio`
 - [iFlow](Iflow.md): built-in `iflow -> iflow --experimental-acp`
+- [Junie](Junie.md): built-in `junie -> junie --acp true`
 - [Kilocode](Kilocode.md): built-in `kilocode -> npx -y @kilocode/cli acp`
 - [Kimi](Kimi.md): built-in `kimi -> kimi acp`
 - [Kiro](Kiro.md): built-in `kiro -> kiro-cli-chat acp`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -22,6 +22,7 @@ The default agent for top-level commands like `acpx exec â€¦` and `acpx prompt â
 | `fast-agent` | `uvx fast-agent-mcp acp`                       | [fast-agent](https://fast-agent.ai/)                                                                            |
 | `grok-build` | `grok agent stdio`                             | [Grok Build](https://docs.x.ai/build/overview)                                                                  |
 | `iflow`      | `iflow --experimental-acp`                     | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                                                              |
+| `junie`      | `junie --acp true`                             | [JetBrains Junie CLI](https://www.jetbrains.com/junie/)                                                         |
 | `kilocode`   | `npx -y @kilocode/cli acp`                     | [Kilocode](https://kilocode.ai)                                                                                 |
 | `kimi`       | `kimi acp`                                     | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli)                                                              |
 | `kiro`       | `kiro-cli-chat acp`                            | [Kiro CLI](https://kiro.dev)                                                                                    |
@@ -157,6 +158,14 @@ Configure model/provider settings through fast-agent environment variables, fast
 - Built-in name: `iflow`
 - Default command: `iflow --experimental-acp`
 - Upstream: [iflow-ai/iflow-cli](https://github.com/iflow-ai/iflow-cli)
+
+### Junie
+
+- Built-in name: `junie`
+- Default command: `junie --acp true`
+- Upstream: [JetBrains Junie CLI](https://www.jetbrains.com/junie/)
+
+`acpx junie` launches the locally installed JetBrains Junie CLI in ACP stdio mode. Junie must already be installed and authenticated; `acpx` never installs it for you.
 
 ### Kilocode
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -92,6 +92,7 @@ Friendly agent names resolve to commands:
 - `fast-agent` -> `uvx fast-agent-mcp acp`
 - `grok-build` -> `grok agent stdio`
 - `iflow` -> `iflow --experimental-acp`
+- `junie` -> `junie --acp true`
 - `kilocode` -> `npx -y @kilocode/cli acp`
 - `kimi` -> `kimi acp`
 - `kiro` -> `kiro-cli-chat acp`

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -48,6 +48,7 @@ export const AGENT_REGISTRY: Record<string, string> = {
   "fast-agent": "uvx fast-agent-mcp acp",
   "grok-build": "grok agent stdio",
   iflow: "iflow --experimental-acp",
+  junie: "junie --acp true",
   kilocode: "npx -y @kilocode/cli acp",
   kimi: "kimi acp",
   kiro: "kiro-cli-chat acp",

--- a/test/agent-registry.test.ts
+++ b/test/agent-registry.test.ts
@@ -7,6 +7,7 @@ import {
   AGENT_REGISTRY,
   BUILT_IN_AGENT_PACKAGES,
   DEFAULT_AGENT_NAME,
+  findBuiltInAgentPackage,
   listBuiltInAgents,
   resolveBuiltInAgentLaunch,
   resolveInstalledBuiltInAgentLaunch,
@@ -64,6 +65,22 @@ test("mux built-in runs the coder/mux ACP stdio bridge through npx", () => {
   assert.equal(resolveAgentCommand("mux"), "npx -y mux@^0.28.0 acp");
 });
 
+test("junie built-in launches the native ACP stdio server", () => {
+  assert.equal(AGENT_REGISTRY.junie, "junie --acp true");
+  assert.equal(resolveAgentCommand("junie"), "junie --acp true");
+});
+
+test("junie is a native agent and is not routed through an npm adapter package", () => {
+  assert.equal(findBuiltInAgentPackage(AGENT_REGISTRY.junie), undefined);
+  assert.equal(resolveInstalledBuiltInAgentLaunch(AGENT_REGISTRY.junie), undefined);
+  assert.equal(resolveBuiltInAgentLaunch(AGENT_REGISTRY.junie), undefined);
+});
+
+test("junie resolves case-insensitively and ignores surrounding whitespace", () => {
+  assert.equal(resolveAgentCommand("JUNIE"), "junie --acp true");
+  assert.equal(resolveAgentCommand("  Junie  "), "junie --acp true");
+});
+
 test("listBuiltInAgents preserves the required example prefix and alphabetical tail", () => {
   const agents = listBuiltInAgents();
   assert.deepEqual(agents, Object.keys(AGENT_REGISTRY));
@@ -81,6 +98,7 @@ test("listBuiltInAgents preserves the required example prefix and alphabetical t
     "fast-agent",
     "grok-build",
     "iflow",
+    "junie",
     "kilocode",
     "kimi",
     "kiro",

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -929,6 +929,33 @@ test("integration: built-in qoder agent resolves to qodercli --acp", async () =>
   });
 });
 
+test("integration: built-in junie agent resolves to junie --acp true", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const fakeBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fake-junie-"));
+
+    try {
+      await writeFakeJunieAgent(fakeBinDir);
+
+      const result = await runCli(
+        ["--approve-all", "--cwd", cwd, "--format", "quiet", "junie", "exec", "echo hello"],
+        homeDir,
+        {
+          env: {
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /hello/);
+    } finally {
+      await fs.rm(fakeBinDir, { recursive: true, force: true });
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: qoder session reuse preserves persisted startup flags", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
@@ -4512,6 +4539,40 @@ async function writeFakeIflowAgent(binDir: string): Promise<void> {
       "#!/bin/sh",
       'if [ "$1" = "--experimental-acp" ]; then',
       "  shift",
+      "fi",
+      `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
+      "",
+    ].join("\n"),
+    { encoding: "utf8", mode: 0o755 },
+  );
+}
+
+async function writeFakeJunieAgent(binDir: string): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      path.join(binDir, "junie.cmd"),
+      [
+        "@echo off",
+        "setlocal",
+        'if "%~1"=="--acp" shift',
+        'if "%~1"=="true" shift',
+        `"${process.execPath}" "${MOCK_AGENT_PATH}" %*`,
+        "",
+      ].join("\r\n"),
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  await fs.writeFile(
+    path.join(binDir, "junie"),
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "--acp" ]; then',
+      "  shift",
+      '  if [ "$1" = "true" ]; then',
+      "    shift",
+      "  fi",
       "fi",
       `exec "${process.execPath}" "${MOCK_AGENT_PATH}" "$@"`,
       "",


### PR DESCRIPTION
feat: add JetBrains Junie as a built-in agent

What Problem This Solves
Users who work with JetBrains Junie could not target it directly through acpx — there was no junie built-in agent, so acpx junie ... did not resolve to a known harness. This change adds Junie to the built-in agent registry so it is available as a first-class native agent alongside the other supported harnesses in the acpx CLI.

Why This Change Was Made
Junie already ships a compliant ACP stdio mode junie --acp true and its ACP adapter correctly advertises persistent-session capabilities loadSession + sessionCapabilities.resume, so it works over the standard native ACP path with no adapter package and no agent-specific glue in src/acp/client.ts. The change is intentionally minimal: register the launch command and update the documentation surfaces required by repo policy. Non-goal: no changes to docs/CLI.md main-landing docs stay impartial and only name pi, openclaw, codex, claude, and no adapter version specifiers in docs.

User Impact
Users can now run Junie directly through acpx, for example:

acpx junie exec 'echo hello'
acpx junie sessions new --name docs
acpx junie -s docs 'rewrite CLI docs'

Named sessions reopen across processes persistent mode because acpx detects Junie's capabilities automatically. Junie must be installed and authenticated locally — acpx never installs it. The one intentional limitation is that exec/prompt without a named session is one-shot by design.

Evidence
• test/agent-registry.test.ts: resolution junie, JUNIE, whitespace, "native, not via adapter", and presence in listBuiltInAgents.
• test/integration.test.ts: writeFakeJunieAgent helper + e2e test that acpx junie exec 'echo hello' resolves to junie --acp true and returns exit code 0 with hello output.
• pnpm run check format, typecheck, lint, build, viewer build, coverage tests passes; pnpm run check:docs passes.