### PR TITLE
fix: harden adapter and queue-owner lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/status: report a normal cold-start session as `agent starting` while preserving `needs reconnect` for an unreachable live owner. Thanks @guettli.
 
+- Runtime/agents: terminate the owned adapter process group/tree during normal and failed startup cleanup so package-exec wrappers cannot leave descendants running after ACPX exits.
+
 ## 2026.7.23 (v0.12.1)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Repo: https://github.com/openclaw/acpx
   best-effort tracked process trees on Windows during normal and failed startup
   cleanup so package-exec wrappers do not leave captured descendants running
   after ACPX exits; exit-triggered snapshots are observed before cleanup
-  completes, owned POSIX group members created during shutdown are discovered,
-  external process-list discovery is bounded, and remembered descendants are
+  completes, owned POSIX group members created during shutdown are discovered
+  and re-signaled during forced cleanup, external process-list discovery is
+  bounded, and Windows parent edges plus remembered descendants are
   identity-checked before later signaling.
 
 - Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Repo: https://github.com/openclaw/acpx
   best-effort tracked process trees on Windows during normal and failed startup
   cleanup so package-exec wrappers do not leave captured descendants running
   after ACPX exits; exit-triggered snapshots are observed before cleanup
-  completes, external process-list discovery is bounded, and remembered
-  descendants are identity-checked before later signaling.
+  completes, owned POSIX group members created during shutdown are discovered,
+  external process-list discovery is bounded, and remembered descendants are
+  identity-checked before later signaling.
 
 - Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed
   locks during collisions, serialize generation-checked refresh and release,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,25 @@ Repo: https://github.com/openclaw/acpx
   best-effort tracked process trees on Windows during normal and failed startup
   cleanup so package-exec wrappers do not leave captured descendants running
   after ACPX exits; exit-triggered snapshots are observed before cleanup
-  completes, owned POSIX group members created during shutdown are discovered
-  and re-signaled during forced cleanup, external process-list discovery is
-  bounded, and Windows parent edges plus remembered descendants are
-  identity-checked before later signaling.
+  completes, POSIX descendants are captured before signaling so later session
+  or group changes cannot escape forced cleanup, owned POSIX group members
+  created during shutdown are discovered and re-signaled, external process-list
+  discovery is bounded, Linux process identities come from procfs, other POSIX
+  snapshots use a fixed locale, Windows wrappers are sampled with bounded
+  exponential backoff through multi-stage launches, transient discovery
+  failures preserve and still signal captured targets, and Windows parent edges
+  plus remembered descendants are identity-checked before later signaling.
 
 - Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed
-  locks during collisions, serialize generation-checked refresh and release,
-  and treat only a fresh lease-before-bind owner as a fast startup miss,
-  preventing premature `QUEUE_NOT_ACCEPTING_REQUESTS` errors without masking
-  older unreachable owners, letting released owners overwrite successors, or
-  leaving stale dangling-symlink locks unrecoverable.
+  locks during collisions, serialize cross-process refresh, release, and stale
+  cleanup through inode-qualified, crash-recoverable claims, retry explicit
+  cleanup across heartbeat contention while making unresolved explicit cleanup
+  fail visibly, reacquire atomically with fresh timestamps after retiring a
+  stale collision, and treat only a fresh, live lease-before-bind owner as a
+  fast startup miss, preventing premature
+  `QUEUE_NOT_ACCEPTING_REQUESTS` errors without masking older unreachable
+  owners, letting released owners overwrite successors, or leaving stale
+  dangling-symlink locks unrecoverable.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Runtime/agents: terminate owned adapter process groups on POSIX and
+  best-effort tracked process trees on Windows during normal and failed startup
+  cleanup so package-exec wrappers do not leave captured descendants running
+  after ACPX exits.
+
+- Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed
+  locks during collisions, and treat only a fresh lease-before-bind owner as a
+  fast startup miss, preventing premature `QUEUE_NOT_ACCEPTING_REQUESTS` errors
+  without masking older unreachable owners.
+
 ## 2026.7.27 (v0.13.0)
 
 ### Highlights
@@ -44,10 +54,6 @@ Repo: https://github.com/openclaw/acpx
 - Runtime/sessions: use collision-resistant temporary paths for concurrent atomic session and index writes. Thanks @henkterharmsel.
 
 - CLI/status: report a normal cold-start session as `agent starting` while preserving `needs reconnect` for an unreachable live owner. Thanks @guettli.
-
-- Runtime/agents: terminate owned adapter process groups on POSIX and best-effort tracked process trees on Windows during normal and failed startup cleanup so package-exec wrappers do not leave captured descendants running after ACPX exits.
-
-- Runtime/queue: treat a cold-start owner lease that has not bound its socket yet as a startup miss without a second health probe, allowing the caller to recover instead of reporting `QUEUE_NOT_ACCEPTING_REQUESTS`.
 
 ## 2026.7.23 (v0.12.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,15 @@ Repo: https://github.com/openclaw/acpx
   best-effort tracked process trees on Windows during normal and failed startup
   cleanup so package-exec wrappers do not leave captured descendants running
   after ACPX exits; exit-triggered snapshots are observed before cleanup
-  completes, and external process-list discovery is bounded.
+  completes, external process-list discovery is bounded, and remembered
+  descendants are identity-checked before later signaling.
 
 - Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed
   locks during collisions, serialize generation-checked refresh and release,
   and treat only a fresh lease-before-bind owner as a fast startup miss,
   preventing premature `QUEUE_NOT_ACCEPTING_REQUESTS` errors without masking
-  older unreachable owners or letting released owners overwrite successors.
+  older unreachable owners, letting released owners overwrite successors, or
+  leaving stale dangling-symlink locks unrecoverable.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,21 +20,23 @@ Repo: https://github.com/openclaw/acpx
   or group changes cannot escape forced cleanup, owned POSIX group members
   created during shutdown are discovered and re-signaled, external process-list
   discovery is bounded, Linux process identities come from procfs, other POSIX
-  snapshots use a fixed locale, Windows wrappers are sampled with bounded
-  exponential backoff through multi-stage launches, transient discovery
+  snapshots use a fixed locale, adapter wrappers are sampled with bounded
+  exponential backoff through multi-stage launches, escaped descendants are
+  extended from identity-validated parents after root exit, transient discovery
   failures preserve and still signal captured targets, and Windows parent edges
   plus remembered descendants are identity-checked before later signaling.
 
 - Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed
   locks during collisions, serialize cross-process refresh, release, and stale
-  cleanup through inode-qualified, crash-recoverable claims, retry explicit
-  cleanup across heartbeat contention while making unresolved explicit cleanup
-  fail visibly, reacquire atomically with fresh timestamps after retiring a
-  stale collision, and treat only a fresh, live lease-before-bind owner as a
-  fast startup miss, preventing premature
-  `QUEUE_NOT_ACCEPTING_REQUESTS` errors without masking older unreachable
-  owners, letting released owners overwrite successors, or leaving stale
-  dangling-symlink locks unrecoverable.
+  cleanup through inode-qualified, crash-recoverable claims, revalidate stale
+  owners while holding cleanup claims, retry explicit cleanup across heartbeat
+  contention while making unresolved explicit cleanup fail visibly, reacquire
+  atomically with fresh timestamps after retiring a stale collision, and treat
+  only a fresh, live lease-before-bind owner as a fast startup miss while
+  retaining a retry window that covers the full startup grace period, preventing
+  premature `QUEUE_NOT_ACCEPTING_REQUESTS` errors without masking older
+  unreachable owners, letting released owners overwrite successors, or leaving
+  stale dangling-symlink locks unrecoverable.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ Repo: https://github.com/openclaw/acpx
 - Runtime/agents: terminate owned adapter process groups on POSIX and
   best-effort tracked process trees on Windows during normal and failed startup
   cleanup so package-exec wrappers do not leave captured descendants running
-  after ACPX exits.
+  after ACPX exits; exit-triggered snapshots are observed before cleanup
+  completes, and external process-list discovery is bounded.
 
 - Runtime/queue: publish queue-owner leases atomically, preserve fresh malformed
-  locks during collisions, and treat only a fresh lease-before-bind owner as a
-  fast startup miss, preventing premature `QUEUE_NOT_ACCEPTING_REQUESTS` errors
-  without masking older unreachable owners.
+  locks during collisions, serialize generation-checked refresh and release,
+  and treat only a fresh lease-before-bind owner as a fast startup miss,
+  preventing premature `QUEUE_NOT_ACCEPTING_REQUESTS` errors without masking
+  older unreachable owners or letting released owners overwrite successors.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ Repo: https://github.com/openclaw/acpx
 
 - CLI/status: report a normal cold-start session as `agent starting` while preserving `needs reconnect` for an unreachable live owner. Thanks @guettli.
 
-- Runtime/agents: terminate the owned adapter process group/tree during normal and failed startup cleanup so package-exec wrappers cannot leave descendants running after ACPX exits.
+- Runtime/agents: terminate owned adapter process groups on POSIX and best-effort tracked process trees on Windows during normal and failed startup cleanup so package-exec wrappers do not leave captured descendants running after ACPX exits.
+
+- Runtime/queue: treat a cold-start owner lease that has not bound its socket yet as a startup miss without a second health probe, allowing the caller to recover instead of reporting `QUEUE_NOT_ACCEPTING_REQUESTS`.
 
 ## 2026.7.23 (v0.12.1)
 

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -174,12 +174,14 @@ export function buildAgentSpawnOptions(
   sessionEnv?: Record<string, string>,
 ): {
   cwd: string;
+  detached: true;
   env: NodeJS.ProcessEnv;
   stdio: ["pipe", "pipe", "pipe"];
   windowsHide: true;
 } {
   return {
     cwd,
+    detached: true,
     env: buildAgentEnvironment(authCredentials, sessionEnv),
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -108,6 +108,7 @@ import {
   type SessionModelState,
 } from "./model-support.js";
 import {
+  beginProcessTreeTracking,
   captureProcessTreePids,
   createManagedProcessTree,
   rememberProcessTreePids,
@@ -751,6 +752,7 @@ export class AcpClient {
     } catch (error) {
       throw new AgentSpawnError(this.options.agentCommand, error);
     }
+    beginProcessTreeTracking(processTree);
     return requireAgentStdio(spawnedChild);
   }
 
@@ -1412,8 +1414,9 @@ export class AcpClient {
   ): Promise<void> {
     const processTree = this.agentProcessTree ?? createManagedProcessTree(child.pid, true);
     const stdinCloseGraceMs = resolveAgentCloseAfterStdinEndMs(this.options.agentCommand);
-    await captureProcessTreePids(processTree, isChildProcessRunning(child));
+    const processTreeSnapshot = captureProcessTreePids(processTree, isChildProcessRunning(child));
     this.endAgentStdin(child);
+    await processTreeSnapshot;
     let exited = await waitForProcessTreeExit(
       processTree,
       () => isChildProcessRunning(child),

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -108,6 +108,14 @@ import {
   type SessionModelState,
 } from "./model-support.js";
 import {
+  captureProcessTreePids,
+  createManagedProcessTree,
+  rememberProcessTreePids,
+  signalProcessTree,
+  waitForProcessTreeExit,
+  type ManagedProcessTree,
+} from "./process-tree.js";
+import {
   formatSessionControlAcpSummary,
   maybeWrapSessionControlError,
 } from "./session-control-errors.js";
@@ -410,6 +418,7 @@ export class AcpClient {
   private options: AcpClientOptions;
   private connection?: ClientSideConnection;
   private agent?: ChildProcessByStdio<Writable, Readable, Readable>;
+  private agentProcessTree?: ManagedProcessTree;
   private initResult?: InitializeResponse;
   private loadedSessionId?: string;
   private eventHandlers: Pick<
@@ -732,6 +741,11 @@ export class AcpClient {
       ...plan.spawnOptions,
       windowsVerbatimArguments: spawnCommand.windowsVerbatimArguments,
     }) as ChildProcessByStdio<Writable, Readable, Readable>;
+    const processTree = createManagedProcessTree(spawnedChild.pid, true);
+    this.agentProcessTree = processTree;
+    spawnedChild.once("exit", () => {
+      rememberProcessTreePids(processTree);
+    });
     try {
       await waitForSpawn(spawnedChild);
     } catch (error) {
@@ -856,7 +870,7 @@ export class AcpClient {
       params.startupStderr,
     );
     try {
-      params.child.kill();
+      await this.terminateAgentProcess(params.child);
     } catch {
       // best effort
     }
@@ -1390,18 +1404,37 @@ export class AcpClient {
     this.initResult = undefined;
     this.connection = undefined;
     this.agent = undefined;
+    this.agentProcessTree = undefined;
   }
 
   private async terminateAgentProcess(
     child: ChildProcessByStdio<Writable, Readable, Readable>,
   ): Promise<void> {
+    const processTree = this.agentProcessTree ?? createManagedProcessTree(child.pid, true);
     const stdinCloseGraceMs = resolveAgentCloseAfterStdinEndMs(this.options.agentCommand);
+    await captureProcessTreePids(processTree, isChildProcessRunning(child));
     this.endAgentStdin(child);
-    let exited = await waitForChildExit(child, stdinCloseGraceMs);
-    exited = await this.killAgentIfRunning(child, exited, "SIGTERM", AGENT_CLOSE_TERM_GRACE_MS);
+    let exited = await waitForProcessTreeExit(
+      processTree,
+      () => isChildProcessRunning(child),
+      stdinCloseGraceMs,
+    );
+    exited = await this.killAgentIfRunning(
+      child,
+      processTree,
+      exited,
+      "SIGTERM",
+      AGENT_CLOSE_TERM_GRACE_MS,
+    );
     if (!exited) {
       this.log(`agent did not exit after ${AGENT_CLOSE_TERM_GRACE_MS}ms; forcing SIGKILL`);
-      exited = await this.killAgentIfRunning(child, exited, "SIGKILL", AGENT_CLOSE_KILL_GRACE_MS);
+      exited = await this.killAgentIfRunning(
+        child,
+        processTree,
+        exited,
+        "SIGKILL",
+        AGENT_CLOSE_KILL_GRACE_MS,
+      );
     }
 
     // Ensure stdio handles don't keep this process alive after close() returns.
@@ -1422,19 +1455,20 @@ export class AcpClient {
 
   private async killAgentIfRunning(
     child: ChildProcessByStdio<Writable, Readable, Readable>,
+    processTree: ManagedProcessTree,
     alreadyExited: boolean,
     signal: NodeJS.Signals,
     waitMs: number,
   ): Promise<boolean> {
-    if (alreadyExited || !isChildProcessRunning(child)) {
-      return alreadyExited;
+    if (alreadyExited) {
+      return true;
     }
     try {
-      child.kill(signal);
+      await signalProcessTree(processTree, isChildProcessRunning(child), signal);
     } catch {
       // best effort
     }
-    return await waitForChildExit(child, waitMs);
+    return await waitForProcessTreeExit(processTree, () => isChildProcessRunning(child), waitMs);
   }
 
   private detachAgentHandles(agent: ChildProcess, unref: boolean): void {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1471,7 +1471,12 @@ export class AcpClient {
     } catch {
       // best effort
     }
-    return await waitForProcessTreeExit(processTree, () => isChildProcessRunning(child), waitMs);
+    return await waitForProcessTreeExit(
+      processTree,
+      () => isChildProcessRunning(child),
+      waitMs,
+      signal === "SIGKILL" ? signal : undefined,
+    );
   }
 
   private detachAgentHandles(agent: ChildProcess, unref: boolean): void {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -738,21 +738,27 @@ export class AcpClient {
       process.platform,
       plan.spawnOptions.env,
     );
+    const rootCreatedAfterMs = Date.now();
     const spawnedChild = spawn(spawnCommand.command, spawnCommand.args, {
       ...plan.spawnOptions,
       windowsVerbatimArguments: spawnCommand.windowsVerbatimArguments,
     }) as ChildProcessByStdio<Writable, Readable, Readable>;
-    const processTree = createManagedProcessTree(spawnedChild.pid, true);
+    const processTree = createManagedProcessTree(
+      spawnedChild.pid,
+      true,
+      process.platform,
+      rootCreatedAfterMs,
+    );
     this.agentProcessTree = processTree;
     spawnedChild.once("exit", () => {
       rememberProcessTreePids(processTree);
     });
+    beginProcessTreeTracking(processTree, () => isChildProcessRunning(spawnedChild));
     try {
       await waitForSpawn(spawnedChild);
     } catch (error) {
       throw new AgentSpawnError(this.options.agentCommand, error);
     }
-    beginProcessTreeTracking(processTree);
     return requireAgentStdio(spawnedChild);
   }
 

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -3,9 +3,9 @@ import fs from "node:fs/promises";
 
 const PROCESS_TREE_POLL_MS = 25;
 const PROCESS_LIST_COMMAND_TIMEOUT_MS = 1_000;
-const WINDOWS_TRACKING_INITIAL_POLL_MS = 25;
-const WINDOWS_TRACKING_MAX_POLL_MS = 1_000;
-const WINDOWS_TRACKING_MAX_DURATION_MS = 10_000;
+const PROCESS_TREE_TRACKING_INITIAL_POLL_MS = 25;
+const PROCESS_TREE_TRACKING_MAX_POLL_MS = 1_000;
+const PROCESS_TREE_TRACKING_MAX_DURATION_MS = 10_000;
 const WINDOWS_EPOCH_OFFSET_TICKS = 621_355_968_000_000_000n;
 
 export type ManagedProcessTree = {
@@ -61,9 +61,10 @@ export function beginProcessTreeTracking(
   tree: ManagedProcessTree,
   rootRunning: () => boolean,
 ): void {
-  if (tree.platform === "win32") {
-    queueWindowsProcessTreeTracking(tree, rootRunning);
+  if (!tree.killProcessGroup || !tree.rootPid) {
+    return;
   }
+  queueProcessTreeTracking(tree, rootRunning);
 }
 
 export async function captureProcessTreePids(
@@ -99,17 +100,14 @@ function queueProcessTreeSnapshot(tree: ManagedProcessTree): void {
   })();
 }
 
-function queueWindowsProcessTreeTracking(
-  tree: ManagedProcessTree,
-  rootRunning: () => boolean,
-): void {
+function queueProcessTreeTracking(tree: ManagedProcessTree, rootRunning: () => boolean): void {
   const priorSnapshot = tree.snapshotPromise;
   tree.snapshotPromise = (async () => {
     await priorSnapshot?.catch(() => {
       // Tracking can continue after an earlier best-effort snapshot failure.
     });
-    const deadline = Date.now() + WINDOWS_TRACKING_MAX_DURATION_MS;
-    let pollMs = WINDOWS_TRACKING_INITIAL_POLL_MS;
+    const deadline = Date.now() + PROCESS_TREE_TRACKING_MAX_DURATION_MS;
+    let pollMs = PROCESS_TREE_TRACKING_INITIAL_POLL_MS;
     while (rootRunning() && Date.now() < deadline) {
       const descendantCount = tree.descendantPids.size;
       await recordCurrentProcessTreePids(tree);
@@ -117,8 +115,8 @@ function queueWindowsProcessTreeTracking(
         await waitMs(pollMs);
         pollMs =
           tree.descendantPids.size > descendantCount
-            ? WINDOWS_TRACKING_INITIAL_POLL_MS
-            : Math.min(pollMs * 2, WINDOWS_TRACKING_MAX_POLL_MS);
+            ? PROCESS_TREE_TRACKING_INITIAL_POLL_MS
+            : Math.min(pollMs * 2, PROCESS_TREE_TRACKING_MAX_POLL_MS);
       }
     }
   })();
@@ -220,7 +218,7 @@ export async function waitForProcessTreeExit(
       }
       rootIsRunning = rootRunning();
     }
-    if (!rootIsRunning && !hasLiveManagedProcessTree(tree, rootIsRunning)) {
+    if (shouldRefreshExitedTree(tree, rootIsRunning, finalSignal)) {
       if (await exitedTreeRemainsEmptyAfterRefresh(tree, finalSignal, signaledIdentities)) {
         return true;
       }
@@ -230,6 +228,14 @@ export async function waitForProcessTreeExit(
     }
     await waitMs(Math.min(PROCESS_TREE_POLL_MS, Math.max(0, deadline - Date.now())));
   }
+}
+
+function shouldRefreshExitedTree(
+  tree: ManagedProcessTree,
+  rootIsRunning: boolean,
+  finalSignal: NodeJS.Signals | undefined,
+): boolean {
+  return !rootIsRunning && Boolean(finalSignal || !hasLiveManagedProcessTree(tree, false));
 }
 
 async function waitForPriorSnapshotBeforeDeadline(
@@ -262,12 +268,12 @@ async function exitedTreeRemainsEmptyAfterRefresh(
     return true;
   }
   if (finalSignal) {
-    signalNewlyDiscoveredProcessPids(tree, finalSignal, signaledIdentities);
+    signalUnsignaledProcessPids(tree, finalSignal, signaledIdentities);
   }
   return false;
 }
 
-function signalNewlyDiscoveredProcessPids(
+function signalUnsignaledProcessPids(
   tree: ManagedProcessTree,
   signal: NodeJS.Signals,
   signaledIdentities: Set<string>,
@@ -544,6 +550,7 @@ async function refreshExitedProcessTreePids(tree: ManagedProcessTree): Promise<b
   const currentByPid = new Map(processList.map((entry) => [entry.pid, entry]));
   retainCurrentProcessTreePids(tree, currentByPid);
   if (tree.platform !== "win32") {
+    discoverRememberedPosixDescendants(tree, currentByPid, processList);
     discoverCurrentPosixGroupMembers(tree, rootPid, processList);
   }
   return true;
@@ -560,6 +567,20 @@ function retainCurrentProcessTreePids(
       tree.descendantPids.delete(pid);
       tree.descendantIdentities.delete(pid);
     }
+  }
+}
+
+function discoverRememberedPosixDescendants(
+  tree: ManagedProcessTree,
+  currentByPid: Map<number, ProcessListEntry>,
+  processList: ProcessListEntry[],
+): void {
+  const childrenByParent = indexProcessesByParent(processList);
+  const rememberedRoots = [...tree.descendantPids]
+    .map((pid) => currentByPid.get(pid))
+    .filter((entry): entry is ProcessListEntry => entry !== undefined);
+  for (const rememberedRoot of rememberedRoots) {
+    recordProcessTreePids(tree, walkValidatedDescendants(rememberedRoot, childrenByParent));
   }
 }
 

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -8,7 +8,14 @@ export type ManagedProcessTree = {
   killProcessGroup: boolean;
   platform: NodeJS.Platform;
   descendantPids: Set<number>;
+  descendantIdentities: Map<number, string>;
   snapshotPromise?: Promise<void>;
+};
+
+type ProcessListEntry = {
+  pid: number;
+  parentPid: number;
+  identity: string;
 };
 
 export function createManagedProcessTree(
@@ -21,6 +28,7 @@ export function createManagedProcessTree(
     killProcessGroup,
     platform,
     descendantPids: new Set(),
+    descendantIdentities: new Map(),
   };
 }
 
@@ -72,19 +80,20 @@ async function recordCurrentProcessTreePids(tree: ManagedProcessTree): Promise<v
   if (!tree.killProcessGroup || !rootPid) {
     return;
   }
-  const pids =
+  const processes =
     tree.platform === "win32"
-      ? await listDescendantPids(rootPid, tree.platform)
-      : await listProcessGroupPids(rootPid);
-  recordProcessTreePids(tree, pids);
+      ? await listDescendantProcesses(rootPid, tree.platform)
+      : await listProcessGroupEntries(rootPid, tree.platform);
+  recordProcessTreePids(tree, processes);
 }
 
-function recordProcessTreePids(tree: ManagedProcessTree, pids: number[]): void {
-  for (const pid of pids) {
-    if (pid === tree.rootPid) {
+function recordProcessTreePids(tree: ManagedProcessTree, processes: ProcessListEntry[]): void {
+  for (const processEntry of processes) {
+    if (processEntry.pid === tree.rootPid) {
       continue;
     }
-    tree.descendantPids.add(pid);
+    tree.descendantPids.add(processEntry.pid);
+    tree.descendantIdentities.set(processEntry.pid, processEntry.identity);
   }
 }
 
@@ -101,7 +110,10 @@ export async function signalProcessTree(
     return;
   }
 
-  await captureProcessTreePids(tree, rootRunning);
+  if (!rootRunning) {
+    await captureProcessTreePids(tree, false);
+    await retainOwnedProcessTreePids(tree);
+  }
   for (const target of resolveProcessTreeSignalTargets(tree, rootRunning)) {
     if (target.tree) {
       await killWindowsProcessTree(target.pid, signal);
@@ -194,86 +206,100 @@ function hasLiveManagedProcessTree(tree: ManagedProcessTree, rootRunning: boolea
   ) {
     return true;
   }
-  return hasLivePid(tree.descendantPids);
+  return hasLivePid(tree);
 }
 
-async function listDescendantPids(
+async function listDescendantProcesses(
   rootPid: number,
   platform: NodeJS.Platform = process.platform,
-): Promise<number[]> {
-  let output: string;
-  try {
-    output = await runProcessListCommand(platform);
-  } catch {
+): Promise<ProcessListEntry[]> {
+  const processList = await readProcessList(platform);
+  if (!processList) {
     return [];
   }
 
-  const childrenByParent = new Map<number, number[]>();
-  for (const line of output.split("\n")) {
-    addProcessListLine(childrenByParent, line);
+  const childrenByParent = new Map<number, ProcessListEntry[]>();
+  for (const processEntry of processList) {
+    const children = childrenByParent.get(processEntry.parentPid);
+    if (children) {
+      children.push(processEntry);
+    } else {
+      childrenByParent.set(processEntry.parentPid, [processEntry]);
+    }
   }
 
-  const descendants: number[] = [];
+  const descendants: ProcessListEntry[] = [];
   const queue = [...(childrenByParent.get(rootPid) ?? [])];
   for (let index = 0; index < queue.length; index += 1) {
-    const pid = queue[index];
-    descendants.push(pid);
-    queue.push(...(childrenByParent.get(pid) ?? []));
+    const processEntry = queue[index];
+    descendants.push(processEntry);
+    queue.push(...(childrenByParent.get(processEntry.pid) ?? []));
   }
   return descendants;
 }
 
-function addProcessListLine(childrenByParent: Map<number, number[]>, line: string): void {
-  const parsed = parseProcessListLine(line);
-  if (!parsed) {
-    return;
-  }
-
-  const children = childrenByParent.get(parsed.parentPid);
-  if (children) {
-    children.push(parsed.pid);
-  } else {
-    childrenByParent.set(parsed.parentPid, [parsed.pid]);
-  }
-}
-
-function parseProcessListLine(line: string): { pid: number; parentPid: number } | undefined {
-  const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+function parseProcessListLine(line: string): ProcessListEntry | undefined {
+  const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
   if (!match) {
     return undefined;
   }
 
   const pid = Number(match[1]);
   const parentPid = Number(match[2]);
+  const identity = match[3].trim();
   if (!Number.isInteger(pid) || !Number.isInteger(parentPid) || pid <= 0 || parentPid <= 0) {
     return undefined;
   }
-  return { pid, parentPid };
-}
-
-async function runProcessListCommand(platform: NodeJS.Platform): Promise<string> {
-  if (platform === "win32") {
-    return await runWindowsProcessListCommand();
+  if (!identity) {
+    return undefined;
   }
-  return await runPsCommand(["-eo", "pid=,ppid="]);
+  return { pid, parentPid, identity };
 }
 
-async function listProcessGroupPids(processGroupId: number): Promise<number[]> {
+async function readProcessList(platform: NodeJS.Platform): Promise<ProcessListEntry[] | undefined> {
   let output: string;
   try {
-    output = await runPsCommand(["-eo", "pid=,pgid="]);
+    output =
+      platform === "win32"
+        ? await runWindowsProcessListCommand()
+        : await runPsCommand(["-eo", "pid=,pgid=,lstart="]);
   } catch {
+    return undefined;
+  }
+  return output
+    .split("\n")
+    .map((line) => parseProcessListLine(line))
+    .filter((entry): entry is ProcessListEntry => entry !== undefined);
+}
+
+async function listProcessGroupEntries(
+  processGroupId: number,
+  platform: NodeJS.Platform,
+): Promise<ProcessListEntry[]> {
+  const processList = await readProcessList(platform);
+  if (!processList) {
     return [];
   }
+  return processList.filter((entry) => entry.parentPid === processGroupId);
+}
 
-  const pids: number[] = [];
-  for (const line of output.split("\n")) {
-    const parsed = parseProcessListLine(line);
-    if (parsed?.parentPid === processGroupId) {
-      pids.push(parsed.pid);
+async function retainOwnedProcessTreePids(tree: ManagedProcessTree): Promise<void> {
+  const processList = await readProcessList(tree.platform);
+  if (!processList) {
+    tree.descendantPids.clear();
+    tree.descendantIdentities.clear();
+    return;
+  }
+  const currentByPid = new Map(processList.map((entry) => [entry.pid, entry]));
+  for (const pid of tree.descendantPids) {
+    const current = currentByPid.get(pid);
+    const capturedIdentity = tree.descendantIdentities.get(pid);
+    const remainsInOwnedGroup = tree.platform === "win32" || current?.parentPid === tree.rootPid;
+    if (!current || current.identity !== capturedIdentity || !remainsInOwnedGroup) {
+      tree.descendantPids.delete(pid);
+      tree.descendantIdentities.delete(pid);
     }
   }
-  return pids;
 }
 
 async function runPsCommand(args: string[]): Promise<string> {
@@ -283,7 +309,7 @@ async function runPsCommand(args: string[]): Promise<string> {
 async function runWindowsProcessListCommand(): Promise<string> {
   const command = [
     "Get-CimInstance Win32_Process |",
-    'ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
+    'ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId) $($_.CreationDate.ToUniversalTime().Ticks)" }',
   ].join(" ");
   return await runCapturedCommand(
     "powershell.exe",
@@ -389,14 +415,15 @@ function hasLiveProcessGroup(processGroupId: number): boolean {
   }
 }
 
-function hasLivePid(pids: Set<number>): boolean {
+function hasLivePid(tree: ManagedProcessTree): boolean {
   let live = false;
-  for (const pid of pids) {
+  for (const pid of tree.descendantPids) {
     try {
       process.kill(pid, 0);
       live = true;
     } catch {
-      pids.delete(pid);
+      tree.descendantPids.delete(pid);
+      tree.descendantIdentities.delete(pid);
     }
   }
   return live;

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -1,7 +1,12 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
 
 const PROCESS_TREE_POLL_MS = 25;
 const PROCESS_LIST_COMMAND_TIMEOUT_MS = 1_000;
+const WINDOWS_TRACKING_INITIAL_POLL_MS = 25;
+const WINDOWS_TRACKING_MAX_POLL_MS = 1_000;
+const WINDOWS_TRACKING_MAX_DURATION_MS = 10_000;
+const WINDOWS_EPOCH_OFFSET_TICKS = 621_355_968_000_000_000n;
 
 export type ManagedProcessTree = {
   rootPid: number | undefined;
@@ -10,19 +15,30 @@ export type ManagedProcessTree = {
   descendantPids: Set<number>;
   descendantIdentities: Map<number, string>;
   rootIdentity?: string;
+  rootIdentityFloor?: string;
   snapshotPromise?: Promise<void>;
 };
 
 export type ProcessListEntry = {
   pid: number;
   parentPid: number;
+  processGroupId?: number;
   identity: string;
 };
+
+export async function readProcessIdentity(
+  pid: number,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string | undefined> {
+  const processList = await readProcessList(platform);
+  return processList?.find((entry) => entry.pid === pid)?.identity;
+}
 
 export function createManagedProcessTree(
   rootPid: number | undefined,
   killProcessGroup: boolean,
   platform: NodeJS.Platform = process.platform,
+  rootCreatedAfterMs?: number,
 ): ManagedProcessTree {
   return {
     rootPid,
@@ -30,6 +46,10 @@ export function createManagedProcessTree(
     platform,
     descendantPids: new Set(),
     descendantIdentities: new Map(),
+    rootIdentityFloor:
+      platform === "win32" && rootCreatedAfterMs !== undefined
+        ? windowsTicksFromUnixMs(rootCreatedAfterMs)
+        : undefined,
   };
 }
 
@@ -37,9 +57,12 @@ export function rememberProcessTreePids(tree: ManagedProcessTree): void {
   queueProcessTreeSnapshot(tree);
 }
 
-export function beginProcessTreeTracking(tree: ManagedProcessTree): void {
+export function beginProcessTreeTracking(
+  tree: ManagedProcessTree,
+  rootRunning: () => boolean,
+): void {
   if (tree.platform === "win32") {
-    queueProcessTreeSnapshot(tree);
+    queueWindowsProcessTreeTracking(tree, rootRunning);
   }
 }
 
@@ -76,6 +99,31 @@ function queueProcessTreeSnapshot(tree: ManagedProcessTree): void {
   })();
 }
 
+function queueWindowsProcessTreeTracking(
+  tree: ManagedProcessTree,
+  rootRunning: () => boolean,
+): void {
+  const priorSnapshot = tree.snapshotPromise;
+  tree.snapshotPromise = (async () => {
+    await priorSnapshot?.catch(() => {
+      // Tracking can continue after an earlier best-effort snapshot failure.
+    });
+    const deadline = Date.now() + WINDOWS_TRACKING_MAX_DURATION_MS;
+    let pollMs = WINDOWS_TRACKING_INITIAL_POLL_MS;
+    while (rootRunning() && Date.now() < deadline) {
+      const descendantCount = tree.descendantPids.size;
+      await recordCurrentProcessTreePids(tree);
+      if (rootRunning() && Date.now() < deadline) {
+        await waitMs(pollMs);
+        pollMs =
+          tree.descendantPids.size > descendantCount
+            ? WINDOWS_TRACKING_INITIAL_POLL_MS
+            : Math.min(pollMs * 2, WINDOWS_TRACKING_MAX_POLL_MS);
+      }
+    }
+  })();
+}
+
 async function recordCurrentProcessTreePids(tree: ManagedProcessTree): Promise<void> {
   const rootPid = tree.rootPid;
   if (!tree.killProcessGroup || !rootPid) {
@@ -84,7 +132,7 @@ async function recordCurrentProcessTreePids(tree: ManagedProcessTree): Promise<v
   const processes =
     tree.platform === "win32"
       ? await listDescendantProcesses(tree)
-      : await listProcessGroupEntries(rootPid, tree.platform);
+      : await listOwnedPosixProcesses(tree);
   recordProcessTreePids(tree, processes);
 }
 
@@ -113,11 +161,9 @@ export async function signalProcessTree(
 
   if (!rootRunning) {
     await captureProcessTreePids(tree, false);
-    const refreshed = await refreshExitedProcessTreePids(tree);
-    if (!refreshed) {
-      tree.descendantPids.clear();
-      tree.descendantIdentities.clear();
-    }
+    await refreshExitedProcessTreePids(tree);
+  } else {
+    await recordCurrentProcessTreePids(tree);
   }
   for (const target of resolveProcessTreeSignalTargets(tree, rootRunning)) {
     if (target.tree) {
@@ -260,7 +306,12 @@ async function listDescendantProcesses(tree: ManagedProcessTree): Promise<Proces
     return [];
   }
 
-  const snapshot = collectWindowsDescendantProcesses(rootPid, tree.rootIdentity, processList);
+  const snapshot = collectWindowsDescendantProcesses(
+    rootPid,
+    tree.rootIdentity,
+    processList,
+    tree.rootIdentityFloor,
+  );
   if (!snapshot) {
     return [];
   }
@@ -272,9 +323,16 @@ export function collectWindowsDescendantProcesses(
   rootPid: number,
   expectedRootIdentity: string | undefined,
   processList: ProcessListEntry[],
+  rootIdentityFloor?: string,
 ): { rootIdentity: string; descendants: ProcessListEntry[] } | undefined {
   const root = processList.find((entry) => entry.pid === rootPid);
-  if (!root || (expectedRootIdentity && expectedRootIdentity !== root.identity)) {
+  if (!root) {
+    return undefined;
+  }
+  if (
+    (expectedRootIdentity && expectedRootIdentity !== root.identity) ||
+    (rootIdentityFloor && !isCreatedAtOrAfter(root.identity, rootIdentityFloor))
+  ) {
     return undefined;
   }
 
@@ -283,6 +341,10 @@ export function collectWindowsDescendantProcesses(
     rootIdentity: root.identity,
     descendants: walkValidatedDescendants(root, childrenByParent),
   };
+}
+
+function windowsTicksFromUnixMs(unixMs: number): string {
+  return (BigInt(Math.floor(unixMs)) * 10_000n + WINDOWS_EPOCH_OFFSET_TICKS).toString();
 }
 
 function indexProcessesByParent(processList: ProcessListEntry[]): Map<number, ProcessListEntry[]> {
@@ -323,11 +385,13 @@ function isCreatedAtOrAfter(childIdentity: string, parentIdentity: string): bool
   try {
     return BigInt(childIdentity) >= BigInt(parentIdentity);
   } catch {
-    return false;
+    const childTime = Date.parse(childIdentity);
+    const parentTime = Date.parse(parentIdentity);
+    return Number.isFinite(childTime) && Number.isFinite(parentTime) && childTime >= parentTime;
   }
 }
 
-function parseProcessListLine(line: string): ProcessListEntry | undefined {
+function parseWindowsProcessListLine(line: string): ProcessListEntry | undefined {
   const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
   if (!match) {
     return undefined;
@@ -345,31 +409,127 @@ function parseProcessListLine(line: string): ProcessListEntry | undefined {
   return { pid, parentPid, identity };
 }
 
+function parsePosixProcessListLine(line: string): ProcessListEntry | undefined {
+  const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+  if (!match) {
+    return undefined;
+  }
+  const pid = Number(match[1]);
+  const parentPid = Number(match[2]);
+  const processGroupId = Number(match[3]);
+  const identity = match[4].trim();
+  if (
+    !isPositiveInteger(pid) ||
+    !isPositiveInteger(parentPid) ||
+    !isPositiveInteger(processGroupId) ||
+    !identity
+  ) {
+    return undefined;
+  }
+  return { pid, parentPid, processGroupId, identity };
+}
+
 async function readProcessList(platform: NodeJS.Platform): Promise<ProcessListEntry[] | undefined> {
+  if (platform === "linux") {
+    return await readLinuxProcProcessList();
+  }
   let output: string;
   try {
     output =
       platform === "win32"
         ? await runWindowsProcessListCommand()
-        : await runPsCommand(["-eo", "pid=,pgid=,lstart="]);
+        : await runPsCommand(["-eo", "pid=,ppid=,pgid=,lstart="]);
   } catch {
     return undefined;
   }
+  const parseLine = platform === "win32" ? parseWindowsProcessListLine : parsePosixProcessListLine;
   return output
     .split("\n")
-    .map((line) => parseProcessListLine(line))
+    .map((line) => parseLine(line))
     .filter((entry): entry is ProcessListEntry => entry !== undefined);
 }
 
-async function listProcessGroupEntries(
-  processGroupId: number,
-  platform: NodeJS.Platform,
-): Promise<ProcessListEntry[]> {
-  const processList = await readProcessList(platform);
+async function readLinuxProcProcessList(): Promise<ProcessListEntry[] | undefined> {
+  let entries;
+  try {
+    entries = await fs.readdir("/proc", { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  const processList = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+      .map(async (entry) => {
+        try {
+          const stat = await fs.readFile(`/proc/${entry.name}/stat`, "utf8");
+          return parseLinuxProcStat(stat);
+        } catch {
+          return undefined;
+        }
+      }),
+  );
+  return processList.filter((entry): entry is ProcessListEntry => entry !== undefined);
+}
+
+function parseLinuxProcStat(stat: string): ProcessListEntry | undefined {
+  const commandEnd = stat.lastIndexOf(")");
+  const commandStart = stat.indexOf("(");
+  if (commandStart <= 0 || commandEnd <= commandStart) {
+    return undefined;
+  }
+  const pid = Number(stat.slice(0, commandStart).trim());
+  const fields = stat
+    .slice(commandEnd + 1)
+    .trim()
+    .split(/\s+/);
+  const parentPid = Number(fields[1]);
+  const processGroupId = Number(fields[2]);
+  const startTime = fields[19];
+  if (
+    !isPositiveInteger(pid) ||
+    !isPositiveInteger(parentPid) ||
+    !isPositiveInteger(processGroupId) ||
+    !isNumericIdentity(startTime)
+  ) {
+    return undefined;
+  }
+  return { pid, parentPid, processGroupId, identity: startTime };
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0;
+}
+
+function isNumericIdentity(value: string | undefined): value is string {
+  return value !== undefined && /^\d+$/.test(value);
+}
+
+async function listOwnedPosixProcesses(tree: ManagedProcessTree): Promise<ProcessListEntry[]> {
+  const rootPid = tree.rootPid;
+  if (!rootPid) {
+    return [];
+  }
+  const processList = await readProcessList(tree.platform);
   if (!processList) {
     return [];
   }
-  return processList.filter((entry) => entry.parentPid === processGroupId);
+  const ownedByPid = new Map(
+    processList
+      .filter((entry) => entry.processGroupId === rootPid)
+      .map((entry) => [entry.pid, entry]),
+  );
+  const root = processList.find((entry) => entry.pid === rootPid);
+  if (
+    root &&
+    (!tree.rootIdentity || tree.rootIdentity === root.identity) &&
+    root.processGroupId === rootPid
+  ) {
+    tree.rootIdentity = root.identity;
+    for (const descendant of walkValidatedDescendants(root, indexProcessesByParent(processList))) {
+      ownedByPid.set(descendant.pid, descendant);
+    }
+  }
+  return [...ownedByPid.values()];
 }
 
 async function refreshExitedProcessTreePids(tree: ManagedProcessTree): Promise<boolean> {
@@ -396,8 +556,7 @@ function retainCurrentProcessTreePids(
   for (const pid of tree.descendantPids) {
     const current = currentByPid.get(pid);
     const capturedIdentity = tree.descendantIdentities.get(pid);
-    const remainsInOwnedGroup = tree.platform === "win32" || current?.parentPid === tree.rootPid;
-    if (!current || current.identity !== capturedIdentity || !remainsInOwnedGroup) {
+    if (!current || current.identity !== capturedIdentity) {
       tree.descendantPids.delete(pid);
       tree.descendantIdentities.delete(pid);
     }
@@ -409,7 +568,7 @@ function discoverCurrentPosixGroupMembers(
   rootPid: number,
   processList: ProcessListEntry[],
 ): void {
-  const currentGroup = processList.filter((entry) => entry.parentPid === rootPid);
+  const currentGroup = processList.filter((entry) => entry.processGroupId === rootPid);
   if (currentGroup.some((entry) => entry.pid === rootPid)) {
     // A live process whose PID equals the old group leader means the numeric
     // PID/PGID was recycled after the owned group became empty.
@@ -421,7 +580,11 @@ function discoverCurrentPosixGroupMembers(
 }
 
 async function runPsCommand(args: string[]): Promise<string> {
-  return await runCapturedCommand("ps", args, "ps");
+  return await runCapturedCommand("ps", args, "ps", {
+    ...process.env,
+    LANG: "C",
+    LC_ALL: "C",
+  });
 }
 
 async function runWindowsProcessListCommand(): Promise<string> {
@@ -440,9 +603,11 @@ async function runCapturedCommand(
   command: string,
   args: string[],
   description: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     const child = spawn(command, args, {
+      env,
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -1,0 +1,290 @@
+import { spawn } from "node:child_process";
+
+const PROCESS_TREE_POLL_MS = 25;
+
+export type ManagedProcessTree = {
+  rootPid: number | undefined;
+  killProcessGroup: boolean;
+  descendantPids: Set<number>;
+  snapshotPromise?: Promise<void>;
+};
+
+export function createManagedProcessTree(
+  rootPid: number | undefined,
+  killProcessGroup: boolean,
+): ManagedProcessTree {
+  return {
+    rootPid,
+    killProcessGroup,
+    descendantPids: new Set(),
+  };
+}
+
+export function rememberProcessTreePids(tree: ManagedProcessTree): void {
+  tree.snapshotPromise = captureProcessTreePids(tree, false);
+}
+
+export async function captureProcessTreePids(
+  tree: ManagedProcessTree,
+  rootRunning: boolean,
+): Promise<void> {
+  const rootPid = tree.rootPid;
+  // POSIX ownership is the process group created at spawn. Descendants that
+  // deliberately create another session are outside that ownership boundary.
+  if (!tree.killProcessGroup || !rootPid || process.platform !== "win32") {
+    return;
+  }
+  await waitForPriorSnapshot(tree, rootRunning);
+
+  recordProcessTreePids(tree, await listDescendantPids(rootPid));
+}
+
+async function waitForPriorSnapshot(tree: ManagedProcessTree, rootRunning: boolean): Promise<void> {
+  if (rootRunning) {
+    return;
+  }
+  await tree.snapshotPromise?.catch(() => {
+    // Process tree snapshots are best-effort because the root may already be gone.
+  });
+}
+
+function recordProcessTreePids(tree: ManagedProcessTree, pids: number[]): void {
+  for (const pid of pids) {
+    if (pid === tree.rootPid) {
+      continue;
+    }
+    tree.descendantPids.add(pid);
+  }
+}
+
+export async function signalProcessTree(
+  tree: ManagedProcessTree,
+  rootRunning: boolean,
+  signal: NodeJS.Signals,
+): Promise<void> {
+  const rootPid = tree.rootPid;
+  if (!tree.killProcessGroup || !rootPid) {
+    if (rootPid) {
+      sendSignal(rootPid, signal);
+    }
+    return;
+  }
+
+  await captureProcessTreePids(tree, rootRunning);
+  if (process.platform === "win32") {
+    await signalWindowsProcessTree(tree, rootRunning, signal);
+    return;
+  }
+  signalPosixProcessTree(tree, signal);
+}
+
+export async function waitForProcessTreeExit(
+  tree: ManagedProcessTree,
+  rootRunning: () => boolean,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (rootRunning() || hasLiveManagedProcessTree(tree)) {
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await waitMs(Math.min(PROCESS_TREE_POLL_MS, Math.max(0, deadline - Date.now())));
+  }
+  return true;
+}
+
+async function signalWindowsProcessTree(
+  tree: ManagedProcessTree,
+  rootRunning: boolean,
+  signal: NodeJS.Signals,
+): Promise<void> {
+  const rootPid = tree.rootPid;
+  if (rootRunning && rootPid) {
+    await killWindowsProcessTree(rootPid, signal);
+    return;
+  }
+  for (const descendantPid of tree.descendantPids) {
+    await killWindowsProcessTree(descendantPid, signal);
+  }
+}
+
+function signalPosixProcessTree(tree: ManagedProcessTree, signal: NodeJS.Signals): void {
+  const rootPid = tree.rootPid;
+  if (rootPid && hasLiveProcessGroup(rootPid)) {
+    sendSignal(-rootPid, signal);
+  }
+}
+
+function hasLiveManagedProcessTree(tree: ManagedProcessTree): boolean {
+  const rootPid = tree.rootPid;
+  if (
+    tree.killProcessGroup &&
+    rootPid &&
+    process.platform !== "win32" &&
+    hasLiveProcessGroup(rootPid)
+  ) {
+    return true;
+  }
+  return process.platform === "win32" && hasLivePid(tree.descendantPids);
+}
+
+async function listDescendantPids(rootPid: number): Promise<number[]> {
+  let output: string;
+  try {
+    output = await runProcessListCommand();
+  } catch {
+    return [];
+  }
+
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of output.split("\n")) {
+    addProcessListLine(childrenByParent, line);
+  }
+
+  const descendants: number[] = [];
+  const queue = [...(childrenByParent.get(rootPid) ?? [])];
+  for (let index = 0; index < queue.length; index += 1) {
+    const pid = queue[index];
+    descendants.push(pid);
+    queue.push(...(childrenByParent.get(pid) ?? []));
+  }
+  return descendants;
+}
+
+function addProcessListLine(childrenByParent: Map<number, number[]>, line: string): void {
+  const parsed = parseProcessListLine(line);
+  if (!parsed) {
+    return;
+  }
+
+  const children = childrenByParent.get(parsed.parentPid);
+  if (children) {
+    children.push(parsed.pid);
+  } else {
+    childrenByParent.set(parsed.parentPid, [parsed.pid]);
+  }
+}
+
+function parseProcessListLine(line: string): { pid: number; parentPid: number } | undefined {
+  const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+  if (!match) {
+    return undefined;
+  }
+
+  const pid = Number(match[1]);
+  const parentPid = Number(match[2]);
+  if (!Number.isInteger(pid) || !Number.isInteger(parentPid) || pid <= 0 || parentPid <= 0) {
+    return undefined;
+  }
+  return { pid, parentPid };
+}
+
+async function runProcessListCommand(): Promise<string> {
+  if (process.platform === "win32") {
+    return await runWindowsProcessListCommand();
+  }
+  return await runPsCommand(["-eo", "pid=,ppid="]);
+}
+
+async function runPsCommand(args: string[]): Promise<string> {
+  return await runCapturedCommand("ps", args, "ps");
+}
+
+async function runWindowsProcessListCommand(): Promise<string> {
+  const command = [
+    "Get-CimInstance Win32_Process |",
+    'ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
+  ].join(" ");
+  return await runCapturedCommand(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", command],
+    "powershell process list",
+  );
+}
+
+async function runCapturedCommand(
+  command: string,
+  args: string[],
+  description: string,
+): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(
+        new Error(
+          `${description} exited with code ${code ?? "null"} signal ${signal ?? "null"}: ${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+async function killWindowsProcessTree(pid: number, signal: NodeJS.Signals): Promise<void> {
+  const args = ["/pid", String(pid), "/t"];
+  if (signal === "SIGKILL") {
+    args.push("/f");
+  }
+  await new Promise<void>((resolve) => {
+    const child = spawn("taskkill", args, {
+      stdio: ["ignore", "ignore", "ignore"],
+      windowsHide: true,
+    });
+    child.once("error", () => resolve());
+    child.once("close", () => resolve());
+  });
+}
+
+function sendSignal(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Processes can exit between discovery and signaling.
+  }
+}
+
+function hasLiveProcessGroup(processGroupId: number): boolean {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasLivePid(pids: Set<number>): boolean {
+  let live = false;
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 0);
+      live = true;
+    } catch {
+      pids.delete(pid);
+    }
+  }
+  return live;
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, Math.max(0, ms));
+  });
+}

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 
 const PROCESS_TREE_POLL_MS = 25;
 const PROCESS_LIST_COMMAND_TIMEOUT_MS = 1_000;
+const WINDOWS_PROCESS_LIST_COMMAND_TIMEOUT_MS = 5_000;
 const PROCESS_TREE_TRACKING_INITIAL_POLL_MS = 25;
 const PROCESS_TREE_TRACKING_MAX_POLL_MS = 1_000;
 const PROCESS_TREE_TRACKING_MAX_DURATION_MS = 10_000;
@@ -519,23 +520,33 @@ async function listOwnedPosixProcesses(tree: ManagedProcessTree): Promise<Proces
   if (!processList) {
     return [];
   }
+  const root = processList.find((entry) => entry.pid === rootPid);
+  if (!posixRootIdentityMatches(tree, root)) {
+    return [];
+  }
   const ownedByPid = new Map(
     processList
       .filter((entry) => entry.processGroupId === rootPid)
       .map((entry) => [entry.pid, entry]),
   );
-  const root = processList.find((entry) => entry.pid === rootPid);
-  if (
-    root &&
-    (!tree.rootIdentity || tree.rootIdentity === root.identity) &&
-    root.processGroupId === rootPid
-  ) {
+  if (root) {
     tree.rootIdentity = root.identity;
     for (const descendant of walkValidatedDescendants(root, indexProcessesByParent(processList))) {
       ownedByPid.set(descendant.pid, descendant);
     }
   }
   return [...ownedByPid.values()];
+}
+
+function posixRootIdentityMatches(
+  tree: ManagedProcessTree,
+  root: ProcessListEntry | undefined,
+): boolean {
+  return (
+    !root ||
+    (root.processGroupId === tree.rootPid &&
+      (tree.rootIdentity === undefined || tree.rootIdentity === root.identity))
+  );
 }
 
 async function refreshExitedProcessTreePids(tree: ManagedProcessTree): Promise<boolean> {
@@ -592,9 +603,8 @@ function discoverCurrentPosixGroupMembers(
   const currentGroup = processList.filter((entry) => entry.processGroupId === rootPid);
   if (currentGroup.some((entry) => entry.pid === rootPid)) {
     // A live process whose PID equals the old group leader means the numeric
-    // PID/PGID was recycled after the owned group became empty.
-    tree.descendantPids.clear();
-    tree.descendantIdentities.clear();
+    // PID/PGID was recycled. Do not adopt ambiguous group members, but retain
+    // descendants whose identities were validated by retainCurrentProcessTreePids.
     return;
   }
   recordProcessTreePids(tree, currentGroup);
@@ -617,6 +627,8 @@ async function runWindowsProcessListCommand(): Promise<string> {
     "powershell.exe",
     ["-NoProfile", "-NonInteractive", "-Command", command],
     "powershell process list",
+    undefined,
+    WINDOWS_PROCESS_LIST_COMMAND_TIMEOUT_MS,
   );
 }
 
@@ -625,6 +637,7 @@ async function runCapturedCommand(
   args: string[],
   description: string,
   env?: NodeJS.ProcessEnv,
+  timeoutMs = PROCESS_LIST_COMMAND_TIMEOUT_MS,
 ): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     const child = spawn(command, args, {
@@ -658,9 +671,9 @@ async function runCapturedCommand(
       }
       child.unref();
       finish({
-        error: new Error(`${description} did not exit within ${PROCESS_LIST_COMMAND_TIMEOUT_MS}ms`),
+        error: new Error(`${description} did not exit within ${timeoutMs}ms`),
       });
-    }, PROCESS_LIST_COMMAND_TIMEOUT_MS);
+    }, timeoutMs);
 
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -9,10 +9,11 @@ export type ManagedProcessTree = {
   platform: NodeJS.Platform;
   descendantPids: Set<number>;
   descendantIdentities: Map<number, string>;
+  rootIdentity?: string;
   snapshotPromise?: Promise<void>;
 };
 
-type ProcessListEntry = {
+export type ProcessListEntry = {
   pid: number;
   parentPid: number;
   identity: string;
@@ -82,7 +83,7 @@ async function recordCurrentProcessTreePids(tree: ManagedProcessTree): Promise<v
   }
   const processes =
     tree.platform === "win32"
-      ? await listDescendantProcesses(rootPid, tree.platform)
+      ? await listDescendantProcesses(tree)
       : await listProcessGroupEntries(rootPid, tree.platform);
   recordProcessTreePids(tree, processes);
 }
@@ -160,8 +161,10 @@ export async function waitForProcessTreeExit(
   tree: ManagedProcessTree,
   rootRunning: () => boolean,
   timeoutMs: number,
+  finalSignal?: NodeJS.Signals,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
+  const signaledIdentities = new Set<string>();
   while (true) {
     let rootIsRunning = rootRunning();
     if (!rootIsRunning) {
@@ -172,7 +175,7 @@ export async function waitForProcessTreeExit(
       rootIsRunning = rootRunning();
     }
     if (!rootIsRunning && !hasLiveManagedProcessTree(tree, rootIsRunning)) {
-      if (await exitedTreeRemainsEmptyAfterRefresh(tree)) {
+      if (await exitedTreeRemainsEmptyAfterRefresh(tree, finalSignal, signaledIdentities)) {
         return true;
       }
     }
@@ -201,8 +204,36 @@ async function waitForPriorSnapshotBeforeDeadline(
   ]);
 }
 
-async function exitedTreeRemainsEmptyAfterRefresh(tree: ManagedProcessTree): Promise<boolean> {
-  return (await refreshExitedProcessTreePids(tree)) && !hasLiveManagedProcessTree(tree, false);
+async function exitedTreeRemainsEmptyAfterRefresh(
+  tree: ManagedProcessTree,
+  finalSignal: NodeJS.Signals | undefined,
+  signaledIdentities: Set<string>,
+): Promise<boolean> {
+  if (!(await refreshExitedProcessTreePids(tree))) {
+    return false;
+  }
+  if (!hasLiveManagedProcessTree(tree, false)) {
+    return true;
+  }
+  if (finalSignal) {
+    signalNewlyDiscoveredProcessPids(tree, finalSignal, signaledIdentities);
+  }
+  return false;
+}
+
+function signalNewlyDiscoveredProcessPids(
+  tree: ManagedProcessTree,
+  signal: NodeJS.Signals,
+  signaledIdentities: Set<string>,
+): void {
+  for (const pid of tree.descendantPids) {
+    const identity = tree.descendantIdentities.get(pid);
+    const signalKey = `${pid}:${identity ?? ""}`;
+    if (!signaledIdentities.has(signalKey)) {
+      sendSignal(pid, signal);
+      signaledIdentities.add(signalKey);
+    }
+  }
 }
 
 function hasLiveManagedProcessTree(tree: ManagedProcessTree, rootRunning: boolean): boolean {
@@ -219,15 +250,42 @@ function hasLiveManagedProcessTree(tree: ManagedProcessTree, rootRunning: boolea
   return hasLivePid(tree);
 }
 
-async function listDescendantProcesses(
-  rootPid: number,
-  platform: NodeJS.Platform = process.platform,
-): Promise<ProcessListEntry[]> {
-  const processList = await readProcessList(platform);
+async function listDescendantProcesses(tree: ManagedProcessTree): Promise<ProcessListEntry[]> {
+  const rootPid = tree.rootPid;
+  if (!rootPid) {
+    return [];
+  }
+  const processList = await readProcessList(tree.platform);
   if (!processList) {
     return [];
   }
 
+  const snapshot = collectWindowsDescendantProcesses(rootPid, tree.rootIdentity, processList);
+  if (!snapshot) {
+    return [];
+  }
+  tree.rootIdentity = snapshot.rootIdentity;
+  return snapshot.descendants;
+}
+
+export function collectWindowsDescendantProcesses(
+  rootPid: number,
+  expectedRootIdentity: string | undefined,
+  processList: ProcessListEntry[],
+): { rootIdentity: string; descendants: ProcessListEntry[] } | undefined {
+  const root = processList.find((entry) => entry.pid === rootPid);
+  if (!root || (expectedRootIdentity && expectedRootIdentity !== root.identity)) {
+    return undefined;
+  }
+
+  const childrenByParent = indexProcessesByParent(processList);
+  return {
+    rootIdentity: root.identity,
+    descendants: walkValidatedDescendants(root, childrenByParent),
+  };
+}
+
+function indexProcessesByParent(processList: ProcessListEntry[]): Map<number, ProcessListEntry[]> {
   const childrenByParent = new Map<number, ProcessListEntry[]>();
   for (const processEntry of processList) {
     const children = childrenByParent.get(processEntry.parentPid);
@@ -237,15 +295,36 @@ async function listDescendantProcesses(
       childrenByParent.set(processEntry.parentPid, [processEntry]);
     }
   }
+  return childrenByParent;
+}
 
+function walkValidatedDescendants(
+  root: ProcessListEntry,
+  childrenByParent: Map<number, ProcessListEntry[]>,
+): ProcessListEntry[] {
   const descendants: ProcessListEntry[] = [];
-  const queue = [...(childrenByParent.get(rootPid) ?? [])];
+  const visited = new Set([root.pid]);
+  const queue = [root];
   for (let index = 0; index < queue.length; index += 1) {
-    const processEntry = queue[index];
-    descendants.push(processEntry);
-    queue.push(...(childrenByParent.get(processEntry.pid) ?? []));
+    const parent = queue[index];
+    for (const child of childrenByParent.get(parent.pid) ?? []) {
+      if (visited.has(child.pid) || !isCreatedAtOrAfter(child.identity, parent.identity)) {
+        continue;
+      }
+      visited.add(child.pid);
+      descendants.push(child);
+      queue.push(child);
+    }
   }
   return descendants;
+}
+
+function isCreatedAtOrAfter(childIdentity: string, parentIdentity: string): boolean {
+  try {
+    return BigInt(childIdentity) >= BigInt(parentIdentity);
+  } catch {
+    return false;
+  }
 }
 
 function parseProcessListLine(line: string): ProcessListEntry | undefined {

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -5,6 +5,7 @@ const PROCESS_TREE_POLL_MS = 25;
 export type ManagedProcessTree = {
   rootPid: number | undefined;
   killProcessGroup: boolean;
+  platform: NodeJS.Platform;
   descendantPids: Set<number>;
   snapshotPromise?: Promise<void>;
 };
@@ -12,16 +13,24 @@ export type ManagedProcessTree = {
 export function createManagedProcessTree(
   rootPid: number | undefined,
   killProcessGroup: boolean,
+  platform: NodeJS.Platform = process.platform,
 ): ManagedProcessTree {
   return {
     rootPid,
     killProcessGroup,
+    platform,
     descendantPids: new Set(),
   };
 }
 
 export function rememberProcessTreePids(tree: ManagedProcessTree): void {
-  tree.snapshotPromise = captureProcessTreePids(tree, false);
+  queueProcessTreeSnapshot(tree);
+}
+
+export function beginProcessTreeTracking(tree: ManagedProcessTree): void {
+  if (tree.platform === "win32") {
+    queueProcessTreeSnapshot(tree);
+  }
 }
 
 export async function captureProcessTreePids(
@@ -29,23 +38,44 @@ export async function captureProcessTreePids(
   rootRunning: boolean,
 ): Promise<void> {
   const rootPid = tree.rootPid;
-  // POSIX ownership is the process group created at spawn. Descendants that
-  // deliberately create another session are outside that ownership boundary.
-  if (!tree.killProcessGroup || !rootPid || process.platform !== "win32") {
+  if (!tree.killProcessGroup || !rootPid) {
     return;
   }
-  await waitForPriorSnapshot(tree, rootRunning);
 
-  recordProcessTreePids(tree, await listDescendantPids(rootPid));
+  if (!rootRunning) {
+    await waitForPriorSnapshot(tree);
+    return;
+  }
+
+  await recordCurrentProcessTreePids(tree);
 }
 
-async function waitForPriorSnapshot(tree: ManagedProcessTree, rootRunning: boolean): Promise<void> {
-  if (rootRunning) {
-    return;
-  }
+async function waitForPriorSnapshot(tree: ManagedProcessTree): Promise<void> {
   await tree.snapshotPromise?.catch(() => {
     // Process tree snapshots are best-effort because the root may already be gone.
   });
+}
+
+function queueProcessTreeSnapshot(tree: ManagedProcessTree): void {
+  const priorSnapshot = tree.snapshotPromise;
+  tree.snapshotPromise = (async () => {
+    await priorSnapshot?.catch(() => {
+      // A later snapshot can still succeed after an earlier best-effort failure.
+    });
+    await recordCurrentProcessTreePids(tree);
+  })();
+}
+
+async function recordCurrentProcessTreePids(tree: ManagedProcessTree): Promise<void> {
+  const rootPid = tree.rootPid;
+  if (!tree.killProcessGroup || !rootPid) {
+    return;
+  }
+  const pids =
+    tree.platform === "win32"
+      ? await listDescendantPids(rootPid, tree.platform)
+      : await listProcessGroupPids(rootPid);
+  recordProcessTreePids(tree, pids);
 }
 
 function recordProcessTreePids(tree: ManagedProcessTree, pids: number[]): void {
@@ -71,11 +101,42 @@ export async function signalProcessTree(
   }
 
   await captureProcessTreePids(tree, rootRunning);
-  if (process.platform === "win32") {
-    await signalWindowsProcessTree(tree, rootRunning, signal);
-    return;
+  for (const target of resolveProcessTreeSignalTargets(tree, rootRunning)) {
+    if (target.tree) {
+      await killWindowsProcessTree(target.pid, signal);
+    } else {
+      sendSignal(target.pid, signal);
+    }
   }
-  signalPosixProcessTree(tree, signal);
+}
+
+export type ProcessTreeSignalTarget = {
+  pid: number;
+  tree: boolean;
+};
+
+export function resolveProcessTreeSignalTargets(
+  tree: ManagedProcessTree,
+  rootRunning: boolean,
+): ProcessTreeSignalTarget[] {
+  const rootPid = tree.rootPid;
+  if (!rootPid) {
+    return [];
+  }
+  if (!tree.killProcessGroup) {
+    return [{ pid: rootPid, tree: false }];
+  }
+  if (tree.platform === "win32") {
+    return rootRunning
+      ? [{ pid: rootPid, tree: true }]
+      : Array.from(tree.descendantPids, (pid) => ({ pid, tree: true }));
+  }
+  if (rootRunning) {
+    return [{ pid: -rootPid, tree: false }];
+  }
+  // Once the root exits, its numeric PID/PGID can be recycled. Signal only
+  // members captured while the owned group still existed.
+  return Array.from(tree.descendantPids, (pid) => ({ pid, tree: false }));
 }
 
 export async function waitForProcessTreeExit(
@@ -84,54 +145,38 @@ export async function waitForProcessTreeExit(
   timeoutMs: number,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
-  while (rootRunning() || hasLiveManagedProcessTree(tree)) {
+  let rootIsRunning = rootRunning();
+  while (rootIsRunning || hasLiveManagedProcessTree(tree, rootIsRunning)) {
     if (Date.now() >= deadline) {
       return false;
     }
     await waitMs(Math.min(PROCESS_TREE_POLL_MS, Math.max(0, deadline - Date.now())));
+    rootIsRunning = rootRunning();
   }
   return true;
 }
 
-async function signalWindowsProcessTree(
-  tree: ManagedProcessTree,
-  rootRunning: boolean,
-  signal: NodeJS.Signals,
-): Promise<void> {
-  const rootPid = tree.rootPid;
-  if (rootRunning && rootPid) {
-    await killWindowsProcessTree(rootPid, signal);
-    return;
-  }
-  for (const descendantPid of tree.descendantPids) {
-    await killWindowsProcessTree(descendantPid, signal);
-  }
-}
-
-function signalPosixProcessTree(tree: ManagedProcessTree, signal: NodeJS.Signals): void {
-  const rootPid = tree.rootPid;
-  if (rootPid && hasLiveProcessGroup(rootPid)) {
-    sendSignal(-rootPid, signal);
-  }
-}
-
-function hasLiveManagedProcessTree(tree: ManagedProcessTree): boolean {
+function hasLiveManagedProcessTree(tree: ManagedProcessTree, rootRunning: boolean): boolean {
   const rootPid = tree.rootPid;
   if (
+    rootRunning &&
     tree.killProcessGroup &&
     rootPid &&
-    process.platform !== "win32" &&
+    tree.platform !== "win32" &&
     hasLiveProcessGroup(rootPid)
   ) {
     return true;
   }
-  return process.platform === "win32" && hasLivePid(tree.descendantPids);
+  return hasLivePid(tree.descendantPids);
 }
 
-async function listDescendantPids(rootPid: number): Promise<number[]> {
+async function listDescendantPids(
+  rootPid: number,
+  platform: NodeJS.Platform = process.platform,
+): Promise<number[]> {
   let output: string;
   try {
-    output = await runProcessListCommand();
+    output = await runProcessListCommand(platform);
   } catch {
     return [];
   }
@@ -179,11 +224,29 @@ function parseProcessListLine(line: string): { pid: number; parentPid: number } 
   return { pid, parentPid };
 }
 
-async function runProcessListCommand(): Promise<string> {
-  if (process.platform === "win32") {
+async function runProcessListCommand(platform: NodeJS.Platform): Promise<string> {
+  if (platform === "win32") {
     return await runWindowsProcessListCommand();
   }
   return await runPsCommand(["-eo", "pid=,ppid="]);
+}
+
+async function listProcessGroupPids(processGroupId: number): Promise<number[]> {
+  let output: string;
+  try {
+    output = await runPsCommand(["-eo", "pid=,pgid="]);
+  } catch {
+    return [];
+  }
+
+  const pids: number[] = [];
+  for (const line of output.split("\n")) {
+    const parsed = parseProcessListLine(line);
+    if (parsed?.parentPid === processGroupId) {
+      pids.push(parsed.pid);
+    }
+  }
+  return pids;
 }
 
 async function runPsCommand(args: string[]): Promise<string> {

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -112,7 +112,11 @@ export async function signalProcessTree(
 
   if (!rootRunning) {
     await captureProcessTreePids(tree, false);
-    await retainOwnedProcessTreePids(tree);
+    const refreshed = await refreshExitedProcessTreePids(tree);
+    if (!refreshed) {
+      tree.descendantPids.clear();
+      tree.descendantIdentities.clear();
+    }
   }
   for (const target of resolveProcessTreeSignalTargets(tree, rootRunning)) {
     if (target.tree) {
@@ -168,7 +172,9 @@ export async function waitForProcessTreeExit(
       rootIsRunning = rootRunning();
     }
     if (!rootIsRunning && !hasLiveManagedProcessTree(tree, rootIsRunning)) {
-      return true;
+      if (await exitedTreeRemainsEmptyAfterRefresh(tree)) {
+        return true;
+      }
     }
     if (Date.now() >= deadline) {
       return false;
@@ -193,6 +199,10 @@ async function waitForPriorSnapshotBeforeDeadline(
     ),
     waitMs(remainingMs).then(() => false),
   ]);
+}
+
+async function exitedTreeRemainsEmptyAfterRefresh(tree: ManagedProcessTree): Promise<boolean> {
+  return (await refreshExitedProcessTreePids(tree)) && !hasLiveManagedProcessTree(tree, false);
 }
 
 function hasLiveManagedProcessTree(tree: ManagedProcessTree, rootRunning: boolean): boolean {
@@ -283,14 +293,27 @@ async function listProcessGroupEntries(
   return processList.filter((entry) => entry.parentPid === processGroupId);
 }
 
-async function retainOwnedProcessTreePids(tree: ManagedProcessTree): Promise<void> {
+async function refreshExitedProcessTreePids(tree: ManagedProcessTree): Promise<boolean> {
+  const rootPid = tree.rootPid;
+  if (!tree.killProcessGroup || !rootPid) {
+    return true;
+  }
   const processList = await readProcessList(tree.platform);
   if (!processList) {
-    tree.descendantPids.clear();
-    tree.descendantIdentities.clear();
-    return;
+    return false;
   }
   const currentByPid = new Map(processList.map((entry) => [entry.pid, entry]));
+  retainCurrentProcessTreePids(tree, currentByPid);
+  if (tree.platform !== "win32") {
+    discoverCurrentPosixGroupMembers(tree, rootPid, processList);
+  }
+  return true;
+}
+
+function retainCurrentProcessTreePids(
+  tree: ManagedProcessTree,
+  currentByPid: Map<number, ProcessListEntry>,
+): void {
   for (const pid of tree.descendantPids) {
     const current = currentByPid.get(pid);
     const capturedIdentity = tree.descendantIdentities.get(pid);
@@ -300,6 +323,22 @@ async function retainOwnedProcessTreePids(tree: ManagedProcessTree): Promise<voi
       tree.descendantIdentities.delete(pid);
     }
   }
+}
+
+function discoverCurrentPosixGroupMembers(
+  tree: ManagedProcessTree,
+  rootPid: number,
+  processList: ProcessListEntry[],
+): void {
+  const currentGroup = processList.filter((entry) => entry.parentPid === rootPid);
+  if (currentGroup.some((entry) => entry.pid === rootPid)) {
+    // A live process whose PID equals the old group leader means the numeric
+    // PID/PGID was recycled after the owned group became empty.
+    tree.descendantPids.clear();
+    tree.descendantIdentities.clear();
+    return;
+  }
+  recordProcessTreePids(tree, currentGroup);
 }
 
 async function runPsCommand(args: string[]): Promise<string> {

--- a/src/acp/process-tree.ts
+++ b/src/acp/process-tree.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 
 const PROCESS_TREE_POLL_MS = 25;
+const PROCESS_LIST_COMMAND_TIMEOUT_MS = 1_000;
 
 export type ManagedProcessTree = {
   rootPid: number | undefined;
@@ -145,15 +146,41 @@ export async function waitForProcessTreeExit(
   timeoutMs: number,
 ): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, timeoutMs);
-  let rootIsRunning = rootRunning();
-  while (rootIsRunning || hasLiveManagedProcessTree(tree, rootIsRunning)) {
+  while (true) {
+    let rootIsRunning = rootRunning();
+    if (!rootIsRunning) {
+      const snapshotCompleted = await waitForPriorSnapshotBeforeDeadline(tree, deadline);
+      if (!snapshotCompleted) {
+        return false;
+      }
+      rootIsRunning = rootRunning();
+    }
+    if (!rootIsRunning && !hasLiveManagedProcessTree(tree, rootIsRunning)) {
+      return true;
+    }
     if (Date.now() >= deadline) {
       return false;
     }
     await waitMs(Math.min(PROCESS_TREE_POLL_MS, Math.max(0, deadline - Date.now())));
-    rootIsRunning = rootRunning();
   }
-  return true;
+}
+
+async function waitForPriorSnapshotBeforeDeadline(
+  tree: ManagedProcessTree,
+  deadline: number,
+): Promise<boolean> {
+  const snapshot = tree.snapshotPromise;
+  if (!snapshot) {
+    return true;
+  }
+  const remainingMs = Math.max(0, deadline - Date.now());
+  return await Promise.race([
+    snapshot.then(
+      () => true,
+      () => true,
+    ),
+    waitMs(remainingMs).then(() => false),
+  ]);
 }
 
 function hasLiveManagedProcessTree(tree: ManagedProcessTree, rootRunning: boolean): boolean {
@@ -277,6 +304,33 @@ async function runCapturedCommand(
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+
+    const finish = (result: { output: string } | { error: Error }): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if ("output" in result) {
+        resolve(result.output);
+      } else {
+        reject(result.error);
+      }
+    };
+    const timeout = setTimeout(() => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // best-effort cleanup for a stalled process-list command
+      }
+      child.unref();
+      finish({
+        error: new Error(`${description} did not exit within ${PROCESS_LIST_COMMAND_TIMEOUT_MS}ms`),
+      });
+    }, PROCESS_LIST_COMMAND_TIMEOUT_MS);
 
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
@@ -286,17 +340,19 @@ async function runCapturedCommand(
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
     });
-    child.once("error", reject);
+    child.once("error", (error) => {
+      finish({ error });
+    });
     child.once("close", (code, signal) => {
       if (code === 0) {
-        resolve(stdout);
+        finish({ output: stdout });
         return;
       }
-      reject(
-        new Error(
+      finish({
+        error: new Error(
           `${description} exited with code ${code ?? "null"} signal ${signal ?? "null"}: ${stderr}`,
         ),
-      );
+      });
     });
   });
 }

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -25,6 +25,7 @@ import {
 } from "../spawn-command-options.js";
 import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } from "../types.js";
 import {
+  beginProcessTreeTracking,
   createManagedProcessTree,
   rememberProcessTreePids,
   signalProcessTree,
@@ -218,6 +219,7 @@ export class TerminalManager {
         exitPromise,
         resolveExit,
       };
+      beginProcessTreeTracking(terminal.processTree);
 
       const appendOutput = (chunk: Buffer | string): void => {
         const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -470,14 +470,18 @@ export class TerminalManager {
       return;
     }
 
-    await this.waitForCleanupAfterSignal(terminal);
+    await this.waitForCleanupAfterSignal(terminal, "SIGKILL");
   }
 
-  private async waitForCleanupAfterSignal(terminal: ManagedTerminal): Promise<boolean> {
+  private async waitForCleanupAfterSignal(
+    terminal: ManagedTerminal,
+    finalSignal?: NodeJS.Signals,
+  ): Promise<boolean> {
     return await waitForProcessTreeExit(
       terminal.processTree,
       () => this.isRunning(terminal),
       this.killGraceMs,
+      finalSignal,
     );
   }
 }

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -203,6 +203,7 @@ export class TerminalManager {
         0,
         Math.round(params.outputByteLimit ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES),
       );
+      const rootCreatedAfterMs = Date.now();
       const { proc, spawnCommand } = await spawnTerminalProcess(params, this.cwd);
 
       let resolveExit: (response: WaitForTerminalExitResponse) => void = () => {};
@@ -212,7 +213,12 @@ export class TerminalManager {
 
       const terminal: ManagedTerminal = {
         process: proc,
-        processTree: createManagedProcessTree(proc.pid, spawnCommand.killProcessGroup),
+        processTree: createManagedProcessTree(
+          proc.pid,
+          spawnCommand.killProcessGroup,
+          process.platform,
+          rootCreatedAfterMs,
+        ),
         output: Buffer.alloc(0),
         truncated: false,
         outputByteLimit,
@@ -221,7 +227,10 @@ export class TerminalManager {
         exitPromise,
         resolveExit,
       };
-      beginProcessTreeTracking(terminal.processTree);
+      beginProcessTreeTracking(
+        terminal.processTree,
+        () => proc.exitCode === null && proc.signalCode === null,
+      );
 
       const appendOutput = (chunk: Buffer | string): void => {
         const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -26,6 +26,7 @@ import {
 import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } from "../types.js";
 import {
   beginProcessTreeTracking,
+  captureProcessTreePids,
   createManagedProcessTree,
   rememberProcessTreePids,
   signalProcessTree,
@@ -35,6 +36,7 @@ import {
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
 const DEFAULT_KILL_GRACE_MS = 1_500;
+const TERMINAL_OUTPUT_DRAIN_GRACE_MS = 50;
 
 type ManagedTerminal = {
   process: ChildProcessByStdio<null, Readable, Readable>;
@@ -236,14 +238,24 @@ export class TerminalManager {
 
       proc.stdout.on("data", appendOutput);
       proc.stderr.on("data", appendOutput);
+      const outputDrained = Promise.all([
+        waitForReadableCompletion(proc.stdout),
+        waitForReadableCompletion(proc.stderr),
+      ]).then(() => {});
       proc.once("exit", (exitCode, signal) => {
         terminal.exitCode = exitCode;
         terminal.signal = signal;
         rememberProcessTreePids(terminal.processTree);
-        terminal.resolveExit({
-          exitCode: exitCode ?? null,
-          signal: signal ?? null,
-        });
+        void (async () => {
+          await Promise.all([
+            captureProcessTreePids(terminal.processTree, false),
+            waitForTerminalOutputDrain(outputDrained),
+          ]);
+          terminal.resolveExit({
+            exitCode: exitCode ?? null,
+            signal: signal ?? null,
+          });
+        })();
       });
 
       const terminalId = randomUUID();
@@ -468,6 +480,31 @@ export class TerminalManager {
       this.killGraceMs,
     );
   }
+}
+
+function waitForReadableCompletion(stream: Readable): Promise<void> {
+  if (stream.readableEnded || stream.closed) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    const finish = (): void => {
+      stream.off("end", finish);
+      stream.off("close", finish);
+      resolve();
+    };
+    stream.once("end", finish);
+    stream.once("close", finish);
+  });
+}
+
+async function waitForTerminalOutputDrain(outputDrained: Promise<void>): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, TERMINAL_OUTPUT_DRAIN_GRACE_MS);
+    void outputDrained.then(() => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
 }
 
 async function spawnTerminalProcess(

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -24,15 +24,20 @@ import {
   type TerminalSpawnCommand,
 } from "../spawn-command-options.js";
 import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } from "../types.js";
+import {
+  createManagedProcessTree,
+  rememberProcessTreePids,
+  signalProcessTree,
+  waitForProcessTreeExit,
+  type ManagedProcessTree,
+} from "./process-tree.js";
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
 const DEFAULT_KILL_GRACE_MS = 1_500;
 
 type ManagedTerminal = {
   process: ChildProcessByStdio<null, Readable, Readable>;
-  killProcessGroup: boolean;
-  descendantPids: Set<number>;
-  processGroupSnapshotPromise?: Promise<void>;
+  processTree: ManagedProcessTree;
   output: Buffer;
   truncated: boolean;
   outputByteLimit: number;
@@ -147,12 +152,6 @@ function canPromptForPermission(): boolean {
   return process.stdin.isTTY && process.stderr.isTTY;
 }
 
-function waitMs(ms: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, Math.max(0, ms));
-  });
-}
-
 export class TerminalManager {
   private readonly cwd: string;
   private permissionMode: PermissionMode;
@@ -210,8 +209,7 @@ export class TerminalManager {
 
       const terminal: ManagedTerminal = {
         process: proc,
-        killProcessGroup: spawnCommand.killProcessGroup,
-        descendantPids: new Set(),
+        processTree: createManagedProcessTree(proc.pid, spawnCommand.killProcessGroup),
         output: Buffer.alloc(0),
         truncated: false,
         outputByteLimit,
@@ -239,14 +237,11 @@ export class TerminalManager {
       proc.once("exit", (exitCode, signal) => {
         terminal.exitCode = exitCode;
         terminal.signal = signal;
-        terminal.processGroupSnapshotPromise = rememberProcessGroupPids(terminal);
-        void (async () => {
-          await terminal.processGroupSnapshotPromise;
-          terminal.resolveExit({
-            exitCode: exitCode ?? null,
-            signal: signal ?? null,
-          });
-        })();
+        rememberProcessTreePids(terminal.processTree);
+        terminal.resolveExit({
+          exitCode: exitCode ?? null,
+          signal: signal ?? null,
+        });
       });
 
       const terminalId = randomUUID();
@@ -440,23 +435,23 @@ export class TerminalManager {
   }
 
   private async killProcess(terminal: ManagedTerminal): Promise<void> {
-    if (!this.isRunning(terminal) && !terminal.killProcessGroup) {
+    if (!this.isRunning(terminal) && !terminal.processTree.killProcessGroup) {
       return;
     }
 
     try {
-      await this.signalProcess(terminal, "SIGTERM");
+      await signalProcessTree(terminal.processTree, this.isRunning(terminal), "SIGTERM");
     } catch {
       return;
     }
 
     const exitedAfterTerm = await this.waitForCleanupAfterSignal(terminal);
-    if (exitedAfterTerm && !terminal.killProcessGroup) {
+    if (exitedAfterTerm) {
       return;
     }
 
     try {
-      await this.signalProcess(terminal, "SIGKILL");
+      await signalProcessTree(terminal.processTree, this.isRunning(terminal), "SIGKILL");
     } catch {
       return;
     }
@@ -464,75 +459,12 @@ export class TerminalManager {
     await this.waitForCleanupAfterSignal(terminal);
   }
 
-  private async signalProcess(terminal: ManagedTerminal, signal: NodeJS.Signals): Promise<void> {
-    const pid = terminal.process.pid;
-    if (terminal.killProcessGroup && pid && process.platform === "win32") {
-      await this.signalWindowsProcessGroup(terminal, pid, signal);
-      return;
-    }
-    if (terminal.killProcessGroup && pid) {
-      await this.signalPosixProcessGroup(terminal, pid, signal);
-      return;
-    }
-    terminal.process.kill(signal);
-  }
-
-  private async signalWindowsProcessGroup(
-    terminal: ManagedTerminal,
-    pid: number,
-    signal: NodeJS.Signals,
-  ): Promise<void> {
-    await this.captureDescendantPids(terminal, pid);
-    if (this.isRunning(terminal)) {
-      await killWindowsProcessTree(pid, signal);
-      return;
-    }
-    for (const descendantPid of terminal.descendantPids) {
-      await killWindowsProcessTree(descendantPid, signal);
-    }
-  }
-
-  private async signalPosixProcessGroup(
-    terminal: ManagedTerminal,
-    pid: number,
-    signal: NodeJS.Signals,
-  ): Promise<void> {
-    await this.captureDescendantPids(terminal, pid);
-    if (hasLiveProcessGroup(pid)) {
-      sendSignal(-pid, signal);
-      return;
-    }
-    for (const descendantPid of terminal.descendantPids) {
-      sendSignal(descendantPid, signal);
-    }
-  }
-
-  private async captureDescendantPids(terminal: ManagedTerminal, pid: number): Promise<void> {
-    if (!this.isRunning(terminal)) {
-      await terminal.processGroupSnapshotPromise?.catch(() => {
-        // ignore best-effort process group snapshot failures
-      });
-    }
-    for (const descendantPid of await listDescendantPids(pid)) {
-      terminal.descendantPids.add(descendantPid);
-    }
-  }
-
   private async waitForCleanupAfterSignal(terminal: ManagedTerminal): Promise<boolean> {
-    return await Promise.race([
-      this.waitForTerminalAndTrackedDescendants(terminal).then(() => true),
-      waitMs(this.killGraceMs).then(() => false),
-    ]);
-  }
-
-  private async waitForTerminalAndTrackedDescendants(terminal: ManagedTerminal): Promise<void> {
-    await terminal.exitPromise;
-    while (hasLiveTerminalProcessGroup(terminal)) {
-      await waitMs(25);
-    }
-    while (hasLivePid(terminal.descendantPids)) {
-      await waitMs(25);
-    }
+    return await waitForProcessTreeExit(
+      terminal.processTree,
+      () => this.isRunning(terminal),
+      this.killGraceMs,
+    );
   }
 }
 
@@ -626,259 +558,4 @@ function commandPathExists(command: string, cwd: string): boolean {
   }
   const resolvedPath = path.isAbsolute(command) ? command : path.resolve(cwd, command);
   return fs.existsSync(resolvedPath);
-}
-
-async function listDescendantPids(rootPid: number): Promise<number[]> {
-  let output: string;
-  try {
-    output = await runProcessListCommand();
-  } catch {
-    return [];
-  }
-
-  const childrenByParent = new Map<number, number[]>();
-  for (const line of output.split("\n")) {
-    addProcessListLine(childrenByParent, line);
-  }
-
-  const descendants: number[] = [];
-  const queue = [...(childrenByParent.get(rootPid) ?? [])];
-  for (let index = 0; index < queue.length; index += 1) {
-    const pid = queue[index];
-    descendants.push(pid);
-    queue.push(...(childrenByParent.get(pid) ?? []));
-  }
-  return descendants;
-}
-
-function addProcessListLine(childrenByParent: Map<number, number[]>, line: string): void {
-  const parsed = parseProcessListLine(line);
-  if (!parsed) {
-    return;
-  }
-
-  const children = childrenByParent.get(parsed.parentPid);
-  if (children) {
-    children.push(parsed.pid);
-  } else {
-    childrenByParent.set(parsed.parentPid, [parsed.pid]);
-  }
-}
-
-function parseProcessListLine(line: string): { pid: number; parentPid: number } | undefined {
-  const match = line.trim().match(/^(\d+)\s+(\d+)$/);
-  if (!match) {
-    return undefined;
-  }
-
-  const pid = Number(match[1]);
-  const parentPid = Number(match[2]);
-  if (!Number.isInteger(pid) || !Number.isInteger(parentPid) || pid <= 0 || parentPid <= 0) {
-    return undefined;
-  }
-  return { pid, parentPid };
-}
-
-async function runProcessListCommand(): Promise<string> {
-  if (process.platform === "win32") {
-    return await runWindowsProcessListCommand();
-  }
-
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn("ps", ["-eo", "pid=,ppid="], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(`ps exited with code ${code ?? "null"} signal ${signal ?? "null"}: ${stderr}`),
-      );
-    });
-  });
-}
-
-async function rememberProcessGroupPids(terminal: ManagedTerminal): Promise<void> {
-  const processGroupId = terminal.process.pid;
-  if (!terminal.killProcessGroup || !processGroupId) {
-    return;
-  }
-
-  if (process.platform === "win32") {
-    for (const pid of await listDescendantPids(processGroupId)) {
-      terminal.descendantPids.add(pid);
-    }
-    return;
-  }
-
-  for (const pid of await listProcessGroupPids(processGroupId)) {
-    if (pid !== processGroupId) {
-      terminal.descendantPids.add(pid);
-    }
-  }
-}
-
-async function listProcessGroupPids(processGroupId: number): Promise<number[]> {
-  let output: string;
-  try {
-    output = await runProcessGroupListCommand();
-  } catch {
-    return [];
-  }
-
-  const pids: number[] = [];
-  for (const line of output.split("\n")) {
-    const match = line.trim().match(/^(\d+)\s+(\d+)$/);
-    if (!match) {
-      continue;
-    }
-
-    const pid = Number(match[1]);
-    const pgid = Number(match[2]);
-    if (Number.isInteger(pid) && Number.isInteger(pgid) && pid > 0 && pgid === processGroupId) {
-      pids.push(pid);
-    }
-  }
-  return pids;
-}
-
-async function runProcessGroupListCommand(): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn("ps", ["-eo", "pid=,pgid="], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(`ps exited with code ${code ?? "null"} signal ${signal ?? "null"}: ${stderr}`),
-      );
-    });
-  });
-}
-
-async function runWindowsProcessListCommand(): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const command = [
-      "Get-CimInstance Win32_Process |",
-      'ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
-    ].join(" ");
-    const child = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], {
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(
-          `powershell process list exited with code ${code ?? "null"} signal ${
-            signal ?? "null"
-          }: ${stderr}`,
-        ),
-      );
-    });
-  });
-}
-
-async function killWindowsProcessTree(pid: number, signal: NodeJS.Signals): Promise<void> {
-  const args = ["/pid", String(pid), "/t"];
-  if (signal === "SIGKILL") {
-    args.push("/f");
-  }
-  await new Promise<void>((resolve) => {
-    const child = spawn("taskkill", args, {
-      stdio: ["ignore", "ignore", "ignore"],
-      windowsHide: true,
-    });
-    child.once("error", () => resolve());
-    child.once("close", () => resolve());
-  });
-}
-
-function sendSignal(pid: number, signal: NodeJS.Signals): void {
-  try {
-    process.kill(pid, signal);
-  } catch {
-    // Process tree cleanup is best-effort because descendants can exit between ps and kill.
-  }
-}
-
-function hasLiveProcessGroup(processGroupId: number): boolean {
-  try {
-    process.kill(-processGroupId, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function hasLiveTerminalProcessGroup(terminal: ManagedTerminal): boolean {
-  const pid = terminal.process.pid;
-  return Boolean(
-    terminal.killProcessGroup && pid && process.platform !== "win32" && hasLiveProcessGroup(pid),
-  );
-}
-
-function hasLivePid(pids: Set<number>): boolean {
-  for (const pid of pids) {
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch {
-      pids.delete(pid);
-    }
-  }
-  return false;
 }

--- a/src/cli/queue/ipc-transport.ts
+++ b/src/cli/queue/ipc-transport.ts
@@ -70,7 +70,9 @@ export async function connectToQueueOwner(
       if (!shouldRetryQueueConnect(error)) {
         throw error;
       }
-      await waitMs(QUEUE_CONNECT_RETRY_MS);
+      if (attempt + 1 < attempts) {
+        await waitMs(QUEUE_CONNECT_RETRY_MS);
+      }
     }
   }
 

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -52,7 +52,7 @@ export {
 } from "./lease-store.js";
 export type { QueueOwnerLease } from "./lease-store.js";
 
-const QUEUE_OWNER_STARTUP_GRACE_MS = 10_000;
+export const QUEUE_OWNER_STARTUP_GRACE_MS = 10_000;
 const STALE_OWNER_PROTOCOL_DETAIL_CODES = new Set([
   "QUEUE_PROTOCOL_MALFORMED_MESSAGE",
   "QUEUE_PROTOCOL_UNEXPECTED_RESPONSE",

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -425,7 +425,7 @@ async function submitToQueueOwner(
   return await runQueueOwnerRequest<SessionSendOutcome>({
     owner,
     request,
-    connectAttempts: options.startupProbe ? 1 : undefined,
+    connectAttempts: options.startupProbe && queueOwnerIsWithinStartupGrace(owner) ? 1 : undefined,
     onAccepted: ({ resolve }) => {
       options.onQueueAccepted?.();
       options.outputFormatter.setContext({

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -711,11 +711,15 @@ function assertQueueOwnerMcpConfigMatches(
   );
 }
 
-function unavailableOwnerCountsAsMissing(
-  health: QueueOwnerHealth,
+async function unavailableOwnerCountsAsMissing(
+  sessionId: string,
   startupProbe: boolean | undefined,
-): boolean {
-  return !health.hasLease || startupProbe === true;
+): Promise<boolean> {
+  if (startupProbe) {
+    return true;
+  }
+  const health = await probeQueueOwnerHealth(sessionId);
+  return !health.hasLease;
 }
 
 export async function trySubmitToRunningOwner(
@@ -754,8 +758,7 @@ export async function trySubmitToRunningOwner(
     return submitted;
   }
 
-  const health = await probeQueueOwnerHealth(options.sessionId);
-  if (unavailableOwnerCountsAsMissing(health, options.startupProbe)) {
+  if (await unavailableOwnerCountsAsMissing(options.sessionId, options.startupProbe)) {
     return undefined;
   }
 

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -201,11 +201,12 @@ function parseQueueOwnerResponseLine(
 async function runQueueOwnerRequest<TResult>(options: {
   owner: QueueOwnerRecord;
   request: QueueRequest;
+  connectAttempts?: number;
   onAccepted?: (controls: QueueOwnerRequestControls<TResult>) => void;
   onMessage: (message: QueueOwnerMessage, controls: QueueOwnerRequestControls<TResult>) => void;
   onClose: (controls: QueueOwnerRequestControls<TResult>) => void;
 }): Promise<TResult | undefined> {
-  const socket = await connectToQueueOwner(options.owner);
+  const socket = await connectToQueueOwner(options.owner, options.connectAttempts);
   if (!socket) {
     return undefined;
   }
@@ -322,6 +323,8 @@ export type SubmitToQueueOwnerOptions = {
   waitForCompletion: boolean;
   verbose?: boolean;
   sessionOptions?: NonNullable<AcpClientOptions["sessionOptions"]>;
+  /** Use a single connection probe and treat lease-before-bind as a startup miss. */
+  startupProbe?: boolean;
   /** Fires when the queue owner acknowledges the request (IPC accept), before completion. */
   onQueueAccepted?: () => void;
 };
@@ -415,6 +418,7 @@ async function submitToQueueOwner(
   return await runQueueOwnerRequest<SessionSendOutcome>({
     owner,
     request,
+    connectAttempts: options.startupProbe ? 1 : undefined,
     onAccepted: ({ resolve }) => {
       options.onQueueAccepted?.();
       options.outputFormatter.setContext({
@@ -707,6 +711,13 @@ function assertQueueOwnerMcpConfigMatches(
   );
 }
 
+function unavailableOwnerCountsAsMissing(
+  health: QueueOwnerHealth,
+  startupProbe: boolean | undefined,
+): boolean {
+  return !health.hasLease || startupProbe === true;
+}
+
 export async function trySubmitToRunningOwner(
   options: SubmitToQueueOwnerOptions,
 ): Promise<SessionSendOutcome | undefined> {
@@ -744,7 +755,7 @@ export async function trySubmitToRunningOwner(
   }
 
   const health = await probeQueueOwnerHealth(options.sessionId);
-  if (!health.hasLease) {
+  if (unavailableOwnerCountsAsMissing(health, options.startupProbe)) {
     return undefined;
   }
 

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -51,10 +51,16 @@ export {
 } from "./lease-store.js";
 export type { QueueOwnerLease } from "./lease-store.js";
 
+const QUEUE_OWNER_STARTUP_GRACE_MS = 10_000;
 const STALE_OWNER_PROTOCOL_DETAIL_CODES = new Set([
   "QUEUE_PROTOCOL_MALFORMED_MESSAGE",
   "QUEUE_PROTOCOL_UNEXPECTED_RESPONSE",
 ]);
+
+function queueOwnerIsWithinStartupGrace(owner: QueueOwnerRecord): boolean {
+  const createdAt = Date.parse(owner.createdAt);
+  return Number.isFinite(createdAt) && Date.now() - createdAt < QUEUE_OWNER_STARTUP_GRACE_MS;
+}
 
 async function maybeRecoverStaleOwnerAfterProtocolMismatch(params: {
   sessionId: string;
@@ -713,10 +719,16 @@ function assertQueueOwnerMcpConfigMatches(
 
 async function unavailableOwnerCountsAsMissing(
   sessionId: string,
+  owner: QueueOwnerRecord,
   startupProbe: boolean | undefined,
 ): Promise<boolean> {
   if (startupProbe) {
-    return true;
+    const latestOwner = await readQueueOwnerRecord(sessionId);
+    return (
+      !latestOwner ||
+      latestOwner.ownerGeneration !== owner.ownerGeneration ||
+      queueOwnerIsWithinStartupGrace(latestOwner)
+    );
   }
   const health = await probeQueueOwnerHealth(sessionId);
   return !health.hasLease;
@@ -758,7 +770,7 @@ export async function trySubmitToRunningOwner(
     return submitted;
   }
 
-  if (await unavailableOwnerCountsAsMissing(options.sessionId, options.startupProbe)) {
+  if (await unavailableOwnerCountsAsMissing(options.sessionId, owner, options.startupProbe)) {
     return undefined;
   }
 

--- a/src/cli/queue/ipc.ts
+++ b/src/cli/queue/ipc.ts
@@ -18,6 +18,7 @@ import { probeQueueOwnerHealth, type QueueOwnerHealth } from "./ipc-health.js";
 import { connectToQueueOwner } from "./ipc-transport.js";
 import {
   ensureOwnerIsUsable,
+  isProcessAlive,
   type QueueOwnerRecord,
   readQueueOwnerRecord,
   terminateQueueOwnerForSession,
@@ -727,7 +728,7 @@ async function unavailableOwnerCountsAsMissing(
     return (
       !latestOwner ||
       latestOwner.ownerGeneration !== owner.ownerGeneration ||
-      queueOwnerIsWithinStartupGrace(latestOwner)
+      (queueOwnerIsWithinStartupGrace(latestOwner) && isProcessAlive(latestOwner.pid))
     );
   }
   const health = await probeQueueOwnerHealth(sessionId);

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -1,5 +1,7 @@
 import { randomInt, randomUUID } from "node:crypto";
+import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
+import { readProcessIdentity } from "../../acp/process-tree.js";
 import { isProcessAlive } from "../../process-liveness.js";
 import { queueBaseDir, queueLockFilePath, queueSocketBaseDir, queueSocketPath } from "./paths.js";
 
@@ -15,6 +17,8 @@ const PROCESS_SIGTERM_GRACE_MS = 6_500;
 // After SIGKILL the OS terminates the process almost immediately; 1 500 ms is generous.
 const PROCESS_SIGKILL_GRACE_MS = 1_500;
 const PROCESS_POLL_MS = 50;
+const QUEUE_OWNER_CLEANUP_CLAIM_WAIT_MS = 1_000;
+const QUEUE_OWNER_CLEANUP_CLAIM_POLL_MS = 10;
 const QUEUE_OWNER_STALE_HEARTBEAT_MS = 15_000;
 const QUEUE_OWNER_MALFORMED_LOCK_STALE_MS = QUEUE_OWNER_STALE_HEARTBEAT_MS;
 
@@ -184,19 +188,60 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boole
 async function cleanupStaleQueueOwner(
   sessionId: string,
   owner: QueueOwnerRecord | undefined,
-): Promise<void> {
+  expectedLockStat?: Stats,
+): Promise<boolean> {
   const lockPath = queueLockFilePath(sessionId);
   const socketPath = owner?.socketPath ?? queueSocketPath(sessionId);
+  const claim = await claimQueueOwnerLockForCleanup(
+    lockPath,
+    owner?.ownerGeneration,
+    expectedLockStat,
+  );
+  if (!claim) {
+    return false;
+  }
 
+  try {
+    if (owner && isProcessAlive(owner.pid)) {
+      await terminateProcess(owner.pid);
+    }
+    await removeClaimedQueueOwnerFiles(claim, socketPath, lockPath);
+    return true;
+  } finally {
+    await claim.release();
+  }
+}
+
+async function claimQueueOwnerLockForCleanup(
+  lockPath: string,
+  expectedGeneration?: number,
+  expectedStat?: Stats,
+): Promise<QueueOwnerLockClaim | undefined> {
+  const deadline = Date.now() + QUEUE_OWNER_CLEANUP_CLAIM_WAIT_MS;
+  do {
+    const claim = await claimQueueOwnerLock(lockPath, expectedGeneration, expectedStat);
+    if (claim) {
+      return claim;
+    }
+    await waitMs(QUEUE_OWNER_CLEANUP_CLAIM_POLL_MS);
+  } while (Date.now() < deadline);
+  return undefined;
+}
+
+async function removeClaimedQueueOwnerFiles(
+  claim: QueueOwnerLockClaim,
+  socketPath: string,
+  lockPath: string,
+): Promise<void> {
+  if (!(await claim.isHeld())) {
+    return;
+  }
   await removeSocketFile(socketPath).catch(() => {
     // ignore stale socket cleanup failures
   });
-
-  await fs.unlink(lockPath).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  });
+  if (await claim.isHeld()) {
+    await unlinkIfPresent(lockPath);
+  }
 }
 
 function queueOwnerLockTempPath(lockPath: string): string {
@@ -227,30 +272,268 @@ async function writeQueueOwnerFileAtomically(
   }
 }
 
-async function malformedQueueOwnerLockIsStale(lockPath: string): Promise<boolean> {
+async function staleMalformedQueueOwnerLockStat(lockPath: string): Promise<Stats | undefined> {
   try {
     const stat = await fs.lstat(lockPath);
-    return Date.now() - stat.mtimeMs > QUEUE_OWNER_MALFORMED_LOCK_STALE_MS;
+    return Date.now() - stat.mtimeMs > QUEUE_OWNER_MALFORMED_LOCK_STALE_MS ? stat : undefined;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
 async function retireStaleQueueOwner(
   sessionId: string,
   owner: QueueOwnerRecord | undefined,
-): Promise<void> {
-  if (owner && isProcessAlive(owner.pid)) {
-    await terminateProcess(owner.pid);
+): Promise<boolean> {
+  return await cleanupStaleQueueOwner(sessionId, owner);
+}
+
+export type QueueOwnerLockClaim = {
+  isHeld: () => Promise<boolean>;
+  release: () => Promise<void>;
+};
+
+type QueueOwnerLockClaimRecord = {
+  claimId: string;
+  pid: number;
+  processIdentity?: string;
+};
+
+let currentProcessIdentityPromise: Promise<string | undefined> | undefined;
+
+function queueOwnerLockClaimPath(lockPath: string, stat: Stats): string {
+  return `${lockPath}.claim-${stat.dev}-${stat.ino}`;
+}
+
+export async function claimQueueOwnerLock(
+  lockPath: string,
+  expectedGeneration?: number,
+  expectedStat?: Stats,
+): Promise<QueueOwnerLockClaim | undefined> {
+  const observedStat = expectedStat ?? (await lstatIfPresent(lockPath));
+  if (!observedStat) {
+    return undefined;
+  }
+  const claimPath = queueOwnerLockClaimPath(lockPath, observedStat);
+  const claimRecord = await currentQueueOwnerLockClaimRecord();
+  if (!(await createOrRecoverQueueOwnerLockClaim(claimPath, claimRecord))) {
+    return undefined;
+  }
+  const claim = {
+    isHeld: async (): Promise<boolean> => {
+      const current = await readQueueOwnerLockClaimRecord(claimPath);
+      return current?.claimId === claimRecord.claimId;
+    },
+    release: async (): Promise<void> => {
+      if ((await readQueueOwnerLockClaimRecord(claimPath))?.claimId === claimRecord.claimId) {
+        await unlinkIfPresent(claimPath);
+      }
+    },
+  };
+  if (!(await validateQueueOwnerLockClaim(lockPath, observedStat, expectedGeneration, claim))) {
+    return undefined;
+  }
+  return claim;
+}
+
+async function currentQueueOwnerLockClaimRecord(): Promise<QueueOwnerLockClaimRecord> {
+  currentProcessIdentityPromise ??= readProcessIdentity(process.pid);
+  return {
+    claimId: randomUUID(),
+    pid: process.pid,
+    processIdentity: await currentProcessIdentityPromise,
+  };
+}
+
+async function createOrRecoverQueueOwnerLockClaim(
+  claimPath: string,
+  claimRecord: QueueOwnerLockClaimRecord,
+): Promise<boolean> {
+  if (await tryCreateQueueOwnerLockClaim(claimPath, claimRecord)) {
+    return true;
+  }
+  if (!(await recoverStaleQueueOwnerLockClaim(claimPath))) {
+    return false;
+  }
+  return await tryCreateQueueOwnerLockClaim(claimPath, claimRecord);
+}
+
+async function tryCreateQueueOwnerLockClaim(
+  claimPath: string,
+  claimRecord: QueueOwnerLockClaimRecord,
+): Promise<boolean> {
+  try {
+    await fs.writeFile(claimPath, `${JSON.stringify(claimRecord)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST" || code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+  return true;
+}
+
+async function recoverStaleQueueOwnerLockClaim(claimPath: string): Promise<boolean> {
+  const observedStat = await lstatIfPresent(claimPath);
+  if (!observedStat || !(await queueOwnerLockClaimIsStale(claimPath, observedStat))) {
+    return false;
   }
 
-  await cleanupStaleQueueOwner(sessionId, owner);
+  const quarantinePath = `${claimPath}.reap-${process.pid}-${randomUUID()}`;
+  try {
+    await fs.rename(claimPath, quarantinePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
+    throw error;
+  }
+
+  const movedStat = await lstatIfPresent(quarantinePath);
+  if (!movedStat || !sameFileIdentity(observedStat, movedStat)) {
+    await restoreDisplacedQueueOwnerLockClaim(quarantinePath, claimPath);
+    return false;
+  }
+  if (!(await queueOwnerLockClaimIsStale(quarantinePath, movedStat))) {
+    await restoreDisplacedQueueOwnerLockClaim(quarantinePath, claimPath);
+    return false;
+  }
+  await unlinkIfPresent(quarantinePath);
+  return true;
+}
+
+async function restoreDisplacedQueueOwnerLockClaim(
+  quarantinePath: string,
+  claimPath: string,
+): Promise<void> {
+  try {
+    await fs.rename(quarantinePath, claimPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+    await unlinkIfPresent(quarantinePath);
+  }
+}
+
+async function queueOwnerLockClaimIsStale(claimPath: string, stat: Stats): Promise<boolean> {
+  const claimRecord = await readQueueOwnerLockClaimRecord(claimPath);
+  if (!claimRecord) {
+    return Date.now() - stat.mtimeMs > QUEUE_OWNER_MALFORMED_LOCK_STALE_MS;
+  }
+  if (!claimantProcessIsAlive(claimRecord.pid)) {
+    return true;
+  }
+  if (!claimRecord.processIdentity) {
+    return Date.now() - stat.mtimeMs > QUEUE_OWNER_MALFORMED_LOCK_STALE_MS;
+  }
+  const currentIdentity = await readProcessIdentity(claimRecord.pid);
+  return currentIdentity !== undefined && currentIdentity !== claimRecord.processIdentity;
+}
+
+function claimantProcessIsAlive(pid: number): boolean {
+  return pid === process.pid || isProcessAlive(pid);
+}
+
+async function readQueueOwnerLockClaimRecord(
+  claimPath: string,
+): Promise<QueueOwnerLockClaimRecord | undefined> {
+  try {
+    const parsed: unknown = JSON.parse(await fs.readFile(claimPath, "utf8"));
+    return parseQueueOwnerLockClaimRecord(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseQueueOwnerLockClaimRecord(value: unknown): QueueOwnerLockClaimRecord | undefined {
+  if (!isQueueOwnerLockClaimRecord(value)) {
+    return undefined;
+  }
+  return {
+    claimId: value.claimId,
+    pid: value.pid,
+    processIdentity: value.processIdentity,
+  };
+}
+
+function isQueueOwnerLockClaimRecord(value: unknown): value is QueueOwnerLockClaimRecord {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    isNonEmptyString(candidate.claimId) &&
+    isPositiveInteger(candidate.pid) &&
+    isOptionalString(candidate.processIdentity)
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+async function validateQueueOwnerLockClaim(
+  lockPath: string,
+  observedStat: Stats,
+  expectedGeneration: number | undefined,
+  claim: QueueOwnerLockClaim,
+): Promise<boolean> {
+  let valid = false;
+  try {
+    const currentStat = await lstatIfPresent(lockPath);
+    valid = Boolean(currentStat && sameFileIdentity(observedStat, currentStat));
+    if (valid && expectedGeneration !== undefined) {
+      const claimedOwner = await readQueueOwnerRecordAtPath(lockPath);
+      valid = claimedOwner?.ownerGeneration === expectedGeneration;
+    }
+    return valid;
+  } finally {
+    if (!valid) {
+      await claim.release();
+    }
+  }
+}
+
+async function lstatIfPresent(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await fs.lstat(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function sameFileIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function unlinkIfPresent(filePath: string): Promise<void> {
+  await fs.unlink(filePath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  });
 }
 
 export async function readQueueOwnerRecord(
   sessionId: string,
 ): Promise<QueueOwnerRecord | undefined> {
-  const lockPath = queueLockFilePath(sessionId);
+  return await readQueueOwnerRecordAtPath(queueLockFilePath(sessionId));
+}
+
+async function readQueueOwnerRecordAtPath(lockPath: string): Promise<QueueOwnerRecord | undefined> {
   try {
     const payload = await fs.readFile(lockPath, "utf8");
     const parsed = parseQueueOwnerRecord(JSON.parse(payload));
@@ -340,44 +623,62 @@ export async function tryAcquireQueueOwnerLease(
   await ensureQueueDir();
   const lockPath = queueLockFilePath(sessionId);
   const socketPath = queueSocketPath(sessionId);
-  const createdAt = clock();
+  let createdAt = clock();
   const ownerGeneration = createOwnerGeneration();
-  const payload = JSON.stringify(
-    {
-      pid: process.pid,
-      sessionId,
-      socketPath,
-      createdAt,
-      heartbeatAt: createdAt,
-      ownerGeneration,
-      queueDepth: 0,
-      ...mcpConfigMetadata,
-    },
-    null,
-    2,
-  );
+  const buildPayload = () =>
+    JSON.stringify(
+      {
+        pid: process.pid,
+        sessionId,
+        socketPath,
+        createdAt,
+        heartbeatAt: createdAt,
+        ownerGeneration,
+        queueDepth: 0,
+        ...mcpConfigMetadata,
+      },
+      null,
+      2,
+    );
+  let payload = buildPayload();
 
+  let acquired = false;
   try {
     await writeQueueOwnerFileAtomically(lockPath, `${payload}\n`, "create");
-    await removeSocketFile(socketPath).catch(() => {
-      // best-effort stale socket cleanup after ownership is acquired
-    });
-    const lease = {
-      sessionId,
-      lockPath,
-      socketPath,
-      createdAt,
-      ownerGeneration,
-      ...mcpConfigMetadata,
-    };
-    queueOwnerLeaseStates.set(lease, {
-      pendingRefresh: Promise.resolve(),
-      released: false,
-    });
-    return lease;
+    acquired = true;
   } catch (error) {
-    return await handleLeaseCollision(sessionId, error);
+    if (!(await handleLeaseCollision(sessionId, error))) {
+      return undefined;
+    }
   }
+  if (!acquired) {
+    createdAt = clock();
+    payload = buildPayload();
+    try {
+      await writeQueueOwnerFileAtomically(lockPath, `${payload}\n`, "create");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+  await removeSocketFile(socketPath).catch(() => {
+    // best-effort stale socket cleanup after ownership is acquired
+  });
+  const lease = {
+    sessionId,
+    lockPath,
+    socketPath,
+    createdAt,
+    ownerGeneration,
+    ...mcpConfigMetadata,
+  };
+  queueOwnerLeaseStates.set(lease, {
+    pendingRefresh: Promise.resolve(),
+    released: false,
+  });
+  return lease;
 }
 
 function readMcpConfigFingerprint(
@@ -405,7 +706,7 @@ function createMcpConfigMetadata(
   };
 }
 
-async function handleLeaseCollision(sessionId: string, error: unknown): Promise<undefined> {
+async function handleLeaseCollision(sessionId: string, error: unknown): Promise<boolean> {
   if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
     throw error;
   }
@@ -413,16 +714,17 @@ async function handleLeaseCollision(sessionId: string, error: unknown): Promise<
   const owner = await readQueueOwnerRecord(sessionId);
   if (!owner) {
     const lockPath = queueLockFilePath(sessionId);
-    if (await malformedQueueOwnerLockIsStale(lockPath)) {
-      await cleanupStaleQueueOwner(sessionId, owner);
+    const staleLockStat = await staleMalformedQueueOwnerLockStat(lockPath);
+    if (staleLockStat) {
+      return await cleanupStaleQueueOwner(sessionId, owner, staleLockStat);
     }
-    return undefined;
+    return false;
   }
 
   if (!isProcessAlive(owner.pid) || isQueueOwnerHeartbeatStale(owner)) {
-    await retireStaleQueueOwner(sessionId, owner);
+    return await retireStaleQueueOwner(sessionId, owner);
   }
-  return undefined;
+  return false;
 }
 
 function resolveLeaseArguments(
@@ -460,7 +762,11 @@ export async function refreshQueueOwnerLease(
     return;
   }
   const refresh = state.pendingRefresh.then(async () => {
-    if (state.released || !(await queueOwnerLeaseStillOwnsLock(lease))) {
+    if (state.released) {
+      return;
+    }
+    const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    if (!claim) {
       return;
     }
     const payload = JSON.stringify(
@@ -478,7 +784,14 @@ export async function refreshQueueOwnerLease(
       null,
       2,
     );
-    await writeQueueOwnerFileAtomically(lease.lockPath, `${payload}\n`, "replace");
+    try {
+      if (!(await claim.isHeld())) {
+        return;
+      }
+      await writeQueueOwnerFileAtomically(lease.lockPath, `${payload}\n`, "replace");
+    } finally {
+      await claim.release();
+    }
   });
   state.pendingRefresh = refresh.catch(() => {
     // Keep the serialization chain usable after a best-effort refresh failure.
@@ -492,21 +805,24 @@ export async function releaseQueueOwnerLease(lease: QueueOwnerLease): Promise<vo
     state.released = true;
     state.releasePromise = (async () => {
       await state.pendingRefresh;
-      if (!(await queueOwnerLeaseStillOwnsLock(lease))) {
+      const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+      if (!claim) {
         return;
       }
-      await removeSocketFile(lease.socketPath).catch(() => {
-        // ignore best-effort cleanup failures
-      });
-
-      if (!(await queueOwnerLeaseStillOwnsLock(lease))) {
-        return;
-      }
-      await fs.unlink(lease.lockPath).catch((error) => {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          throw error;
+      try {
+        if (!(await claim.isHeld())) {
+          return;
         }
-      });
+        await removeSocketFile(lease.socketPath).catch(() => {
+          // ignore best-effort cleanup failures
+        });
+        if (!(await claim.isHeld())) {
+          return;
+        }
+        await unlinkIfPresent(lease.lockPath);
+      } finally {
+        await claim.release();
+      }
     })();
   }
   await state.releasePromise;
@@ -524,22 +840,15 @@ function queueOwnerLeaseState(lease: QueueOwnerLease): QueueOwnerLeaseState {
   return state;
 }
 
-async function queueOwnerLeaseStillOwnsLock(lease: QueueOwnerLease): Promise<boolean> {
-  const owner = await readQueueOwnerRecord(lease.sessionId);
-  return owner?.ownerGeneration === lease.ownerGeneration;
-}
-
 export async function terminateQueueOwnerForSession(sessionId: string): Promise<void> {
   const owner = await readQueueOwnerRecord(sessionId);
   if (!owner) {
     return;
   }
 
-  if (isProcessAlive(owner.pid)) {
-    await terminateProcess(owner.pid);
+  if (!(await cleanupStaleQueueOwner(sessionId, owner))) {
+    throw new Error(`Queue owner cleanup is busy for session ${sessionId}; retry the operation`);
   }
-
-  await cleanupStaleQueueOwner(sessionId, owner);
 }
 
 export async function waitMs(ms: number): Promise<void> {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -189,9 +189,9 @@ async function cleanupStaleQueueOwner(
   sessionId: string,
   owner: QueueOwnerRecord | undefined,
   expectedLockStat?: Stats,
+  revalidateStaleness = false,
 ): Promise<boolean> {
   const lockPath = queueLockFilePath(sessionId);
-  const socketPath = owner?.socketPath ?? queueSocketPath(sessionId);
   const claim = await claimQueueOwnerLockForCleanup(
     lockPath,
     owner?.ownerGeneration,
@@ -202,14 +202,40 @@ async function cleanupStaleQueueOwner(
   }
 
   try {
-    if (owner && isProcessAlive(owner.pid)) {
-      await terminateProcess(owner.pid);
+    const claimedOwner = await resolveQueueOwnerForCleanup(lockPath, owner, revalidateStaleness);
+    if (claimedOwner === false) {
+      return false;
     }
+    const socketPath = claimedOwner?.socketPath ?? queueSocketPath(sessionId);
+    await terminateClaimedQueueOwner(claimedOwner);
     await removeClaimedQueueOwnerFiles(claim, socketPath, lockPath);
     return true;
   } finally {
     await claim.release();
   }
+}
+
+async function terminateClaimedQueueOwner(owner: QueueOwnerRecord | undefined): Promise<void> {
+  if (owner && isProcessAlive(owner.pid)) {
+    await terminateProcess(owner.pid);
+  }
+}
+
+async function resolveQueueOwnerForCleanup(
+  lockPath: string,
+  owner: QueueOwnerRecord | undefined,
+  revalidateStaleness: boolean,
+): Promise<QueueOwnerRecord | false | undefined> {
+  if (!revalidateStaleness || !owner) {
+    return owner;
+  }
+  const currentOwner = await readQueueOwnerRecordAtPath(lockPath);
+  if (currentOwner?.ownerGeneration !== owner.ownerGeneration) {
+    return false;
+  }
+  return isProcessAlive(currentOwner.pid) && !isQueueOwnerHeartbeatStale(currentOwner)
+    ? false
+    : currentOwner;
 }
 
 async function claimQueueOwnerLockForCleanup(
@@ -285,7 +311,7 @@ async function retireStaleQueueOwner(
   sessionId: string,
   owner: QueueOwnerRecord | undefined,
 ): Promise<boolean> {
-  return await cleanupStaleQueueOwner(sessionId, owner);
+  return await cleanupStaleQueueOwner(sessionId, owner, undefined, true);
 }
 
 export type QueueOwnerLockClaim = {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -438,13 +438,17 @@ async function restoreDisplacedQueueOwnerLockClaim(
   claimPath: string,
 ): Promise<void> {
   try {
-    await fs.rename(quarantinePath, claimPath);
+    await fs.link(quarantinePath, claimPath);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return;
+    }
+    if (code !== "EEXIST") {
       throw error;
     }
-    await unlinkIfPresent(quarantinePath);
   }
+  await unlinkIfPresent(quarantinePath);
 }
 
 async function queueOwnerLockClaimIsStale(claimPath: string, stat: Stats): Promise<boolean> {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -1,4 +1,4 @@
-import { randomInt } from "node:crypto";
+import { randomInt, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import { isProcessAlive } from "../../process-liveness.js";
 import { queueBaseDir, queueLockFilePath, queueSocketBaseDir, queueSocketPath } from "./paths.js";
@@ -15,6 +15,7 @@ const PROCESS_SIGTERM_GRACE_MS = 4_000;
 const PROCESS_SIGKILL_GRACE_MS = 1_500;
 const PROCESS_POLL_MS = 50;
 const QUEUE_OWNER_STALE_HEARTBEAT_MS = 15_000;
+const QUEUE_OWNER_MALFORMED_LOCK_STALE_MS = QUEUE_OWNER_STALE_HEARTBEAT_MS;
 
 export type QueueOwnerRecord = {
   pid: number;
@@ -189,6 +190,43 @@ async function cleanupStaleQueueOwner(
   });
 }
 
+function queueOwnerLockTempPath(lockPath: string): string {
+  return `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
+}
+
+async function writeQueueOwnerFileAtomically(
+  lockPath: string,
+  payload: string,
+  operation: "create" | "replace",
+): Promise<void> {
+  const tempPath = queueOwnerLockTempPath(lockPath);
+  try {
+    await fs.writeFile(tempPath, payload, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    if (operation === "create") {
+      await fs.link(tempPath, lockPath);
+    } else {
+      await fs.rename(tempPath, lockPath);
+    }
+  } finally {
+    await fs.rm(tempPath, { force: true }).catch(() => {
+      // best-effort cleanup after publication or a failed collision
+    });
+  }
+}
+
+async function malformedQueueOwnerLockIsStale(lockPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(lockPath);
+    return Date.now() - stat.mtimeMs > QUEUE_OWNER_MALFORMED_LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
 async function retireStaleQueueOwner(
   sessionId: string,
   owner: QueueOwnerRecord | undefined,
@@ -311,10 +349,7 @@ export async function tryAcquireQueueOwnerLease(
   );
 
   try {
-    await fs.writeFile(lockPath, `${payload}\n`, {
-      encoding: "utf8",
-      flag: "wx",
-    });
+    await writeQueueOwnerFileAtomically(lockPath, `${payload}\n`, "create");
     await removeSocketFile(socketPath).catch(() => {
       // best-effort stale socket cleanup after ownership is acquired
     });
@@ -363,7 +398,10 @@ async function handleLeaseCollision(sessionId: string, error: unknown): Promise<
 
   const owner = await readQueueOwnerRecord(sessionId);
   if (!owner) {
-    await cleanupStaleQueueOwner(sessionId, owner);
+    const lockPath = queueLockFilePath(sessionId);
+    if (await malformedQueueOwnerLockIsStale(lockPath)) {
+      await cleanupStaleQueueOwner(sessionId, owner);
+    }
     return undefined;
   }
 
@@ -418,9 +456,7 @@ export async function refreshQueueOwnerLease(
     null,
     2,
   );
-  await fs.writeFile(lease.lockPath, `${payload}\n`, {
-    encoding: "utf8",
-  });
+  await writeQueueOwnerFileAtomically(lease.lockPath, `${payload}\n`, "replace");
 }
 
 export async function releaseQueueOwnerLease(lease: QueueOwnerLease): Promise<void> {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -39,6 +39,14 @@ export type QueueOwnerLease = {
   mcpConfigFingerprint?: string;
 };
 
+type QueueOwnerLeaseState = {
+  pendingRefresh: Promise<void>;
+  released: boolean;
+  releasePromise?: Promise<void>;
+};
+
+const queueOwnerLeaseStates = new WeakMap<QueueOwnerLease, QueueOwnerLeaseState>();
+
 export type QueueOwnerStatus = {
   pid: number;
   socketPath: string;
@@ -353,7 +361,7 @@ export async function tryAcquireQueueOwnerLease(
     await removeSocketFile(socketPath).catch(() => {
       // best-effort stale socket cleanup after ownership is acquired
     });
-    return {
+    const lease = {
       sessionId,
       lockPath,
       socketPath,
@@ -361,6 +369,11 @@ export async function tryAcquireQueueOwnerLease(
       ownerGeneration,
       ...mcpConfigMetadata,
     };
+    queueOwnerLeaseStates.set(lease, {
+      pendingRefresh: Promise.resolve(),
+      released: false,
+    });
+    return lease;
   } catch (error) {
     return await handleLeaseCollision(sessionId, error);
   }
@@ -441,34 +454,78 @@ export async function refreshQueueOwnerLease(
   },
   nowIsoFactory: () => string = nowIso,
 ): Promise<void> {
-  const payload = JSON.stringify(
-    {
-      pid: process.pid,
-      sessionId: lease.sessionId,
-      socketPath: lease.socketPath,
-      createdAt: lease.createdAt,
-      heartbeatAt: nowIsoFactory(),
-      ownerGeneration: lease.ownerGeneration,
-      queueDepth: Math.max(0, Math.round(options.queueDepth)),
-      ...(lease.mcpConfigPath ? { mcpConfigPath: lease.mcpConfigPath } : {}),
-      ...(lease.mcpConfigFingerprint ? { mcpConfigFingerprint: lease.mcpConfigFingerprint } : {}),
-    },
-    null,
-    2,
-  );
-  await writeQueueOwnerFileAtomically(lease.lockPath, `${payload}\n`, "replace");
+  const state = queueOwnerLeaseState(lease);
+  if (state.released) {
+    return;
+  }
+  const refresh = state.pendingRefresh.then(async () => {
+    if (state.released || !(await queueOwnerLeaseStillOwnsLock(lease))) {
+      return;
+    }
+    const payload = JSON.stringify(
+      {
+        pid: process.pid,
+        sessionId: lease.sessionId,
+        socketPath: lease.socketPath,
+        createdAt: lease.createdAt,
+        heartbeatAt: nowIsoFactory(),
+        ownerGeneration: lease.ownerGeneration,
+        queueDepth: Math.max(0, Math.round(options.queueDepth)),
+        ...(lease.mcpConfigPath ? { mcpConfigPath: lease.mcpConfigPath } : {}),
+        ...(lease.mcpConfigFingerprint ? { mcpConfigFingerprint: lease.mcpConfigFingerprint } : {}),
+      },
+      null,
+      2,
+    );
+    await writeQueueOwnerFileAtomically(lease.lockPath, `${payload}\n`, "replace");
+  });
+  state.pendingRefresh = refresh.catch(() => {
+    // Keep the serialization chain usable after a best-effort refresh failure.
+  });
+  await refresh;
 }
 
 export async function releaseQueueOwnerLease(lease: QueueOwnerLease): Promise<void> {
-  await removeSocketFile(lease.socketPath).catch(() => {
-    // ignore best-effort cleanup failures
-  });
+  const state = queueOwnerLeaseState(lease);
+  if (!state.releasePromise) {
+    state.released = true;
+    state.releasePromise = (async () => {
+      await state.pendingRefresh;
+      if (!(await queueOwnerLeaseStillOwnsLock(lease))) {
+        return;
+      }
+      await removeSocketFile(lease.socketPath).catch(() => {
+        // ignore best-effort cleanup failures
+      });
 
-  await fs.unlink(lease.lockPath).catch((error) => {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  });
+      if (!(await queueOwnerLeaseStillOwnsLock(lease))) {
+        return;
+      }
+      await fs.unlink(lease.lockPath).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      });
+    })();
+  }
+  await state.releasePromise;
+}
+
+function queueOwnerLeaseState(lease: QueueOwnerLease): QueueOwnerLeaseState {
+  let state = queueOwnerLeaseStates.get(lease);
+  if (!state) {
+    state = {
+      pendingRefresh: Promise.resolve(),
+      released: false,
+    };
+    queueOwnerLeaseStates.set(lease, state);
+  }
+  return state;
+}
+
+async function queueOwnerLeaseStillOwnsLock(lease: QueueOwnerLease): Promise<boolean> {
+  const owner = await readQueueOwnerRecord(lease.sessionId);
+  return owner?.ownerGeneration === lease.ownerGeneration;
 }
 
 export async function terminateQueueOwnerForSession(sessionId: string): Promise<void> {

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -8,9 +8,10 @@ export { isProcessAlive } from "../../process-liveness.js";
 // Budget for graceful SIGTERM shutdown of a queue-owner process.
 // The owner runs AcpClient.close() during shutdown:
 //   stdin-close grace (100 ms) + SIGTERM wait (1 500 ms) + SIGKILL wait (1 000 ms) = 2 600 ms worst case.
-// We add ~1 400 ms of headroom for event-loop latency and process startup overhead → 4 000 ms.
+// Process identity validation can add two bounded 1 000 ms process-list calls.
+// Add ~1 900 ms of headroom for those calls, event-loop latency, and process startup overhead.
 // If the owner does not exit within this window we escalate to SIGKILL.
-const PROCESS_SIGTERM_GRACE_MS = 4_000;
+const PROCESS_SIGTERM_GRACE_MS = 6_500;
 // After SIGKILL the OS terminates the process almost immediately; 1 500 ms is generous.
 const PROCESS_SIGKILL_GRACE_MS = 1_500;
 const PROCESS_POLL_MS = 50;
@@ -228,7 +229,7 @@ async function writeQueueOwnerFileAtomically(
 
 async function malformedQueueOwnerLockIsStale(lockPath: string): Promise<boolean> {
   try {
-    const stat = await fs.stat(lockPath);
+    const stat = await fs.lstat(lockPath);
     return Date.now() - stat.mtimeMs > QUEUE_OWNER_MALFORMED_LOCK_STALE_MS;
   } catch {
     return false;

--- a/src/cli/queue/lease-store.ts
+++ b/src/cli/queue/lease-store.ts
@@ -1,6 +1,7 @@
 import { randomInt, randomUUID } from "node:crypto";
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { readProcessIdentity } from "../../acp/process-tree.js";
 import { isProcessAlive } from "../../process-liveness.js";
 import { queueBaseDir, queueLockFilePath, queueSocketBaseDir, queueSocketPath } from "./paths.js";
@@ -351,15 +352,49 @@ export async function claimQueueOwnerLock(
       return current?.claimId === claimRecord.claimId;
     },
     release: async (): Promise<void> => {
-      if ((await readQueueOwnerLockClaimRecord(claimPath))?.claimId === claimRecord.claimId) {
-        await unlinkIfPresent(claimPath);
-      }
+      await releaseQueueOwnerLockClaim(claimPath, claimRecord.claimId);
     },
   };
   if (!(await validateQueueOwnerLockClaim(lockPath, observedStat, expectedGeneration, claim))) {
     return undefined;
   }
   return claim;
+}
+
+async function releaseQueueOwnerLockClaim(claimPath: string, claimId: string): Promise<void> {
+  if (await releaseQueueOwnerLockClaimAtPath(claimPath, claimId)) {
+    return;
+  }
+
+  const directory = path.dirname(claimPath);
+  const displacedPrefix = `${path.basename(claimPath)}.reap-`;
+  for (const entry of await readDirectoryIfPresent(directory)) {
+    if (entry.startsWith(displacedPrefix)) {
+      await releaseQueueOwnerLockClaimAtPath(path.join(directory, entry), claimId);
+    }
+  }
+
+  await releaseQueueOwnerLockClaimAtPath(claimPath, claimId);
+}
+
+async function releaseQueueOwnerLockClaimAtPath(
+  candidatePath: string,
+  claimId: string,
+): Promise<boolean> {
+  if ((await readQueueOwnerLockClaimRecord(candidatePath))?.claimId !== claimId) {
+    return false;
+  }
+  await unlinkIfPresent(candidatePath);
+  return true;
+}
+
+async function readDirectoryIfPresent(directory: string): Promise<string[]> {
+  return await fs.readdir(directory).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  });
 }
 
 async function currentQueueOwnerLockClaimRecord(): Promise<QueueOwnerLockClaimRecord> {
@@ -835,9 +870,18 @@ export async function releaseQueueOwnerLease(lease: QueueOwnerLease): Promise<vo
     state.released = true;
     state.releasePromise = (async () => {
       await state.pendingRefresh;
-      const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+      const claim = await claimQueueOwnerLockForCleanup(lease.lockPath, lease.ownerGeneration);
       if (!claim) {
-        return;
+        const currentOwner = await readQueueOwnerRecordAtPath(lease.lockPath);
+        if (!currentOwner || currentOwner.ownerGeneration !== lease.ownerGeneration) {
+          return;
+        }
+        if (await queueOwnerLockHasLiveExternalClaimant(lease.lockPath)) {
+          return;
+        }
+        throw new Error(
+          `Queue owner lease release is busy for session ${lease.sessionId}; retry cleanup`,
+        );
       }
       try {
         if (!(await claim.isHeld())) {
@@ -855,7 +899,34 @@ export async function releaseQueueOwnerLease(lease: QueueOwnerLease): Promise<vo
       }
     })();
   }
-  await state.releasePromise;
+  const releasePromise = state.releasePromise;
+  try {
+    await releasePromise;
+  } catch (error) {
+    if (state.releasePromise === releasePromise) {
+      state.releasePromise = undefined;
+      state.released = false;
+    }
+    throw error;
+  }
+}
+
+async function queueOwnerLockHasLiveExternalClaimant(lockPath: string): Promise<boolean> {
+  const lockStat = await lstatIfPresent(lockPath);
+  if (!lockStat) {
+    return false;
+  }
+  const claimPath = queueOwnerLockClaimPath(lockPath, lockStat);
+  const claimStat = await lstatIfPresent(claimPath);
+  if (!claimStat) {
+    return false;
+  }
+  const claimRecord = await readQueueOwnerLockClaimRecord(claimPath);
+  return Boolean(
+    claimRecord &&
+    claimRecord.pid !== process.pid &&
+    !(await queueOwnerLockClaimIsStale(claimPath, claimStat)),
+  );
 }
 
 function queueOwnerLeaseState(lease: QueueOwnerLease): QueueOwnerLeaseState {
@@ -877,6 +948,9 @@ export async function terminateQueueOwnerForSession(sessionId: string): Promise<
   }
 
   if (!(await cleanupStaleQueueOwner(sessionId, owner))) {
+    if (!(await readQueueOwnerRecord(sessionId))) {
+      return;
+    }
     throw new Error(`Queue owner cleanup is busy for session ${sessionId}; retry the operation`);
   }
 }

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -17,6 +17,7 @@ import {
 import type { SessionSendOutcome } from "../../types.js";
 import {
   QUEUE_CONNECT_RETRY_MS,
+  QUEUE_OWNER_STARTUP_GRACE_MS,
   SessionQueueOwner,
   releaseQueueOwnerLease,
   tryAcquireQueueOwnerLease,
@@ -48,7 +49,8 @@ import {
 } from "./queue-owner-process.js";
 import { runQueuedTask } from "./runtime.js";
 
-const QUEUE_OWNER_STARTUP_MAX_ATTEMPTS = 120;
+const QUEUE_OWNER_STARTUP_MAX_ATTEMPTS =
+  Math.ceil(QUEUE_OWNER_STARTUP_GRACE_MS / QUEUE_CONNECT_RETRY_MS) + 1;
 const QUEUE_OWNER_HEARTBEAT_INTERVAL_MS = 5_000;
 const QUEUE_OWNER_ACTIVE_TURN_CANCEL_GRACE_MS = 750;
 
@@ -573,4 +575,9 @@ export async function sendSession(options: SessionSendOptions): Promise<SessionS
 
 export type { QueueOwnerRuntimeOptions };
 export { DEFAULT_QUEUE_OWNER_TTL_MS };
-export const queueOwnerRuntimeTestInternals = { queueOwnerExitIsFatal };
+export const queueOwnerRuntimeTestInternals = {
+  queueOwnerExitIsFatal,
+  queueOwnerStartupGraceMs: QUEUE_OWNER_STARTUP_GRACE_MS,
+  queueOwnerStartupMaxAttempts: QUEUE_OWNER_STARTUP_MAX_ATTEMPTS,
+  queueConnectRetryMs: QUEUE_CONNECT_RETRY_MS,
+};

--- a/src/cli/session/queue-owner-runtime.ts
+++ b/src/cli/session/queue-owner-runtime.ts
@@ -74,6 +74,7 @@ async function submitToRunningOwner(
     waitForCompletion,
     verbose: options.verbose,
     sessionOptions: options.sessionOptions,
+    startupProbe: true,
     onQueueAccepted: extras?.onQueueAccepted,
   });
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1336,8 +1336,8 @@ test("AcpClient startup failure kills descendants left by an exited npx wrapper"
       "fixture must create a separate stubborn descendant",
     );
     assert.equal(
-      isPidAlive(descendantPid),
-      false,
+      await waitForPidExit(descendantPid),
+      true,
       "startup cleanup must not leave the adapter descendant alive",
     );
   } finally {
@@ -1444,6 +1444,14 @@ async function terminateTestPid(pid: number): Promise<void> {
   while (isPidAlive(pid) && Date.now() < deadline) {
     await new Promise<void>((resolve) => setTimeout(resolve, 25));
   }
+}
+
+async function waitForPidExit(pid: number, timeoutMs = 2_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (isPidAlive(pid) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+  return !isPidAlive(pid);
 }
 
 function asInternals(client: AcpClient): ClientInternals {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import test from "node:test";
@@ -1276,6 +1278,76 @@ test("AcpClient start fails fast when the agent exits during initialize", async 
   assert(Date.now() - startedAt < 2_000);
 });
 
+test("AcpClient startup failure kills descendants left by an exited npx wrapper", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-startup-tree-"));
+  const packageDir = path.join(tempDir, "adapter-package");
+  const processInfoPath = path.join(tempDir, "process-info.json");
+  let descendantPid: number | undefined;
+
+  try {
+    await fs.mkdir(packageDir, { recursive: true });
+    await fs.writeFile(
+      path.join(packageDir, "package.json"),
+      `${JSON.stringify({
+        name: "acpx-startup-tree-fixture",
+        version: "1.0.0",
+        bin: { "acpx-startup-tree-fixture": "adapter.cjs" },
+      })}\n`,
+    );
+    const adapterPath = path.join(packageDir, "adapter.cjs");
+    await fs.writeFile(
+      adapterPath,
+      [
+        "#!/usr/bin/env node",
+        'const { spawn } = require("node:child_process");',
+        'const fs = require("node:fs");',
+        'const child = spawn(process.execPath, ["-e", "process.on(\\"SIGTERM\\", () => {}); setInterval(() => {}, 1000);"], { stdio: "ignore" });',
+        `fs.writeFileSync(${JSON.stringify(processInfoPath)}, JSON.stringify({ adapterPid: process.pid, descendantPid: child.pid }));`,
+        "setTimeout(() => process.exit(17), 100);",
+        "",
+      ].join("\n"),
+    );
+    await fs.chmod(adapterPath, 0o755);
+
+    const client = makeClient({
+      agentCommand: `npx --yes --offline --package ${JSON.stringify(packageDir)} -- acpx-startup-tree-fixture`,
+      cwd: tempDir,
+      sessionOptions: {
+        env: {
+          HOME: tempDir,
+          npm_config_cache: path.join(tempDir, "npm-cache"),
+        },
+      },
+    });
+
+    await assert.rejects(() => client.start(), AgentStartupError);
+    const processInfo = JSON.parse(await fs.readFile(processInfoPath, "utf8")) as {
+      adapterPid: number;
+      descendantPid: number;
+    };
+    descendantPid = processInfo.descendantPid;
+    assert.notEqual(
+      processInfo.adapterPid,
+      descendantPid,
+      "fixture must create a separate stubborn descendant",
+    );
+    assert.equal(
+      isPidAlive(descendantPid),
+      false,
+      "startup cleanup must not leave the adapter descendant alive",
+    );
+  } finally {
+    if (descendantPid) {
+      await terminateTestPid(descendantPid);
+    }
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("AcpClient close resets in-memory state and shuts down terminal manager", async () => {
   const client = makeClient();
   const internals = asInternals(client);
@@ -1352,6 +1424,26 @@ function makeClient(
     permissionMode: "approve-reads",
     ...overrides,
   });
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function terminateTestPid(pid: number): Promise<void> {
+  if (!isPidAlive(pid)) {
+    return;
+  }
+  process.kill(pid, "SIGKILL");
+  const deadline = Date.now() + 2_000;
+  while (isPidAlive(pid) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
 }
 
 function asInternals(client: AcpClient): ClientInternals {

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -132,5 +133,44 @@ test(
 
     assert.equal(tree.descendantPids.has(process.pid), false);
     assert.equal(tree.descendantIdentities.has(process.pid), false);
+  },
+);
+
+test(
+  "exited POSIX trees discover descendants spawned after the exit snapshot",
+  { skip: process.platform === "win32" },
+  async () => {
+    const child = spawn(
+      "sh",
+      ["-c", "trap 'sleep 30 & exit 0' TERM; echo ready; while :; do sleep 1; done"],
+      {
+        detached: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    const rootPid = child.pid;
+    assert(rootPid);
+
+    try {
+      await once(child.stdout, "data");
+      const tree = createManagedProcessTree(rootPid, true, process.platform);
+      await captureProcessTreePids(tree, true);
+      await signalProcessTree(tree, true, "SIGTERM");
+      if (child.exitCode === null && child.signalCode === null) {
+        await once(child, "exit");
+      }
+
+      assert.equal(await waitForProcessTreeExit(tree, () => false, 100), false);
+
+      await signalProcessTree(tree, false, "SIGKILL");
+      assert.equal(await waitForProcessTreeExit(tree, () => false, 2_000), true);
+    } finally {
+      try {
+        process.kill(-rootPid, "SIGKILL");
+      } catch {
+        // The process group was already cleaned up.
+      }
+      child.stdout.destroy();
+    }
   },
 );

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -93,6 +93,53 @@ test(
 );
 
 test(
+  "bounded POSIX tracking captures children before an unexpected root exit",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-posix-tracking-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const counterPath = path.join(fixtureDir, "counter");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(
+      psPath,
+      [
+        "#!/bin/sh",
+        `counter=${JSON.stringify(counterPath)}`,
+        'count=$(cat "$counter" 2>/dev/null || true)',
+        "count=${count:-0}",
+        "count=$((count + 1))",
+        'printf "%s" "$count" > "$counter"',
+        'printf "500 1 500 Wed Jul 29 12:00:00 2026\\n"',
+        'if [ "$count" -ge 2 ]; then',
+        `  printf "${process.pid} 500 999 Wed Jul 29 12:00:01 2026\\n"`,
+        "fi",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    let running = true;
+    try {
+      const tree = createManagedProcessTree(500, true, "darwin");
+      beginProcessTreeTracking(tree, () => running);
+      for (let attempt = 0; attempt < 100 && !tree.descendantPids.has(process.pid); attempt += 1) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 25);
+        });
+      }
+      running = false;
+      await tree.snapshotPromise;
+
+      assert.equal(tree.descendantPids.has(process.pid), true);
+    } finally {
+      running = false;
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   "Linux process identities do not depend on unsupported BusyBox ps columns",
   { skip: process.platform !== "linux" },
   async () => {
@@ -288,6 +335,40 @@ test(
 );
 
 test(
+  "exited POSIX trees discover children of identity-validated escaped descendants",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-posix-escaped-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(
+      psPath,
+      [
+        "#!/bin/sh",
+        'printf "600 1 700 Wed Jul 29 12:00:00 2026\\n"',
+        `printf "${process.pid} 600 999 Wed Jul 29 12:00:01 2026\\n"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(500, true, "darwin");
+      tree.descendantPids.add(600);
+      tree.descendantIdentities.set(600, "Wed Jul 29 12:00:00 2026");
+
+      await signalProcessTree(tree, false, "SIGCONT");
+
+      assert.equal(tree.descendantPids.has(process.pid), true);
+      assert.equal(tree.descendantIdentities.get(process.pid), "Wed Jul 29 12:00:01 2026");
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   "exited POSIX trees discover descendants spawned after the exit snapshot",
   { skip: process.platform === "win32" },
   async () => {
@@ -355,6 +436,34 @@ test(
         // The process group was already cleaned up.
       }
       child.stdout.destroy();
+    }
+  },
+);
+
+test(
+  "final POSIX cleanup signals already-tracked live descendants after root exit",
+  { skip: process.platform === "win32" },
+  async () => {
+    const child = spawn("sleep", ["30"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    const childPid = child.pid;
+    assert(childPid);
+
+    try {
+      const childIdentity = await readProcessIdentity(childPid);
+      assert(childIdentity);
+      const tree = createManagedProcessTree(999_999, true, process.platform);
+      tree.descendantPids.add(childPid);
+      tree.descendantIdentities.set(childPid, childIdentity);
+
+      assert.equal(await waitForProcessTreeExit(tree, () => false, 2_000, "SIGKILL"), true);
+      assert.throws(() => process.kill(childPid, 0));
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
     }
   },
 );

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
+  captureProcessTreePids,
   createManagedProcessTree,
   resolveProcessTreeSignalTargets,
+  waitForProcessTreeExit,
 } from "../src/acp/process-tree.js";
 
 test("running POSIX trees signal the owned process group", () => {
@@ -41,3 +46,39 @@ test("non-group processes signal only their root", () => {
 
   assert.deepEqual(resolveProcessTreeSignalTargets(tree, true), [{ pid: 4400, tree: false }]);
 });
+
+test("waitForProcessTreeExit waits for the exit-triggered process snapshot", async () => {
+  const tree = createManagedProcessTree(4500, true, "linux");
+  let resolveSnapshot: (() => void) | undefined;
+  tree.snapshotPromise = new Promise<void>((resolve) => {
+    resolveSnapshot = resolve;
+  });
+
+  const exitResult = waitForProcessTreeExit(tree, () => false, 50);
+  tree.descendantPids.add(process.pid);
+  resolveSnapshot?.();
+
+  assert.equal(await exitResult, false);
+});
+
+test(
+  "process-tree snapshots bound stalled process-list commands",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-stalled-ps-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(psPath, "#!/bin/sh\nwhile :; do :; done\n", { mode: 0o755 });
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(process.pid, true, "linux");
+      const startedAt = Date.now();
+      await captureProcessTreePids(tree, true);
+      assert(Date.now() - startedAt < 3_000);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -7,9 +7,11 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import {
+  beginProcessTreeTracking,
   captureProcessTreePids,
   collectWindowsDescendantProcesses,
   createManagedProcessTree,
+  readProcessIdentity,
   resolveProcessTreeSignalTargets,
   signalProcessTree,
   waitForProcessTreeExit,
@@ -30,7 +32,114 @@ test("Windows descendant tracking validates creation order and terminates cycles
     descendants: [processList[1], processList[2]],
   });
   assert.equal(collectWindowsDescendantProcesses(100, "different-root", processList), undefined);
+
+  const afterRootExit = processList.slice(1);
+  assert.equal(collectWindowsDescendantProcesses(100, undefined, afterRootExit, "1000"), undefined);
 });
+
+test(
+  "continuous Windows tracking captures children spawned after the initial snapshot",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-windows-tracking-"));
+    const powershellPath = path.join(fixtureDir, "powershell.exe");
+    const counterPath = path.join(fixtureDir, "counter");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(
+      powershellPath,
+      [
+        "#!/bin/sh",
+        `counter=${JSON.stringify(counterPath)}`,
+        'count=$(cat "$counter" 2>/dev/null || true)',
+        "count=${count:-0}",
+        "count=$((count + 1))",
+        'printf "%s" "$count" > "$counter"',
+        'printf "500 1 1000\\n"',
+        'if [ "$count" -ge 2 ]; then',
+        '  printf "600 500 1100\\n"',
+        "fi",
+        'if [ "$count" -ge 3 ]; then',
+        `  printf "${process.pid} 600 1200\\n"`,
+        "fi",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    let running = true;
+    try {
+      const tree = createManagedProcessTree(500, true, "win32");
+      beginProcessTreeTracking(tree, () => running);
+      for (let attempt = 0; attempt < 100 && !tree.descendantPids.has(process.pid); attempt += 1) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 25);
+        });
+      }
+      running = false;
+      await tree.snapshotPromise;
+      const completedSamples = await fs.readFile(counterPath, "utf8");
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      assert.equal(await fs.readFile(counterPath, "utf8"), completedSamples);
+      await captureProcessTreePids(tree, false);
+      assert.equal(tree.descendantPids.has(process.pid), true);
+    } finally {
+      running = false;
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Linux process identities do not depend on unsupported BusyBox ps columns",
+  { skip: process.platform !== "linux" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-busybox-ps-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(psPath, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      assert.match((await readProcessIdentity(process.pid, "linux")) ?? "", /^\d+$/);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "non-Linux POSIX snapshots force a locale-independent process identity",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-posix-locale-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(
+      psPath,
+      [
+        "#!/bin/sh",
+        'test "$LC_ALL" = C || exit 9',
+        'printf "500 1 500 Wed Jul 29 12:00:00 2026\\n"',
+        `printf "${process.pid} 500 999 Wed Jul 29 12:00:01 2026\\n"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(500, true, "darwin");
+      await captureProcessTreePids(tree, true);
+      assert.equal(tree.descendantPids.has(process.pid), true);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
 
 test("running POSIX trees signal the owned process group", () => {
   const tree = createManagedProcessTree(4100, true, "darwin");
@@ -100,7 +209,7 @@ test(
     process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
 
     try {
-      const tree = createManagedProcessTree(process.pid, true, "linux");
+      const tree = createManagedProcessTree(process.pid, true, "darwin");
       const startedAt = Date.now();
       await captureProcessTreePids(tree, true);
       assert(Date.now() - startedAt < 3_000);
@@ -112,7 +221,33 @@ test(
 );
 
 test(
-  "signaling a running POSIX group does not wait for another process-list snapshot",
+  "transient Windows process-list failures preserve remembered descendants",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-stalled-powershell-"));
+    const powershellPath = path.join(fixtureDir, "powershell.exe");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(powershellPath, "#!/bin/sh\nwhile :; do :; done\n", { mode: 0o755 });
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(999_999, true, "win32");
+      tree.descendantPids.add(process.pid);
+      tree.descendantIdentities.set(process.pid, "remembered");
+
+      await signalProcessTree(tree, false, "SIGCONT");
+
+      assert.equal(tree.descendantPids.has(process.pid), true);
+      assert.equal(tree.descendantIdentities.get(process.pid), "remembered");
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "signaling a running POSIX group bounds its pre-signal descendant snapshot",
   { skip: process.platform === "win32" },
   async () => {
     const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-stalled-ps-signal-"));
@@ -125,7 +260,7 @@ test(
       const tree = createManagedProcessTree(process.pid, true, process.platform);
       const startedAt = Date.now();
       await signalProcessTree(tree, true, "SIGCONT");
-      assert(Date.now() - startedAt < 500);
+      assert(Date.now() - startedAt < 1_500);
     } finally {
       process.env.PATH = originalPath;
       await fs.rm(fixtureDir, { recursive: true, force: true });

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { promisify } from "node:util";
 import {
   captureProcessTreePids,
+  collectWindowsDescendantProcesses,
   createManagedProcessTree,
   resolveProcessTreeSignalTargets,
   signalProcessTree,
@@ -15,6 +16,21 @@ import {
 } from "../src/acp/process-tree.js";
 
 const execFileAsync = promisify(execFile);
+
+test("Windows descendant tracking validates creation order and terminates cycles", () => {
+  const processList = [
+    { pid: 100, parentPid: 102, identity: "1000" },
+    { pid: 101, parentPid: 100, identity: "1100" },
+    { pid: 102, parentPid: 101, identity: "1200" },
+    { pid: 103, parentPid: 100, identity: "900" },
+  ];
+
+  assert.deepEqual(collectWindowsDescendantProcesses(100, "1000", processList), {
+    rootIdentity: "1000",
+    descendants: [processList[1], processList[2]],
+  });
+  assert.equal(collectWindowsDescendantProcesses(100, "different-root", processList), undefined);
+});
 
 test("running POSIX trees signal the owned process group", () => {
   const tree = createManagedProcessTree(4100, true, "darwin");
@@ -164,6 +180,39 @@ test(
 
       await signalProcessTree(tree, false, "SIGKILL");
       assert.equal(await waitForProcessTreeExit(tree, () => false, 2_000), true);
+    } finally {
+      try {
+        process.kill(-rootPid, "SIGKILL");
+      } catch {
+        // The process group was already cleaned up.
+      }
+      child.stdout.destroy();
+    }
+  },
+);
+
+test(
+  "final POSIX cleanup signals descendants discovered after the prior SIGKILL snapshot",
+  { skip: process.platform === "win32" },
+  async () => {
+    const child = spawn("sh", ["-c", "sleep 30 & echo $!"], {
+      detached: true,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const rootPid = child.pid;
+    assert(rootPid);
+
+    try {
+      const [output] = await once(child.stdout, "data");
+      const descendantPid = Number(String(output).trim());
+      assert(Number.isInteger(descendantPid));
+      if (child.exitCode === null && child.signalCode === null) {
+        await once(child, "exit");
+      }
+
+      const tree = createManagedProcessTree(rootPid, true, process.platform);
+      assert.equal(await waitForProcessTreeExit(tree, () => false, 2_000, "SIGKILL"), true);
+      assert.throws(() => process.kill(descendantPid, 0));
     } finally {
       try {
         process.kill(-rootPid, "SIGKILL");

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createManagedProcessTree,
+  resolveProcessTreeSignalTargets,
+} from "../src/acp/process-tree.js";
+
+test("running POSIX trees signal the owned process group", () => {
+  const tree = createManagedProcessTree(4100, true, "darwin");
+  tree.descendantPids.add(4101);
+
+  assert.deepEqual(resolveProcessTreeSignalTargets(tree, true), [{ pid: -4100, tree: false }]);
+});
+
+test("exited POSIX roots never signal a potentially recycled process group", () => {
+  const tree = createManagedProcessTree(4200, true, "linux");
+  tree.descendantPids.add(4201);
+  tree.descendantPids.add(4202);
+
+  assert.deepEqual(resolveProcessTreeSignalTargets(tree, false), [
+    { pid: 4201, tree: false },
+    { pid: 4202, tree: false },
+  ]);
+});
+
+test("Windows uses taskkill trees for a running root and remembered descendants after exit", () => {
+  const tree = createManagedProcessTree(4300, true, "win32");
+  tree.descendantPids.add(4301);
+  tree.descendantPids.add(4302);
+
+  assert.deepEqual(resolveProcessTreeSignalTargets(tree, true), [{ pid: 4300, tree: true }]);
+  assert.deepEqual(resolveProcessTreeSignalTargets(tree, false), [
+    { pid: 4301, tree: true },
+    { pid: 4302, tree: true },
+  ]);
+});
+
+test("non-group processes signal only their root", () => {
+  const tree = createManagedProcessTree(4400, false, "linux");
+  tree.descendantPids.add(4401);
+
+  assert.deepEqual(resolveProcessTreeSignalTargets(tree, true), [{ pid: 4400, tree: false }]);
+});

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -294,6 +294,36 @@ test(
 );
 
 test(
+  "Windows snapshots tolerate process-list startup beyond one second",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-slow-powershell-"));
+    const powershellPath = path.join(fixtureDir, "powershell.exe");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(
+      powershellPath,
+      [
+        "#!/bin/sh",
+        "sleep 1.2",
+        'printf "500 1 1000\\n"',
+        `printf "${process.pid} 500 1100\\n"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(500, true, "win32");
+      await captureProcessTreePids(tree, true);
+      assert.equal(tree.descendantPids.has(process.pid), true);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   "signaling a running POSIX group bounds its pre-signal descendant snapshot",
   { skip: process.platform === "win32" },
   async () => {
@@ -331,6 +361,73 @@ test(
 
     assert.equal(tree.descendantPids.has(process.pid), false);
     assert.equal(tree.descendantIdentities.has(process.pid), false);
+  },
+);
+
+test(
+  "exited POSIX trees preserve identity-validated descendants after group leader PID reuse",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-posix-reused-leader-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    const descendantIdentity = "Wed Jul 29 12:00:01 2026";
+    await fs.writeFile(
+      psPath,
+      [
+        "#!/bin/sh",
+        'printf "500 1 500 Wed Jul 29 12:01:00 2026\\n"',
+        `printf "${process.pid} 1 500 ${descendantIdentity}\\n"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(500, true, "darwin");
+      tree.descendantPids.add(process.pid);
+      tree.descendantIdentities.set(process.pid, descendantIdentity);
+
+      await signalProcessTree(tree, false, "SIGCONT");
+
+      assert.equal(tree.descendantPids.has(process.pid), true);
+      assert.equal(tree.descendantIdentities.get(process.pid), descendantIdentity);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "running POSIX snapshots reject a recycled group with a mismatched root identity",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-posix-recycled-group-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(
+      psPath,
+      [
+        "#!/bin/sh",
+        'printf "500 1 500 Wed Jul 29 12:01:00 2026\\n"',
+        `printf "${process.pid} 500 500 Wed Jul 29 12:01:01 2026\\n"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(500, true, "darwin");
+      tree.rootIdentity = "Wed Jul 29 12:00:00 2026";
+
+      await captureProcessTreePids(tree, true);
+
+      assert.equal(tree.descendantPids.has(process.pid), false);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
   },
 );
 

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -1,14 +1,19 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import {
   captureProcessTreePids,
   createManagedProcessTree,
   resolveProcessTreeSignalTargets,
+  signalProcessTree,
   waitForProcessTreeExit,
 } from "../src/acp/process-tree.js";
+
+const execFileAsync = promisify(execFile);
 
 test("running POSIX trees signal the owned process group", () => {
   const tree = createManagedProcessTree(4100, true, "darwin");
@@ -61,6 +66,12 @@ test("waitForProcessTreeExit waits for the exit-triggered process snapshot", asy
   assert.equal(await exitResult, false);
 });
 
+test("waitForProcessTreeExit keeps a live non-group root in the cleanup loop", async () => {
+  const tree = createManagedProcessTree(process.pid, false, process.platform);
+
+  assert.equal(await waitForProcessTreeExit(tree, () => true, 10), false);
+});
+
 test(
   "process-tree snapshots bound stalled process-list commands",
   { skip: process.platform === "win32" },
@@ -80,5 +91,46 @@ test(
       process.env.PATH = originalPath;
       await fs.rm(fixtureDir, { recursive: true, force: true });
     }
+  },
+);
+
+test(
+  "signaling a running POSIX group does not wait for another process-list snapshot",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-stalled-ps-signal-"));
+    const psPath = path.join(fixtureDir, "ps");
+    const originalPath = process.env.PATH;
+    await fs.writeFile(psPath, "#!/bin/sh\nwhile :; do :; done\n", { mode: 0o755 });
+    process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath ?? ""}`;
+
+    try {
+      const tree = createManagedProcessTree(process.pid, true, process.platform);
+      const startedAt = Date.now();
+      await signalProcessTree(tree, true, "SIGCONT");
+      assert(Date.now() - startedAt < 500);
+    } finally {
+      process.env.PATH = originalPath;
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "exited POSIX trees discard remembered PIDs whose identity changed",
+  { skip: process.platform === "win32" },
+  async () => {
+    const { stdout } = await execFileAsync("ps", ["-o", "pgid=", "-p", String(process.pid)]);
+    const processGroupId = Number(stdout.trim());
+    assert(Number.isInteger(processGroupId));
+
+    const tree = createManagedProcessTree(processGroupId, true, process.platform);
+    tree.descendantPids.add(process.pid);
+    tree.descendantIdentities.set(process.pid, "not-this-process");
+
+    await signalProcessTree(tree, false, "SIGCONT");
+
+    assert.equal(tree.descendantPids.has(process.pid), false);
+    assert.equal(tree.descendantIdentities.has(process.pid), false);
   },
 );

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -897,12 +897,70 @@ test("startup probe fails closed for an older live owner without a socket", asyn
           return true;
         },
       );
-      assert.equal(getPerfMetricsSnapshot().timings["queue.connect"]?.count, 1);
+      assert((getPerfMetricsSnapshot().timings["queue.connect"]?.count ?? 0) > 1);
       await fs.access(lockPath);
       assert.equal(keeper.exitCode, null);
       assert.equal(keeper.signalCode, null);
     } finally {
       resetPerfMetrics();
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});
+
+test("startup probe retries a transient connection failure for an established owner", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "startup-established-owner-transient-connect";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+      createdAt: "2000-01-01T00:00:00.000Z",
+      heartbeatAt: new Date().toISOString(),
+    });
+
+    const server = createSingleRequestServer((socket, request) => {
+      assert.equal(request.type, "submit_prompt");
+      socket.write(
+        `${JSON.stringify({
+          type: "accepted",
+          requestId: request.requestId,
+        })}\n`,
+      );
+      socket.end();
+    });
+    const delayedListen = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        void listenServer(server, socketPath).then(resolve, reject);
+      }, 75);
+    });
+
+    resetPerfMetrics();
+    try {
+      const [outcome] = await Promise.all([
+        trySubmitToRunningOwner({
+          sessionId,
+          message: "hello",
+          permissionMode: "approve-reads",
+          outputFormatter: NOOP_OUTPUT_FORMATTER,
+          waitForCompletion: false,
+          startupProbe: true,
+        }),
+        delayedListen,
+      ]);
+      assert(outcome);
+      assert.equal("queued" in outcome, true);
+      assert((getPerfMetricsSnapshot().timings["queue.connect"]?.count ?? 0) > 1);
+    } finally {
+      resetPerfMetrics();
+      await delayedListen.catch(() => {
+        // The submit failure remains the primary assertion signal.
+      });
+      await closeServer(server);
       await cleanupOwnerArtifacts({ socketPath, lockPath });
       stopProcess(keeper);
     }

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -839,6 +839,51 @@ test("startup probe treats lease-before-bind as a miss without a health reconnec
   });
 });
 
+test("startup probe fails closed for an older live owner without a socket", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "startup-owner-not-accepting";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+      createdAt: "2000-01-01T00:00:00.000Z",
+      heartbeatAt: new Date().toISOString(),
+    });
+
+    resetPerfMetrics();
+    try {
+      await assert.rejects(
+        async () =>
+          await trySubmitToRunningOwner({
+            sessionId,
+            message: "hello",
+            permissionMode: "approve-reads",
+            outputFormatter: NOOP_OUTPUT_FORMATTER,
+            waitForCompletion: true,
+            startupProbe: true,
+          }),
+        (error: unknown) => {
+          assert(error instanceof QueueConnectionError);
+          assert.equal(error.detailCode, "QUEUE_NOT_ACCEPTING_REQUESTS");
+          assert.equal(error.retryable, true);
+          return true;
+        },
+      );
+      assert.equal(getPerfMetricsSnapshot().timings["queue.connect"]?.count, 1);
+      await fs.access(lockPath);
+      assert.equal(keeper.exitCode, null);
+      assert.equal(keeper.signalCode, null);
+    } finally {
+      resetPerfMetrics();
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});
+
 test("trySubmitToRunningOwner rejects MCP config changes for a live owner", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "submit-mcp-config-owner-mismatch";

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -839,6 +839,31 @@ test("startup probe treats lease-before-bind as a miss without a health reconnec
   });
 });
 
+test("startup probe retires a fresh dead owner instead of treating it as lease-before-bind", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "startup-dead-before-bind";
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: 999_999,
+      sessionId,
+      socketPath,
+    });
+
+    const outcome = await trySubmitToRunningOwner({
+      sessionId,
+      message: "hello",
+      permissionMode: "approve-reads",
+      outputFormatter: NOOP_OUTPUT_FORMATTER,
+      waitForCompletion: true,
+      startupProbe: true,
+    });
+
+    assert.equal(outcome, undefined);
+    await assert.rejects(fs.access(lockPath));
+  });
+});
+
 test("startup probe fails closed for an older live owner without a socket", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "startup-owner-not-accepting";

--- a/test/queue-ipc-errors.test.ts
+++ b/test/queue-ipc-errors.test.ts
@@ -12,6 +12,7 @@ import {
   trySubmitToRunningOwner,
 } from "../src/cli/queue/ipc.js";
 import { QueueConnectionError, QueueProtocolError } from "../src/errors.js";
+import { getPerfMetricsSnapshot, resetPerfMetrics } from "../src/perf-metrics.js";
 import type { OutputFormatter } from "../src/types.js";
 import {
   cleanupOwnerArtifacts,
@@ -800,6 +801,38 @@ test("trySubmitToRunningOwner clears stale owner lock on protocol mismatch", asy
       await assert.rejects(fs.access(lockPath));
     } finally {
       await closeServer(server);
+      await cleanupOwnerArtifacts({ socketPath, lockPath });
+      stopProcess(keeper);
+    }
+  });
+});
+
+test("startup probe treats lease-before-bind as a miss without a health reconnect", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "startup-lease-before-bind";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: keeper.pid,
+      sessionId,
+      socketPath,
+    });
+
+    resetPerfMetrics();
+    try {
+      const outcome = await trySubmitToRunningOwner({
+        sessionId,
+        message: "hello",
+        permissionMode: "approve-reads",
+        outputFormatter: NOOP_OUTPUT_FORMATTER,
+        waitForCompletion: true,
+        startupProbe: true,
+      });
+      assert.equal(outcome, undefined);
+      assert.equal(getPerfMetricsSnapshot().timings["queue.connect"]?.count, 1);
+    } finally {
+      resetPerfMetrics();
       await cleanupOwnerArtifacts({ socketPath, lockPath });
       stopProcess(keeper);
     }

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -560,6 +560,53 @@ test("ensureOwnerIsUsable cleans up stale live owners", async () => {
   });
 });
 
+test("stale cleanup preserves an owner refreshed before its cleanup claim", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "stale-owner-refreshed-before-claim";
+    const keeper = await startKeeperProcess();
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    let claim: Awaited<ReturnType<typeof claimQueueOwnerLock>> | undefined;
+
+    try {
+      await writeQueueOwnerLock({
+        lockPath,
+        pid: keeper.pid,
+        sessionId,
+        socketPath,
+        heartbeatAt: "2000-01-01T00:00:00.000Z",
+      });
+      const staleOwner = await readQueueOwnerRecord(sessionId);
+      assert(staleOwner);
+      claim = await claimQueueOwnerLock(lockPath, staleOwner.ownerGeneration);
+      assert(claim);
+
+      const cleanup = ensureOwnerIsUsable(sessionId, staleOwner);
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+
+      const refreshedPath = `${lockPath}.refreshed`;
+      await fs.writeFile(
+        refreshedPath,
+        `${JSON.stringify({ ...staleOwner, heartbeatAt: new Date().toISOString() })}\n`,
+        "utf8",
+      );
+      await fs.rename(refreshedPath, lockPath);
+
+      assert.equal(await cleanup, false);
+      assert.equal(isProcessAlive(keeper.pid), true);
+      assert.equal((await readQueueOwnerStatus(sessionId))?.alive, true);
+    } finally {
+      await claim?.release();
+      stopProcess(keeper);
+      await fs.rm(lockPath, { force: true });
+      if (process.platform !== "win32") {
+        await fs.rm(socketPath, { force: true });
+      }
+    }
+  });
+});
+
 test("tryAcquireQueueOwnerLease terminates stale live owners and acquires in the same attempt", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "stale-live-owner-acquire";

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -178,6 +178,82 @@ test("tryAcquireQueueOwnerLease clears stale dead owners and can acquire on retr
   });
 });
 
+test("tryAcquireQueueOwnerLease preserves a fresh malformed lock during collision", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "fresh-malformed-owner";
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    const malformedPayload = "{incomplete";
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+    await fs.writeFile(lockPath, malformedPayload, "utf8");
+    if (process.platform !== "win32") {
+      await fs.mkdir(path.dirname(socketPath), { recursive: true });
+      await fs.writeFile(socketPath, "live-socket-placeholder", "utf8");
+    }
+
+    assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
+    assert.equal(await fs.readFile(lockPath, "utf8"), malformedPayload);
+    if (process.platform !== "win32") {
+      assert.equal(await fs.readFile(socketPath, "utf8"), "live-socket-placeholder");
+    }
+
+    await fs.rm(lockPath, { force: true });
+    if (process.platform !== "win32") {
+      await fs.rm(socketPath, { force: true });
+    }
+  });
+});
+
+test("tryAcquireQueueOwnerLease removes a malformed lock only after it is stale", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "stale-malformed-owner";
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+    await fs.writeFile(lockPath, "{incomplete", "utf8");
+    await fs.utimes(lockPath, new Date(0), new Date(0));
+    if (process.platform !== "win32") {
+      await fs.mkdir(path.dirname(socketPath), { recursive: true });
+      await fs.writeFile(socketPath, "stale-socket-placeholder", "utf8");
+    }
+
+    assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
+    await assert.rejects(fs.access(lockPath));
+    if (process.platform !== "win32") {
+      await assert.rejects(fs.access(socketPath));
+    }
+
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    await releaseQueueOwnerLease(lease);
+  });
+});
+
+test("refreshQueueOwnerLease never exposes a partial record to concurrent readers", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "atomic-refresh";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+
+    try {
+      const writers = Array.from({ length: 200 }, async (_, index) => {
+        await refreshQueueOwnerLease(lease, { queueDepth: index % 5 });
+      });
+      const observations = await Promise.all(
+        Array.from({ length: 200 }, async () => await readQueueOwnerRecord(sessionId)),
+      );
+      await Promise.all(writers);
+      assert.equal(
+        observations.every((record) => record !== undefined),
+        true,
+      );
+
+      const files = await fs.readdir(path.dirname(queueLockFilePath(sessionId, homeDir)));
+      assert.deepEqual(files, [path.basename(queueLockFilePath(sessionId, homeDir))]);
+    } finally {
+      await releaseQueueOwnerLease(lease);
+    }
+  });
+});
+
 test("readQueueOwnerStatus returns live owner details for a healthy owner", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "healthy-owner";

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -227,6 +227,27 @@ test("tryAcquireQueueOwnerLease removes a malformed lock only after it is stale"
   });
 });
 
+test(
+  "tryAcquireQueueOwnerLease ages out a stale dangling symlink lock",
+  { skip: process.platform === "win32" },
+  async () => {
+    await withTempHome(async (homeDir) => {
+      const sessionId = "stale-dangling-symlink-owner";
+      const { lockPath } = queuePaths(homeDir, sessionId);
+      await fs.mkdir(path.dirname(lockPath), { recursive: true });
+      await fs.symlink("missing-owner-record", lockPath);
+      await fs.lutimes(lockPath, new Date(0), new Date(0));
+
+      assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
+      await assert.rejects(fs.lstat(lockPath));
+
+      const lease = await tryAcquireQueueOwnerLease(sessionId);
+      assert(lease);
+      await releaseQueueOwnerLease(lease);
+    });
+  },
+);
+
 test("refreshQueueOwnerLease never exposes a partial record to concurrent readers", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "atomic-refresh";

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -254,6 +254,29 @@ test("refreshQueueOwnerLease never exposes a partial record to concurrent reader
   });
 });
 
+test("released owners cannot overwrite or remove a successor lease", async () => {
+  await withTempHome(async () => {
+    const sessionId = "released-owner-refresh";
+    const releasedLease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(releasedLease);
+    await releaseQueueOwnerLease(releasedLease);
+
+    const successorLease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(successorLease);
+    try {
+      await refreshQueueOwnerLease(releasedLease, { queueDepth: 9 });
+      await releaseQueueOwnerLease(releasedLease);
+
+      const record = await readQueueOwnerRecord(sessionId);
+      assert(record);
+      assert.equal(record.ownerGeneration, successorLease.ownerGeneration);
+      assert.equal(record.queueDepth, 0);
+    } finally {
+      await releaseQueueOwnerLease(successorLease);
+    }
+  });
+});
+
 test("readQueueOwnerStatus returns live owner details for a healthy owner", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "healthy-owner";

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -4,7 +4,9 @@ import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
+  claimQueueOwnerLock,
   ensureOwnerIsUsable,
   isProcessAlive,
   readQueueOwnerRecord,
@@ -156,7 +158,7 @@ test("tryAcquireQueueOwnerLease tightens queue directory permissions", async () 
   });
 });
 
-test("tryAcquireQueueOwnerLease clears stale dead owners and can acquire on retry", async () => {
+test("tryAcquireQueueOwnerLease replaces a stale dead owner in the same attempt", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "stale-dead-owner";
     const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
@@ -169,11 +171,37 @@ test("tryAcquireQueueOwnerLease clears stale dead owners and can acquire on retr
       heartbeatAt: "2000-01-01T00:00:00.000Z",
     });
 
-    assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
-    assert.equal(await readQueueOwnerRecord(sessionId), undefined);
-
     const lease = await tryAcquireQueueOwnerLease(sessionId);
     assert(lease);
+    assert.equal((await readQueueOwnerRecord(sessionId))?.ownerGeneration, lease.ownerGeneration);
+    await releaseQueueOwnerLease(lease);
+  });
+});
+
+test("retry acquisition timestamps the replacement after stale-owner cleanup", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionId = "stale-owner-fresh-replacement-time";
+    const { lockPath, socketPath } = queuePaths(homeDir, sessionId);
+    await writeQueueOwnerLock({
+      lockPath,
+      pid: 999_999,
+      sessionId,
+      socketPath,
+      heartbeatAt: "2000-01-01T00:00:00.000Z",
+    });
+    const timestamps = ["2026-07-29T12:00:00.000Z", "2026-07-29T12:00:07.000Z"];
+    let clockIndex = 0;
+
+    const lease = await tryAcquireQueueOwnerLease(
+      sessionId,
+      () => timestamps[clockIndex++] ?? timestamps[1],
+    );
+    assert(lease);
+    assert.equal(lease.createdAt, timestamps[1]);
+    const owner = await readQueueOwnerRecord(sessionId);
+    assert(owner);
+    assert.equal(owner.createdAt, timestamps[1]);
+    assert.equal(owner.heartbeatAt, timestamps[1]);
     await releaseQueueOwnerLease(lease);
   });
 });
@@ -215,14 +243,12 @@ test("tryAcquireQueueOwnerLease removes a malformed lock only after it is stale"
       await fs.writeFile(socketPath, "stale-socket-placeholder", "utf8");
     }
 
-    assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
-    await assert.rejects(fs.access(lockPath));
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    assert.equal((await readQueueOwnerRecord(sessionId))?.ownerGeneration, lease.ownerGeneration);
     if (process.platform !== "win32") {
       await assert.rejects(fs.access(socketPath));
     }
-
-    const lease = await tryAcquireQueueOwnerLease(sessionId);
-    assert(lease);
     await releaseQueueOwnerLease(lease);
   });
 });
@@ -238,11 +264,9 @@ test(
       await fs.symlink("missing-owner-record", lockPath);
       await fs.lutimes(lockPath, new Date(0), new Date(0));
 
-      assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
-      await assert.rejects(fs.lstat(lockPath));
-
       const lease = await tryAcquireQueueOwnerLease(sessionId);
       assert(lease);
+      assert.equal((await readQueueOwnerRecord(sessionId))?.ownerGeneration, lease.ownerGeneration);
       await releaseQueueOwnerLease(lease);
     });
   },
@@ -272,6 +296,187 @@ test("refreshQueueOwnerLease never exposes a partial record to concurrent reader
     } finally {
       await releaseQueueOwnerLease(lease);
     }
+  });
+});
+
+test("lock claims serialize cross-process refresh and release mutations", async () => {
+  await withTempHome(async () => {
+    const sessionId = "claimed-owner-mutation";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    assert(claim);
+    assert.equal(await claim.isHeld(), true);
+
+    await refreshQueueOwnerLease(lease, { queueDepth: 7 });
+    assert.equal(await claim.isHeld(), true);
+    await releaseQueueOwnerLease({ ...lease });
+    assert.equal(await claim.isHeld(), true);
+    const blockedRecord = await readQueueOwnerRecord(sessionId);
+    assert(blockedRecord);
+    assert.equal(blockedRecord.queueDepth, 0);
+
+    await claim.release();
+    await refreshQueueOwnerLease(lease, { queueDepth: 7 });
+    const refreshedRecord = await readQueueOwnerRecord(sessionId);
+    assert(refreshedRecord);
+    assert.equal(refreshedRecord.queueDepth, 7);
+    await releaseQueueOwnerLease(lease);
+  });
+});
+
+test("lock claims recover after a claimant crashes", async () => {
+  await withTempHome(async () => {
+    const sessionId = "crashed-lock-claimant";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const modulePath = fileURLToPath(new URL("../src/cli/queue/lease-store.js", import.meta.url));
+    const script = `
+      const { claimQueueOwnerLock } = await import(${JSON.stringify(modulePath)});
+      const claim = await claimQueueOwnerLock(
+        ${JSON.stringify(lease.lockPath)},
+        ${lease.ownerGeneration},
+      );
+      if (!claim) process.exit(2);
+      process.stdout.write("claimed\\n");
+      setInterval(() => {}, 60_000);
+    `;
+    const claimant = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+
+    try {
+      assert(claimant.stdout);
+      const output = await waitForChildOutput(claimant);
+      assert.equal(output.toString(), "claimed\n");
+      assert.equal(await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration), undefined);
+
+      claimant.kill("SIGKILL");
+      await once(claimant, "close");
+
+      const recovered = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+      assert(recovered);
+      await recovered.release();
+      await releaseQueueOwnerLease(lease);
+    } finally {
+      if (claimant.exitCode == null && claimant.signalCode == null) {
+        claimant.kill("SIGKILL");
+      }
+    }
+  });
+});
+
+test("explicit cleanup waits for an active lease claim", async () => {
+  await withTempHome(async () => {
+    const sessionId = "cleanup-claim-contention";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    assert(claim);
+
+    const cleanup = terminateQueueOwnerForSession(sessionId);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    assert(await readQueueOwnerRecord(sessionId));
+    await claim.release();
+    await cleanup;
+
+    assert.equal(await readQueueOwnerRecord(sessionId), undefined);
+  });
+});
+
+test("explicit cleanup fails visibly after prolonged lease claim contention", async () => {
+  await withTempHome(async () => {
+    const sessionId = "cleanup-prolonged-claim-contention";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    assert(claim);
+
+    await assert.rejects(
+      terminateQueueOwnerForSession(sessionId),
+      /cleanup is busy.*retry the operation/,
+    );
+    assert(await readQueueOwnerRecord(sessionId));
+
+    await claim.release();
+    await terminateQueueOwnerForSession(sessionId);
+    assert.equal(await readQueueOwnerRecord(sessionId), undefined);
+  });
+});
+
+async function waitForChildOutput(child: ReturnType<typeof spawn>): Promise<Buffer> {
+  const stdout = child.stdout;
+  assert(stdout);
+  return await new Promise<Buffer>((resolve, reject) => {
+    const cleanup = () => {
+      stdout.off("data", onData);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    const onData = (chunk: Buffer) => {
+      cleanup();
+      resolve(chunk);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`claimant exited before readiness: code=${code} signal=${signal}`));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    stdout.once("data", onData);
+    child.once("exit", onExit);
+    child.once("error", onError);
+  });
+}
+
+test("lock claims reject a replacement published after stale identity inspection", async () => {
+  await withTempHome(async () => {
+    const sessionId = "stale-identity-replacement";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const oldStat = await fs.lstat(lease.lockPath);
+    const oldPath = `${lease.lockPath}.old`;
+    await fs.rename(lease.lockPath, oldPath);
+    const successorGeneration = lease.ownerGeneration + 1;
+    const successor = JSON.parse(await fs.readFile(oldPath, "utf8")) as Record<string, unknown>;
+    successor.ownerGeneration = successorGeneration;
+    await fs.writeFile(lease.lockPath, `${JSON.stringify(successor, null, 2)}\n`, "utf8");
+
+    assert.equal(await claimQueueOwnerLock(lease.lockPath, undefined, oldStat), undefined);
+    const record = await readQueueOwnerRecord(sessionId);
+    assert(record);
+    assert.equal(record.ownerGeneration, successorGeneration);
+
+    await fs.rm(oldPath, { force: true });
+    await fs.rm(lease.lockPath, { force: true });
+  });
+});
+
+test("identity-less lock claims age out after claimant PID reuse cannot be excluded", async () => {
+  await withTempHome(async () => {
+    const sessionId = "identity-less-claim";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const lockStat = await fs.lstat(lease.lockPath);
+    const claimPath = `${lease.lockPath}.claim-${lockStat.dev}-${lockStat.ino}`;
+    await fs.writeFile(
+      claimPath,
+      `${JSON.stringify({ claimId: "missing-identity", pid: process.pid })}\n`,
+      "utf8",
+    );
+    const staleTime = new Date(Date.now() - 20_000);
+    await fs.utimes(claimPath, staleTime, staleTime);
+
+    const recovered = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    assert(recovered);
+    await recovered.release();
+    await releaseQueueOwnerLease(lease);
   });
 });
 
@@ -355,7 +560,7 @@ test("ensureOwnerIsUsable cleans up stale live owners", async () => {
   });
 });
 
-test("tryAcquireQueueOwnerLease terminates stale live owners before retry acquisition", async () => {
+test("tryAcquireQueueOwnerLease terminates stale live owners and acquires in the same attempt", async () => {
   await withTempHome(async (homeDir) => {
     const sessionId = "stale-live-owner-acquire";
     const keeper = await startKeeperProcess();
@@ -370,12 +575,10 @@ test("tryAcquireQueueOwnerLease terminates stale live owners before retry acquis
         heartbeatAt: "2000-01-01T00:00:00.000Z",
       });
 
-      assert.equal(await tryAcquireQueueOwnerLease(sessionId), undefined);
-      assert.equal(await readQueueOwnerRecord(sessionId), undefined);
-      assert.equal(isProcessAlive(keeper.pid), false);
-
       const lease = await tryAcquireQueueOwnerLease(sessionId);
       assert(lease);
+      assert.equal((await readQueueOwnerRecord(sessionId))?.ownerGeneration, lease.ownerGeneration);
+      assert.equal(isProcessAlive(keeper.pid), false);
       await releaseQueueOwnerLease(lease);
     } finally {
       stopProcess(keeper);

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -9,6 +9,7 @@ import {
   claimQueueOwnerLock,
   ensureOwnerIsUsable,
   isProcessAlive,
+  type QueueOwnerLease,
   readQueueOwnerRecord,
   readQueueOwnerStatus,
   refreshQueueOwnerLease,
@@ -310,7 +311,7 @@ test("lock claims serialize cross-process refresh and release mutations", async 
 
     await refreshQueueOwnerLease(lease, { queueDepth: 7 });
     assert.equal(await claim.isHeld(), true);
-    await releaseQueueOwnerLease({ ...lease });
+    await assert.rejects(releaseQueueOwnerLease(lease), /lease release is busy.*retry cleanup/);
     assert.equal(await claim.isHeld(), true);
     const blockedRecord = await readQueueOwnerRecord(sessionId);
     assert(blockedRecord);
@@ -368,6 +369,46 @@ test("lock claims recover after a claimant crashes", async () => {
   });
 });
 
+test("owner shutdown defers lease removal to a live external cleanup claimant", async () => {
+  await withTempHome(async () => {
+    const sessionId = "external-cleaner-owner-shutdown";
+    const modulePath = fileURLToPath(new URL("../src/cli/queue/lease-store.js", import.meta.url));
+    const script = `
+      const { releaseQueueOwnerLease, tryAcquireQueueOwnerLease } = await import(${JSON.stringify(modulePath)});
+      const lease = await tryAcquireQueueOwnerLease(${JSON.stringify(sessionId)});
+      if (!lease) process.exit(2);
+      process.stdout.write(JSON.stringify(lease) + "\\n");
+      process.on("SIGTERM", () => {
+        void releaseQueueOwnerLease(lease).then(
+          () => process.exit(0),
+          () => process.exit(1),
+        );
+      });
+      setInterval(() => {}, 60_000);
+    `;
+    const owner = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+
+    try {
+      const lease = JSON.parse((await waitForChildOutput(owner)).toString()) as QueueOwnerLease;
+      const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+      assert(claim);
+      owner.kill("SIGTERM");
+      const [code] = (await once(owner, "exit")) as [number | null, NodeJS.Signals | null];
+      assert.equal(code, 0);
+      await claim.release();
+      await fs.rm(lease.lockPath, { force: true });
+    } finally {
+      if (owner.exitCode == null && owner.signalCode == null) {
+        owner.kill("SIGKILL");
+      }
+    }
+  });
+});
+
 test("explicit cleanup waits for an active lease claim", async () => {
   await withTempHome(async () => {
     const sessionId = "cleanup-claim-contention";
@@ -384,6 +425,46 @@ test("explicit cleanup waits for an active lease claim", async () => {
     await claim.release();
     await cleanup;
 
+    assert.equal(await readQueueOwnerRecord(sessionId), undefined);
+  });
+});
+
+test("lease release waits for an active same-generation claim", async () => {
+  await withTempHome(async () => {
+    const sessionId = "release-claim-contention";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    assert(claim);
+
+    const release = releaseQueueOwnerLease(lease);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    assert(await readQueueOwnerRecord(sessionId));
+    await claim.release();
+    await release;
+
+    assert.equal(await readQueueOwnerRecord(sessionId), undefined);
+  });
+});
+
+test("explicit cleanup succeeds when a contended lease is concurrently removed", async () => {
+  await withTempHome(async () => {
+    const sessionId = "cleanup-concurrent-removal";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const claim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+    assert(claim);
+
+    const cleanup = terminateQueueOwnerForSession(sessionId);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    await fs.rm(lease.lockPath);
+    await claim.release();
+
+    await cleanup;
     assert.equal(await readQueueOwnerRecord(sessionId), undefined);
   });
 });
@@ -532,6 +613,61 @@ test("restoring a displaced lock claim never overwrites a concurrent claim", asy
       );
     } finally {
       fs.rename = originalRename;
+      await fs.rm(claimPath, { force: true });
+      await releaseQueueOwnerLease(lease);
+    }
+  });
+});
+
+test("a claim released while temporarily displaced is not restored as an orphan", async () => {
+  await withTempHome(async () => {
+    const sessionId = "displaced-claim-release-race";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const lockStat = await fs.lstat(lease.lockPath);
+    const claimPath = `${lease.lockPath}.claim-${lockStat.dev}-${lockStat.ino}`;
+    await fs.writeFile(
+      claimPath,
+      `${JSON.stringify({ claimId: "stale-claim", pid: 999_999_999 })}\n`,
+      "utf8",
+    );
+
+    const originalLink = fs.link;
+    const originalRename = fs.rename;
+    let concurrentClaim: Awaited<ReturnType<typeof claimQueueOwnerLock>>;
+    let raceInjected = false;
+    fs.rename = async (oldPath, newPath): Promise<void> => {
+      if (
+        !raceInjected &&
+        oldPath === claimPath &&
+        String(newPath).startsWith(`${claimPath}.reap-`)
+      ) {
+        raceInjected = true;
+        await fs.unlink(claimPath);
+        concurrentClaim = await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration);
+        assert(concurrentClaim);
+      }
+      await originalRename(oldPath, newPath);
+    };
+    fs.link = async (existingPath, newPath): Promise<void> => {
+      if (
+        raceInjected &&
+        concurrentClaim &&
+        String(existingPath).startsWith(`${claimPath}.reap-`) &&
+        newPath === claimPath
+      ) {
+        await concurrentClaim.release();
+      }
+      await originalLink(existingPath, newPath);
+    };
+
+    try {
+      assert.equal(await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration), undefined);
+      assert.equal(raceInjected, true);
+      await assert.rejects(fs.access(claimPath));
+    } finally {
+      fs.rename = originalRename;
+      fs.link = originalLink;
       await fs.rm(claimPath, { force: true });
       await releaseQueueOwnerLease(lease);
     }

--- a/test/queue-lease-store.test.ts
+++ b/test/queue-lease-store.test.ts
@@ -480,6 +480,64 @@ test("identity-less lock claims age out after claimant PID reuse cannot be exclu
   });
 });
 
+test("restoring a displaced lock claim never overwrites a concurrent claim", async () => {
+  await withTempHome(async () => {
+    const sessionId = "displaced-claim-restore-race";
+    const lease = await tryAcquireQueueOwnerLease(sessionId);
+    assert(lease);
+    const lockStat = await fs.lstat(lease.lockPath);
+    const claimPath = `${lease.lockPath}.claim-${lockStat.dev}-${lockStat.ino}`;
+    const displacedClaim = {
+      claimId: "displaced-claim",
+      pid: process.pid,
+    };
+    const concurrentClaim = {
+      claimId: "concurrent-claim",
+      pid: process.pid,
+    };
+    await fs.writeFile(claimPath, `${JSON.stringify(displacedClaim)}\n`, "utf8");
+    const staleTime = new Date(Date.now() - 20_000);
+    await fs.utimes(claimPath, staleTime, staleTime);
+
+    const originalRename = fs.rename;
+    let raceInjected = false;
+    fs.rename = async (oldPath, newPath): Promise<void> => {
+      await originalRename(oldPath, newPath);
+      if (
+        !raceInjected &&
+        oldPath === claimPath &&
+        String(newPath).startsWith(`${claimPath}.reap-`)
+      ) {
+        raceInjected = true;
+        const refreshedTime = new Date();
+        await fs.utimes(newPath, refreshedTime, refreshedTime);
+        await fs.writeFile(claimPath, `${JSON.stringify(concurrentClaim)}\n`, {
+          encoding: "utf8",
+          flag: "wx",
+        });
+      }
+    };
+
+    try {
+      assert.equal(await claimQueueOwnerLock(lease.lockPath, lease.ownerGeneration), undefined);
+      assert.equal(raceInjected, true);
+      const survivingClaim = JSON.parse(await fs.readFile(claimPath, "utf8")) as {
+        claimId?: unknown;
+      };
+      assert.equal(survivingClaim.claimId, concurrentClaim.claimId);
+      const claimFiles = await fs.readdir(path.dirname(claimPath));
+      assert.equal(
+        claimFiles.some((fileName) => fileName.startsWith(`${path.basename(claimPath)}.reap-`)),
+        false,
+      );
+    } finally {
+      fs.rename = originalRename;
+      await fs.rm(claimPath, { force: true });
+      await releaseQueueOwnerLease(lease);
+    }
+  });
+});
+
 test("released owners cannot overwrite or remove a successor lease", async () => {
   await withTempHome(async () => {
     const sessionId = "released-owner-refresh";

--- a/test/queue-owner-lifecycle.test.ts
+++ b/test/queue-owner-lifecycle.test.ts
@@ -15,7 +15,7 @@ import net from "node:net";
 import path from "node:path";
 import readline from "node:readline";
 import { describe, it } from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { isProcessAlive } from "../src/cli/queue/lease-store.js";
 import { queueLockFilePath, queueSocketPath } from "../src/cli/queue/paths.js";
 import { makeSessionRecord, withTempHome, writeSessionRecordFile } from "./runtime-test-helpers.js";
@@ -94,6 +94,45 @@ function waitForProcessExit(
       resolve({ code, signal });
     });
   });
+}
+
+async function writeLocalNpxAdapter(
+  homeDir: string,
+  processInfoPath: string,
+): Promise<{ binName: string; packageDir: string }> {
+  const packageDir = path.join(homeDir, "adapter-package");
+  const binName = "acpx-process-tree-fixture";
+  const adapterPath = path.join(packageDir, "adapter.cjs");
+  await fs.mkdir(packageDir, { recursive: true });
+  await fs.writeFile(
+    path.join(packageDir, "package.json"),
+    `${JSON.stringify({
+      name: binName,
+      version: "1.0.0",
+      bin: { [binName]: "adapter.cjs" },
+    })}\n`,
+  );
+  await fs.writeFile(
+    adapterPath,
+    [
+      "#!/usr/bin/env node",
+      'const fs = require("node:fs");',
+      `fs.writeFileSync(${JSON.stringify(processInfoPath)}, JSON.stringify({ pid: process.pid, parentPid: process.ppid }));`,
+      "setInterval(() => {}, 1_000);",
+      `void import(${JSON.stringify(pathToFileURL(MOCK_AGENT_PATH).href)});`,
+      "",
+    ].join("\n"),
+  );
+  await fs.chmod(adapterPath, 0o755);
+  return { binName, packageDir };
+}
+
+async function terminateFixturePid(pid: number): Promise<void> {
+  if (!isProcessAlive(pid)) {
+    return;
+  }
+  process.kill(pid, "SIGKILL");
+  await waitUntil(async () => !isProcessAlive(pid), 2_000);
 }
 
 describe("queue owner lifecycle — graceful SIGTERM shutdown", () => {
@@ -608,6 +647,116 @@ describe("queue owner lifecycle — bridge process death on SIGTERM", () => {
         queueSocket?.destroy();
         if (child.exitCode == null && child.signalCode == null) {
           child.kill("SIGKILL");
+        }
+      }
+    });
+  });
+
+  it("kills a SIGTERM-resistant adapter grandchild launched through npx", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withTempHome("acpx-lifecycle-npx-tree-", async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
+
+      const processInfoPath = path.join(homeDir, "adapter-process.json");
+      const { binName: adapterBin, packageDir } = await writeLocalNpxAdapter(
+        homeDir,
+        processInfoPath,
+      );
+      const record = makeSessionRecord({
+        acpxRecordId: "lifecycle-npx-tree-test",
+        acpSessionId: "lifecycle-npx-tree-session",
+        agentCommand: `npx --yes --offline --package ${JSON.stringify(packageDir)} -- ${adapterBin} --ignore-sigterm`,
+        cwd,
+      });
+      await writeSessionRecordFile(homeDir, record);
+
+      const socketPath = queueSocketPath(record.acpxRecordId, homeDir);
+      const lockPath = queueLockFilePath(record.acpxRecordId, homeDir);
+      const child = spawn(process.execPath, [CLI_PATH, "__queue-owner"], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          ACPX_QUEUE_OWNER_PAYLOAD: JSON.stringify({
+            sessionId: record.acpxRecordId,
+            permissionMode: "approve-reads",
+          }),
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      const stderrChunks: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      let queueSocket: net.Socket | undefined;
+      let adapterPid: number | undefined;
+      let wrapperPid: number | undefined;
+
+      try {
+        await waitUntil(
+          async () =>
+            (await fileExists(socketPath)) || child.exitCode != null || child.signalCode != null,
+        );
+        assert.equal(
+          await fileExists(socketPath),
+          true,
+          `queue owner must open its socket; stderr=${Buffer.concat(stderrChunks).toString("utf8")}`,
+        );
+        queueSocket = await new Promise<net.Socket>((resolve, reject) => {
+          const socket = net.createConnection(socketPath);
+          socket.once("connect", () => resolve(socket));
+          socket.once("error", reject);
+        });
+        queueSocket.write(
+          `${JSON.stringify({
+            type: "submit_prompt",
+            requestId: "req-npx-tree-test",
+            message: "sleep 10000",
+            permissionMode: "approve-reads",
+            waitForCompletion: true,
+          })}\n`,
+        );
+
+        await waitUntil(() => fileExists(processInfoPath), 8_000);
+        const processInfo = JSON.parse(await fs.readFile(processInfoPath, "utf8")) as {
+          pid: number;
+          parentPid: number;
+        };
+        adapterPid = processInfo.pid;
+        wrapperPid = processInfo.parentPid;
+        assert.notEqual(
+          wrapperPid,
+          child.pid,
+          "fixture must launch the adapter as an npx grandchild, not the queue owner's direct child",
+        );
+        assert.equal(isProcessAlive(adapterPid), true, "adapter grandchild must be alive");
+        assert.equal(isProcessAlive(wrapperPid), true, "npx wrapper must be alive");
+
+        child.kill("SIGTERM");
+        const { code, signal } = await waitForProcessExit(child, 10_000);
+        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+
+        assert.equal(signal, null, `queue owner should exit gracefully; stderr=${stderr}`);
+        assert.equal(code, 0, `expected queue owner exit code 0; stderr=${stderr}`);
+        assert.equal(
+          isProcessAlive(adapterPid),
+          false,
+          "SIGTERM-resistant adapter grandchild must not survive npx wrapper teardown",
+        );
+        assert.equal(isProcessAlive(wrapperPid), false, "npx wrapper must be gone");
+        assert.equal(await fileExists(lockPath), false, "queue owner lease must be released");
+      } finally {
+        queueSocket?.destroy();
+        if (child.exitCode == null && child.signalCode == null) {
+          child.kill("SIGKILL");
+        }
+        if (adapterPid) {
+          await terminateFixturePid(adapterPid);
+        }
+        if (wrapperPid) {
+          await terminateFixturePid(wrapperPid);
         }
       }
     });

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -274,6 +274,7 @@ describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
     `;
     const ownerArgs = JSON.stringify(["--input-type=module", "-e", ownerCode]);
     const probe = `
+      import { writeSync } from "node:fs";
       import { spawnQueueOwnerProcess } from ${JSON.stringify(moduleUrl)};
       process.env.ACPX_QUEUE_OWNER_ARGS = ${JSON.stringify(ownerArgs)};
       const handle = spawnQueueOwnerProcess({
@@ -281,7 +282,7 @@ describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
         permissionMode: "approve-reads",
       });
       handle.stopStartupCapture();
-      console.log(handle.pid);
+      writeSync(1, String(handle.pid));
     `;
 
     const result = spawnSync(process.execPath, ["--input-type=module", "--eval", probe], {
@@ -295,7 +296,10 @@ describe("spawnQueueOwnerProcess startup capture lifecycle", () => {
         0,
         `submitter did not exit independently: ${result.stderr || String(result.signal)}`,
       );
-      assert.ok(Number.isInteger(ownerPid) && ownerPid > 0, "expected detached owner pid");
+      assert.ok(
+        Number.isInteger(ownerPid) && ownerPid > 0,
+        `expected detached owner pid; stdout=${JSON.stringify(result.stdout)} stderr=${JSON.stringify(result.stderr)}`,
+      );
       assert.doesNotThrow(() => process.kill(ownerPid, 0), "owner should still be running");
     } finally {
       if (Number.isInteger(ownerPid) && ownerPid > 0) {

--- a/test/queue-owner-process.test.ts
+++ b/test/queue-owner-process.test.ts
@@ -38,6 +38,14 @@ async function waitForCondition(
   }
 }
 
+it("queue owner startup retries cover the full lease-before-bind grace period", () => {
+  const { queueOwnerStartupGraceMs, queueOwnerStartupMaxAttempts, queueConnectRetryMs } =
+    queueOwnerRuntimeTestInternals;
+  const retryWindowMs = (queueOwnerStartupMaxAttempts - 1) * queueConnectRetryMs;
+
+  assert(retryWindowMs >= queueOwnerStartupGraceMs);
+});
+
 describe("resolveQueueOwnerSpawnArgs", () => {
   it("prefers ACPX_QUEUE_OWNER_ARGS when provided", () => {
     const previous = process.env.ACPX_QUEUE_OWNER_ARGS;

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -112,6 +112,11 @@ test("buildAgentSpawnOptions hides Windows console windows and preserves auth en
   });
 
   assert.equal(options.cwd, "/tmp/acpx-agent");
+  assert.equal(
+    (options as { detached?: boolean }).detached,
+    true,
+    "agent wrappers must lead an owned process group/tree for descendant cleanup",
+  );
   assert.deepEqual(options.stdio, ["pipe", "pipe", "pipe"]);
   assert.equal(options.windowsHide, true);
   assert.equal(options.env.ACPX_AUTH_TOKEN, "secret-token");

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -493,6 +493,45 @@ test("terminal manager kills descendants of no-arg shell command lines", async (
   }
 });
 
+test("terminal manager kills descendants that detach into a new process group", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX process group assertion");
+    return;
+  }
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  const childPidPath = path.join(tmp, "detached-child.pid");
+
+  try {
+    const manager = new TerminalManager({
+      cwd: tmp,
+      permissionMode: "approve-all",
+      killGraceMs: 200,
+    });
+    const detachedScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
+    const launcherScript = [
+      "const { spawn } = require('node:child_process');",
+      "const fs = require('node:fs');",
+      `const child = spawn(process.execPath, ['-e', ${JSON.stringify(detachedScript)}], { detached: true, stdio: 'ignore' });`,
+      `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(child.pid));`,
+      "setInterval(() => {}, 1000);",
+    ].join("");
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(launcherScript)} & wait`,
+    });
+
+    const childPid = await waitForPidFile(childPidPath);
+    await manager.killTerminal({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+
+    await assertPidExits(childPid);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("terminal manager releases shell command groups after wrapper exit", async (t) => {
   if (process.platform === "win32") {
     t.skip("POSIX process group assertion");


### PR DESCRIPTION
## Summary

This fixes two related lifecycle/concurrency failure classes:

- package-exec wrappers could exit while adapter descendants remained alive
- concurrent cold prompts could observe a queue-owner lease before its socket was bound, or mutate the same lease concurrently

The implementation now shares one process-tree supervisor between ACP adapters and terminal commands, publishes and mutates queue-owner leases atomically, serializes lease mutations with crash-recoverable claims, and keeps the optimized startup probe aligned with the full startup grace period.

## Symptom and root cause evidence

### Adapter descendants survived wrapper exit

The old client cleanup primarily tracked the direct adapter child. A launch chain such as `npx -> adapter -> resistant grandchild` can outlive that wrapper, change process group, or become reparented before cleanup discovers it.

The shared process-tree implementation now:

- creates an owned process group for adapter launches on POSIX
- captures descendants before signaling and tracks multi-stage wrapper launches for a bounded 10-second window
- uses Linux `/proc` start times as process identities and a fixed-locale POSIX fallback
- validates remembered identities before signaling after root exit
- rescans the owned group and identity-validated escaped descendants during shutdown
- never signals a potentially recycled POSIX process-group ID after its root exits
- rejects a recycled live group leader when its identity differs from the captured root
- applies the final signal to already-tracked live descendants as well as newly discovered descendants
- uses creation-time-validated Windows parent edges, a Windows-specific five-second discovery bound, and `taskkill /t`

The large deletion in `terminal-manager.ts` is deliberate deduplication: its private process-tree implementation moved to `src/acp/process-tree.ts`, which both the ACP client and terminal manager now use.

### Queue-owner lease races

The old queue-owner record and cleanup paths allowed several time-of-check/time-of-use races:

- readers could observe a partially written lease
- refresh, release, stale cleanup, and successor publication could overlap
- stale cleanup could kill an owner that refreshed before cleanup acquired its claim
- restoring a displaced stale claim could overwrite a concurrently acquired claim
- a fresh lease-before-bind owner could be reported as not accepting requests

The lease store now:

- publishes records with same-directory atomic create/replace operations
- assigns collision-resistant generations
- serializes refresh, release, and cleanup with inode-qualified claims
- recovers claims only after PID/process-identity validation
- revalidates owner generation, liveness, and heartbeat while holding the cleanup claim
- restores displaced claims with no-overwrite hard links
- lets a released claim remove its temporarily quarantined record instead of restoring an orphan
- retries transient same-generation release contention and resets failed release state for an in-process retry
- lets a shutting-down owner defer removal to a live external cleanup claimant without a false non-zero exit
- makes unresolved explicit cleanup fail visibly
- treats an already-removed contended lease as successful cleanup
- reacquires stale collisions in the same attempt with fresh timestamps

## Performance

The startup-probe optimization removes nested retry work from every outer startup-loop iteration.

| Unavailable-socket startup probe | Before | This PR | Change |
| --- | ---: | ---: | ---: |
| Socket attempts | 42 (40 submit + 2 health) | 1 | 97.6% fewer |
| Scheduled inner retry delay | 2,100 ms | 0 ms | 2,100 ms removed |
| Redundant health reconnect | yes | no | removed |

The outer loop now derives its budget from the declared startup grace:

- startup grace: **10,000 ms**
- retry interval: **50 ms**
- attempts: **201**
- covered retry window: **10,000 ms**

This preserves the full lease-before-bind window while keeping each fresh-owner probe single-attempt. Established owners retain the prior retry budget so one transient connection refusal does not become a user-visible failure.

### Before/after microbenchmark

Environment: Darwin arm64, Node v26.5.0, five runs against a nonexistent Unix socket.

| Revision | Samples (ms, sorted) | Median |
| --- | --- | ---: |
| `upstream/main` (`504040f`) | 2146.019, 2146.883, 2147.834, 2149.344, 2155.274 | **2147.834 ms** |
| optimized path (`f68abe0`, unchanged in current head) | 0.087, 0.091, 0.094, 0.129, 1.725 | **0.094 ms** |

That is approximately **22,849x lower probe latency (99.996%)**. This isolates the lease-before-bind probe; it is not a general request-throughput benchmark. A regression also asserts that the `queue.connect` metric records exactly one failed connection.

## Regression coverage

The added tests cover:

- normal and failed adapter startup through real `npx` wrapper/grandchild chains
- SIGTERM-resistant adapter descendants
- descendants that detach into another POSIX process group
- final signaling of already-tracked and newly discovered descendants
- POSIX PID/PGID reuse and process-identity changes
- bounded Windows multi-stage descendant tracking
- Windows process-list startup exceeding one second
- bounded process-list command failures
- Linux procfs identity discovery
- atomic lease publication under concurrent readers
- stale malformed and dangling-symlink lock handling
- refresh/release/cleanup claim serialization across processes
- claimant crash recovery
- release while a fresh claim is temporarily quarantined
- same-object release retry after transient claim contention
- concurrent lease removal during explicit cleanup
- cleanup revalidation after a concurrent heartbeat refresh
- no-overwrite restoration when a concurrent claim wins
- one-attempt startup probing and full-grace outer retry coverage
- synchronous detached-test-owner PID publication

## Validation

| Check | Result |
| --- | --- |
| Format, typecheck, type-aware lint, distributable build | passed on `5d3063b` |
| Earlier clean full main suite | 927 passed, 1 platform skip |
| Final full main-suite retry | runner stalled under system load; affected lease test passed immediately in isolation |
| Timed-out npx grandchild test, isolated | passed in 5.06 s |
| Timed-out flow-disconnect test, isolated | passed in 565 ms |
| Coverage-target suite | 111/111 passed |
| Coverage | 94.16% lines/statements, 87.36% branches, 96.07% functions |
| Final affected process-tree/queue suites | 69 passed, 1 platform skip |
| `pnpm run check:docs` | passed |
| `git diff --check` | passed |
| GitHub CI on `5d3063b` | 11 passed, 0 failed, including Test and Mutation |

The prior full run completed cleanly. The final retry later stalled in the unrelated compare suite under unusually high local load and was interrupted; the only implicated lease test passed immediately in isolation. GitHub CI remains the independent clean-run gate for the pushed head.

## Adversarial review

The repository autoreview loop found and drove fixes for:

- stale cleanup without claim-time revalidation
- POSIX descendants missed before unexpected root exit
- final cleanup skipping already-tracked live descendants
- a startup retry window shorter than its declared grace
- claim restoration overwriting a concurrent winner
- release during temporary claim quarantine restoring an orphan
- recycled POSIX groups being adopted after root identity mismatch
- established owners losing transient-connect retries
- Windows process discovery using a one-second PowerShell budget
- release and explicit cleanup abandoning transient claim contention
- failed release promises preventing same-object retry
- claim-driven owner shutdown reporting a false busy failure

The final stable-snapshot Claude `claude-fable-5` autoreview ran on `5d3063b` with tools disabled and reported:

> no accepted/actionable findings reported
>
> overall: patch is correct

No stale pre-fix vendor verdict is claimed for the current head.

## Size and rationale

- **13 commits**
- **17 files**
- **3,138 insertions / 440 deletions**
- production `src/**`: **1,507 insertions / 431 deletions**

Most added lines are the shared cross-platform process-tree implementation, atomic lease/claim handling, and adversarial regression coverage. The terminal-specific deletion removes duplicate lifecycle logic rather than removing behavior.

SBOM, provenance, Homebrew, and SEA packaging remain intentionally separate from this runtime correctness/performance PR.

## Commits

- `e7efc14` — terminate ACP adapter process groups
- `93b6be1` — retry queue-owner lease-before-bind races
- `f68abe0` — harden lifecycle race handling
- `f158b26` — wait for terminal output drain
- `fdf12ea` — publish queue owner leases atomically
- `006e333` — close lifecycle review races
- `2a4e074` — validate remembered process identities
- `2537ffb` — rescan process groups during shutdown
- `79457ae` — close remaining process tree races
- `a85da81` — serialize queue lease mutations
- `ec048e5` — close adapter lifecycle races
- `475bdb8` — preserve concurrent queue lease claims
- `5d3063b` — close adversarial lifecycle races
