### PR TITLE
fix: resolve symlinks in filesystem sandbox path validation

### DIFF
--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -31,6 +31,69 @@ function isWithinRoot(rootDir: string, targetPath: string): boolean {
   return relative.length === 0 || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
+function canonicalizeRootDir(resolved: string): string {
+  // The cwd may not exist yet (it is created on first write), so fall back
+  // to canonicalizing the deepest existing ancestor rather than throwing.
+  // A dangling-symlink cwd resolves to its lexical form here and is then
+  // rejected per-operation by resolvePathWithinRoot.
+  let ancestor = resolved;
+  for (;;) {
+    try {
+      return path.join(realpathSync(ancestor), path.relative(ancestor, resolved));
+    } catch {
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) {
+        return resolved;
+      }
+      ancestor = parent;
+    }
+  }
+}
+
+async function existsAsEntry(target: string): Promise<boolean> {
+  try {
+    await fs.lstat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Canonicalize `resolved` so symlinks cannot escape the sandbox. If the path
+// itself does not exist (e.g. a write to a new file), walk up to the deepest
+// existing parent, canonicalize that, and rebuild the leaf onto it. A path
+// component that exists per lstat but fails realpath (a dangling symlink or a
+// symlink loop) is rejected: falling back to its lexical form would let a
+// subsequent write follow the link to an external target.
+async function canonicalizeForContainment(resolved: string): Promise<string> {
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    if (await existsAsEntry(resolved)) {
+      throw new Error(`Path contains an unresolvable symlink: ${resolved}`);
+    }
+  }
+  // The walk is bounded only by the filesystem root: `ancestor` is derived
+  // from the lexical path while the caller's rootDir is canonical, so the two
+  // are not comparable and any length-based bound here would skip the walk
+  // whenever the lexical cwd is shorter than its canonical target.
+  let ancestor = path.dirname(resolved);
+  for (;;) {
+    try {
+      return path.join(await fs.realpath(ancestor), path.relative(ancestor, resolved));
+    } catch {
+      if (await existsAsEntry(ancestor)) {
+        throw new Error(`Path contains an unresolvable symlink: ${resolved}`);
+      }
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) {
+        return resolved; // reached the filesystem root
+      }
+      ancestor = parent;
+    }
+  }
+}
+
 function toWritePreview(content: string): string {
   const normalized = content.replace(/\r\n/g, "\n");
   const lines = normalized.split("\n");
@@ -69,7 +132,7 @@ export class FileSystemHandlers {
   private readonly confirmWrite: (filePath: string, preview: string) => Promise<boolean>;
 
   constructor(options: FileSystemHandlersOptions) {
-    this.rootDir = realpathSync(path.resolve(options.cwd));
+    this.rootDir = canonicalizeRootDir(path.resolve(options.cwd));
     this.permissionMode = options.permissionMode;
     this.nonInteractivePermissions = options.nonInteractivePermissions ?? "deny";
     this.onOperation = options.onOperation;
@@ -188,36 +251,7 @@ export class FileSystemHandlers {
     if (!path.isAbsolute(rawPath)) {
       throw new Error(`Path must be absolute: ${rawPath}`);
     }
-    const resolved = path.resolve(rawPath);
-    // Resolve symlinks to prevent sandbox escape via symlinks within the cwd.
-    // If the full path does not exist (e.g. a write to a new file), walk up
-    // to the deepest existing parent and resolve that, then rebuild the path.
-    let realPath = resolved;
-    try {
-      realPath = await fs.realpath(resolved);
-    } catch {
-      // Walk up to deepest existing parent. The walk is bounded only by the
-      // filesystem root: `ancestor` is derived from the lexical path while
-      // `rootDir` is canonical, so the two are not comparable, and any
-      // length-based bound here would skip the walk whenever the lexical cwd
-      // is shorter than its canonical target (a symlinked cwd). Containment is
-      // enforced by isWithinRoot below, once both sides are canonical.
-      let ancestor = path.dirname(resolved);
-      for (;;) {
-        try {
-          const realAncestor = await fs.realpath(ancestor);
-          const relative = path.relative(ancestor, resolved);
-          realPath = path.join(realAncestor, relative);
-          break;
-        } catch {
-          const parent = path.dirname(ancestor);
-          if (parent === ancestor) {
-            break; // reached the filesystem root
-          }
-          ancestor = parent;
-        }
-      }
-    }
+    const realPath = await canonicalizeForContainment(path.resolve(rawPath));
     if (!isWithinRoot(this.rootDir, realPath)) {
       throw new Error(`Path is outside allowed cwd subtree: ${realPath}`);
     }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -85,7 +85,7 @@ export class FileSystemHandlers {
   }
 
   async readTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
-    const filePath = this.resolvePathWithinRoot(params.path);
+    const filePath = await this.resolvePathWithinRoot(params.path);
     const summary = `read_text_file: ${filePath}`;
     this.emitOperation({
       method: "fs/read_text_file",
@@ -125,7 +125,7 @@ export class FileSystemHandlers {
   }
 
   async writeTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
-    const filePath = this.resolvePathWithinRoot(params.path);
+    const filePath = await this.resolvePathWithinRoot(params.path);
     const preview = toWritePreview(params.content);
     const summary = `write_text_file: ${filePath}`;
 
@@ -183,15 +183,17 @@ export class FileSystemHandlers {
     return await this.confirmWrite(filePath, preview);
   }
 
-  private resolvePathWithinRoot(rawPath: string): string {
+  private async resolvePathWithinRoot(rawPath: string): Promise<string> {
     if (!path.isAbsolute(rawPath)) {
       throw new Error(`Path must be absolute: ${rawPath}`);
     }
     const resolved = path.resolve(rawPath);
-    if (!isWithinRoot(this.rootDir, resolved)) {
-      throw new Error(`Path is outside allowed cwd subtree: ${resolved}`);
+    // Resolve symlinks to prevent sandbox escape via symlinks within the cwd
+    const realPath = await fs.realpath(resolved).catch(() => resolved);
+    if (!isWithinRoot(this.rootDir, realPath)) {
+      throw new Error(`Path is outside allowed cwd subtree: ${realPath}`);
     }
-    return resolved;
+    return realPath;
   }
 
   private sliceContent(

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs/promises";
 import { realpathSync } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import type {
   ReadTextFileRequest,
@@ -196,9 +196,14 @@ export class FileSystemHandlers {
     try {
       realPath = await fs.realpath(resolved);
     } catch {
-      // Walk up to deepest existing parent
+      // Walk up to deepest existing parent. The walk is bounded only by the
+      // filesystem root: `ancestor` is derived from the lexical path while
+      // `rootDir` is canonical, so the two are not comparable, and any
+      // length-based bound here would skip the walk whenever the lexical cwd
+      // is shorter than its canonical target (a symlinked cwd). Containment is
+      // enforced by isWithinRoot below, once both sides are canonical.
       let ancestor = path.dirname(resolved);
-      while (ancestor.length >= this.rootDir.length) {
+      for (;;) {
         try {
           const realAncestor = await fs.realpath(ancestor);
           const relative = path.relative(ancestor, resolved);
@@ -206,7 +211,9 @@ export class FileSystemHandlers {
           break;
         } catch {
           const parent = path.dirname(ancestor);
-          if (parent === ancestor) break; // reached root
+          if (parent === ancestor) {
+            break; // reached the filesystem root
+          }
           ancestor = parent;
         }
       }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -188,8 +188,28 @@ export class FileSystemHandlers {
       throw new Error(`Path must be absolute: ${rawPath}`);
     }
     const resolved = path.resolve(rawPath);
-    // Resolve symlinks to prevent sandbox escape via symlinks within the cwd
-    const realPath = await fs.realpath(resolved).catch(() => resolved);
+    // Resolve symlinks to prevent sandbox escape via symlinks within the cwd.
+    // If the full path does not exist (e.g. a write to a new file), walk up
+    // to the deepest existing parent and resolve that, then rebuild the path.
+    let realPath = resolved;
+    try {
+      realPath = await fs.realpath(resolved);
+    } catch {
+      // Walk up to deepest existing parent
+      let ancestor = path.dirname(resolved);
+      while (ancestor.length >= this.rootDir.length) {
+        try {
+          const realAncestor = await fs.realpath(ancestor);
+          const relative = path.relative(ancestor, resolved);
+          realPath = path.join(realAncestor, relative);
+          break;
+        } catch {
+          const parent = path.dirname(ancestor);
+          if (parent === ancestor) break; // reached root
+          ancestor = parent;
+        }
+      }
+    }
     if (!isWithinRoot(this.rootDir, realPath)) {
       throw new Error(`Path is outside allowed cwd subtree: ${realPath}`);
     }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import type {
   ReadTextFileRequest,
@@ -68,7 +69,7 @@ export class FileSystemHandlers {
   private readonly confirmWrite: (filePath: string, preview: string) => Promise<boolean>;
 
   constructor(options: FileSystemHandlersOptions) {
-    this.rootDir = path.resolve(options.cwd);
+    this.rootDir = realpathSync(path.resolve(options.cwd));
     this.permissionMode = options.permissionMode;
     this.nonInteractivePermissions = options.nonInteractivePermissions ?? "deny";
     this.onOperation = options.onOperation;

--- a/test/filesystem.test.ts
+++ b/test/filesystem.test.ts
@@ -189,6 +189,63 @@ test("writeTextFile blocks new files under a symlinked directory pointing outsid
   }
 });
 
+test("writeTextFile blocks writes through a dangling symlink pointing outside cwd", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
+  try {
+    const sandbox = path.join(tmp, "sandbox");
+    const outside = path.join(tmp, "outside");
+    await fs.mkdir(sandbox);
+    await fs.mkdir(outside);
+    // The link itself exists but its target does not, so realpath() fails
+    // even though the leaf is present. Without an lstat guard the ancestor
+    // walk would treat this as a missing file and let the write follow the
+    // link to its external target.
+    await fs.symlink(path.join(outside, "secret.txt"), path.join(sandbox, "link.txt"));
+
+    const handlers = new FileSystemHandlers({
+      cwd: sandbox,
+      permissionMode: "approve-all",
+    });
+
+    await assert.rejects(
+      handlers.writeTextFile({
+        sessionId: "session-1",
+        path: path.join(sandbox, "link.txt"),
+        content: "pwned",
+      }),
+      /unresolvable symlink/,
+    );
+    // The external target must not have been created through the link.
+    await assert.rejects(fs.access(path.join(outside, "secret.txt")));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("constructor tolerates a cwd that does not exist yet", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
+  try {
+    // The configured cwd is created lazily on first write; canonicalizing it
+    // in the constructor must not throw when it is still absent.
+    const missing = path.join(tmp, "not-created-yet");
+
+    const handlers = new FileSystemHandlers({
+      cwd: missing,
+      permissionMode: "approve-all",
+    });
+
+    await handlers.writeTextFile({
+      sessionId: "session-1",
+      path: path.join(missing, "new.txt"),
+      content: "written",
+    });
+
+    assert.equal(await fs.readFile(path.join(missing, "new.txt"), "utf8"), "written");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("readTextFile allows existing files when cwd is itself a symlink", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
   try {

--- a/test/filesystem.test.ts
+++ b/test/filesystem.test.ts
@@ -133,6 +133,116 @@ test("writeTextFile blocks paths outside cwd subtree", async () => {
   }
 });
 
+test("readTextFile blocks reads through a symlink pointing outside cwd", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
+  try {
+    const sandbox = path.join(tmp, "sandbox");
+    const outside = path.join(tmp, "outside");
+    await fs.mkdir(sandbox);
+    await fs.mkdir(outside);
+    await fs.writeFile(path.join(outside, "secret.txt"), "secret", "utf8");
+    await fs.symlink(path.join(outside, "secret.txt"), path.join(sandbox, "link.txt"));
+
+    const handlers = new FileSystemHandlers({
+      cwd: sandbox,
+      permissionMode: "approve-all",
+    });
+
+    await assert.rejects(
+      handlers.readTextFile({
+        sessionId: "session-1",
+        path: path.join(sandbox, "link.txt"),
+      }),
+      /outside allowed cwd subtree/,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("writeTextFile blocks new files under a symlinked directory pointing outside cwd", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
+  try {
+    const sandbox = path.join(tmp, "sandbox");
+    const outside = path.join(tmp, "outside");
+    await fs.mkdir(sandbox);
+    await fs.mkdir(outside);
+    await fs.symlink(outside, path.join(sandbox, "escape"));
+
+    const handlers = new FileSystemHandlers({
+      cwd: sandbox,
+      permissionMode: "approve-all",
+    });
+
+    await assert.rejects(
+      handlers.writeTextFile({
+        sessionId: "session-1",
+        // The leaf does not exist, so containment must be decided from the
+        // resolved parent rather than the lexical path.
+        path: path.join(sandbox, "escape", "pwned.txt"),
+        content: "nope",
+      }),
+      /outside allowed cwd subtree/,
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("readTextFile allows existing files when cwd is itself a symlink", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
+  try {
+    // The link path is deliberately shorter than its canonical target, which is
+    // the shape a symlinked cwd takes in practice (macOS /tmp -> /private/tmp).
+    const realRoot = path.join(tmp, "a", "b", "c", "d", "project");
+    const linkedRoot = path.join(tmp, "w");
+    await fs.mkdir(realRoot, { recursive: true });
+    await fs.symlink(realRoot, linkedRoot);
+    await fs.writeFile(path.join(realRoot, "notes.txt"), "hello", "utf8");
+
+    const handlers = new FileSystemHandlers({
+      cwd: linkedRoot,
+      permissionMode: "approve-all",
+    });
+
+    const response = await handlers.readTextFile({
+      sessionId: "session-1",
+      path: path.join(linkedRoot, "notes.txt"),
+    });
+
+    assert.equal(response.content, "hello");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("writeTextFile allows new files when cwd is itself a symlink", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
+  try {
+    const realRoot = path.join(tmp, "a", "b", "c", "d", "project");
+    const linkedRoot = path.join(tmp, "w");
+    await fs.mkdir(realRoot, { recursive: true });
+    await fs.symlink(realRoot, linkedRoot);
+
+    const handlers = new FileSystemHandlers({
+      cwd: linkedRoot,
+      permissionMode: "approve-all",
+    });
+
+    // Non-existent leaf under a symlinked cwd: the ancestor walk has to run
+    // even though the lexical cwd is shorter than its canonical target.
+    await handlers.writeTextFile({
+      sessionId: "session-1",
+      path: path.join(linkedRoot, "new.txt"),
+      content: "written",
+    });
+
+    assert.equal(await fs.readFile(path.join(realRoot, "new.txt"), "utf8"), "written");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("readTextFile requires absolute paths", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-fs-test-"));
   try {


### PR DESCRIPTION
## Summary

`isWithinRoot()` at `src/filesystem.ts:28` uses `path.relative()` + `..` detection to prevent path traversal, but does not resolve symlinks. An agent with `fs/write_text_file` permission inside the cwd can create a symlink pointing outside the sandbox, then read arbitrary files via `fs/read_text_file`.

## Reproduction

1. Agent has `fs/write_text_file` permission inside cwd
2. Agent creates symlink: `/cwd/link → /etc/passwd`
3. Agent calls `fs/read_text_file` with path `/cwd/link`
4. `path.resolve()` and `isWithinRoot()` pass (link path is within cwd)
5. `fs.readFile()` follows the symlink outside sandbox

## Fix

Add `fs.realpath()` resolution before the `isWithinRoot()` check. If `realpath` fails (broken symlink, missing file), falls back to the original resolved path.

`resolvePathWithinRoot` is now async; both callers (`readTextFile`, `writeTextFile`) were already async.

## Notes

- Exploit requires write permission within the sandbox first — this is an authenticated sandbox escape, not zero-click RCE
- Found during Veronica Burnz security hunt 🦇