### PR TITLE
fix(session): prevent saves failing for long session IDs

### DIFF
--- a/src/session/persistence/atomic-write.ts
+++ b/src/session/persistence/atomic-write.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 
 export function createAtomicWriteTempPath(
   filePath: string,
   createUniqueId: () => string = randomUUID,
 ): string {
-  return `${filePath}.${process.pid}.${Date.now()}.${createUniqueId()}.tmp`;
+  const tempName = `.acpx-write.${process.pid}.${Date.now()}.${createUniqueId()}.tmp`;
+  return path.join(path.dirname(filePath), tempName);
 }

--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -21,3 +21,14 @@ test("atomic write temp paths stay distinct within the same millisecond", () => 
     Date.now = originalNow;
   }
 });
+
+test("atomic write temp paths preserve valid long destination basenames", () => {
+  const destination = path.join("/tmp", `${"x".repeat(220)}.json`);
+  const tempPath = createAtomicWriteTempPath(
+    destination,
+    () => "12345678-1234-1234-1234-123456789abc",
+  );
+
+  assert.equal(path.dirname(tempPath), path.dirname(destination));
+  assert.ok(Buffer.byteLength(path.basename(tempPath)) <= 255);
+});


### PR DESCRIPTION
Related: #447

## What Problem This Solves

Fixes an issue where users with long but valid ACPX session identifiers could see session persistence fail with `ENAMETOOLONG` after the collision fix in #447. Appending PID, timestamp, and UUID to the full destination basename can exceed the common 255-byte filesystem component limit even when the destination itself is valid.

## Why This Change Was Made

Atomic writes now create a bounded sibling temporary basename in the destination directory. This preserves same-filesystem atomic rename behavior, PID/timestamp diagnostics, and per-write UUID uniqueness without extending the destination basename.

## User Impact

Long valid session identifiers remain persistable while concurrent writes continue to use collision-resistant temporary paths.

## Evidence

- Before the fix, the new regression test fails because the generated basename exceeds 255 bytes.
- After the fix, both atomic-write regression tests pass.
- `TMPDIR=/var/tmp PATH=/tmp/codex-corepack-bin:$PATH corepack pnpm run check` passes:
  - 885 regular tests
  - 111 coverage tests
  - formatting, typecheck, lint, build, viewer checks, and coverage thresholds
- `codex review --base upstream/main` reported no findings.

## Real behavior proof

**Behavior or issue addressed:** A valid 220-byte session identifier must remain writable through the real file session store while concurrent writes use distinct temporary files.

**Real environment tested:** Linux x86_64 checkout of this branch using Node 24.18.0 and pnpm 10.34.5. The probe imported the built production `createFileSessionStore` implementation directly; it did not use mocks or snapshots.

**Exact steps or command run after this patch:**

1. Built the production runtime with `corepack pnpm run build`.
2. Created a temporary ACPX state directory.
3. Froze `Date.now()` so all writes shared one millisecond.
4. Used a 220-byte `acpxRecordId`.
5. Ran 400 concurrent `store.save(record)` calls.
6. Loaded the session through the public store and checked for leftover `.tmp` files.

**Evidence after fix:**

```text
{"saves":400,"sessionIdBytes":220,"loaded":true,"tempFiles":0,"jsonFiles":1}
```

**Observed result after fix:** All 400 writes completed without an exception. The long-ID session remained readable, exactly one JSON destination remained, and no temporary files leaked.

**What was not tested:** Windows and macOS were not tested locally. The same-directory and basename-length behavior is covered through Node's platform path API and CI can provide cross-platform validation.

## AI-assisted disclosure

This PR is AI-assisted. I reviewed the implementation and understand that only the private temporary basename changes; the destination path, atomic rename boundary, and UUID uniqueness remain unchanged.
