### PR TITLE
fix(session): re-apply pinned model before set on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Runtime/embedding: settle turn results only after lifecycle persistence and client cleanup attempts finish, including unexpected finalization failures.
+- CLI/session: re-apply a session-pinned model before set_mode/set_model/set_config_option after reconnect, matching the prompt path so model-dependent options work. Fixes #489.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/src/cli/session/prompt-runner.ts
+++ b/src/cli/session/prompt-runner.ts
@@ -198,14 +198,8 @@ export async function runSessionSetModelDirect(
 ): Promise<SessionSetModelResult> {
   const result = await withConnectedSession(
     buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
-      // set-model is an explicit model change; still re-apply pin first so the
-      // agent advertises the pinned option set before we switch.
-      await reapplyPinnedModelAfterConnect({
-        client,
-        sessionId,
-        record,
-        timeoutMs: options.timeoutMs,
-      });
+      // Explicit model switch replaces the saved pin. Do not re-apply the old
+      // pin first: an unadvertised saved model would reject and block the switch.
       const models = advertisedModelState(record.acpx);
       const response = await withTimeout(
         client.setSessionModel(sessionId, options.modelId, models),
@@ -226,13 +220,18 @@ export async function runSessionSetConfigOptionDirect(
 ): Promise<SessionSetConfigOptionResult> {
   const result = await withConnectedSession(
     buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
-      await reapplyPinnedModelAfterConnect({
-        client,
-        sessionId,
-        record,
-        timeoutMs: options.timeoutMs,
-      });
       const modelConfigId = advertisedModelState(record.acpx)?.configId;
+      // Model-valued config updates replace the pin; skip pin replay so an
+      // obsolete saved model cannot block the replacement. Other config keys
+      // still re-apply the pin so model-dependent options see the right set.
+      if (options.configId !== modelConfigId) {
+        await reapplyPinnedModelAfterConnect({
+          client,
+          sessionId,
+          record,
+          timeoutMs: options.timeoutMs,
+        });
+      }
       const response = await withTimeout(
         client.setSessionConfigOption(sessionId, options.configId, options.value),
         options.timeoutMs,

--- a/src/cli/session/prompt-runner.ts
+++ b/src/cli/session/prompt-runner.ts
@@ -1,3 +1,4 @@
+import type { AcpClient } from "../../acp/client.js";
 import { withTimeout } from "../../async-control.js";
 import {
   withConnectedSession,
@@ -5,6 +6,7 @@ import {
   type WithConnectedSessionOptions,
   type WithConnectedSessionResult,
 } from "../../runtime/engine/connected-session.js";
+import { sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
 import { applyConfigOptionsToRecord } from "../../session/config-options.js";
 import {
   setCurrentModelId,
@@ -12,13 +14,17 @@ import {
   setDesiredModeId,
   setDesiredModelId,
 } from "../../session/mode-preference.js";
-import { currentModelIdFromSetModelResponse } from "../../session/model-application.js";
+import {
+  applyRequestedModelIfAdvertised,
+  currentModelIdFromSetModelResponse,
+} from "../../session/model-application.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import { resolveSessionRecord, writeSessionRecord } from "../../session/persistence.js";
 import type {
   AuthPolicy,
   McpServer,
   NonInteractivePermissionPolicy,
+  SessionRecord,
   SessionSetConfigOptionResult,
   SessionSetModelResult,
   SessionSetModeResult,
@@ -121,11 +127,64 @@ function toSessionMutationResult(
   };
 }
 
+/**
+ * Re-apply the session-pinned model after reconnect, matching the prompt path.
+ *
+ * Some agents (e.g. opencode) restore to their default model on session load and
+ * advertise model-dependent config options for that default. Without replaying
+ * `session_options.model` first, `set` fails because the option set belongs to
+ * the wrong model, and the record is overwritten with default-model options.
+ */
+async function reapplyPinnedModelAfterConnect(params: {
+  client: AcpClient;
+  sessionId: string;
+  record: SessionRecord;
+  timeoutMs?: number;
+}): Promise<void> {
+  const pinnedModel = sessionOptionsFromRecord(params.record)?.model;
+  if (!pinnedModel) {
+    return;
+  }
+
+  const models = advertisedModelState(params.record.acpx);
+  if (models?.currentModelId === pinnedModel) {
+    // Keep the pin sticky when the agent already reports it after load.
+    setDesiredModelId(params.record, pinnedModel, models.configId);
+    setCurrentModelId(params.record, pinnedModel);
+    return;
+  }
+
+  const result = await applyRequestedModelIfAdvertised({
+    client: params.client,
+    sessionId: params.sessionId,
+    requestedModel: pinnedModel,
+    models,
+    agentCommand: params.record.agentCommand,
+    timeoutMs: params.timeoutMs,
+  });
+  if (result.response) {
+    applyConfigOptionsToRecord(params.record, result.response);
+  }
+  if (result.applied) {
+    setDesiredModelId(params.record, pinnedModel, models?.configId);
+    setCurrentModelId(
+      params.record,
+      currentModelIdFromSetModelResponse(result.response, pinnedModel),
+    );
+  }
+}
+
 export async function runSessionSetModeDirect(
   options: RunSessionSetModeDirectOptions,
 ): Promise<SessionSetModeResult> {
   const result = await withConnectedSession(
     buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
+      await reapplyPinnedModelAfterConnect({
+        client,
+        sessionId,
+        record,
+        timeoutMs: options.timeoutMs,
+      });
       await withTimeout(client.setSessionMode(sessionId, options.modeId), options.timeoutMs);
       setDesiredModeId(record, options.modeId);
     }),
@@ -139,6 +198,14 @@ export async function runSessionSetModelDirect(
 ): Promise<SessionSetModelResult> {
   const result = await withConnectedSession(
     buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
+      // set-model is an explicit model change; still re-apply pin first so the
+      // agent advertises the pinned option set before we switch.
+      await reapplyPinnedModelAfterConnect({
+        client,
+        sessionId,
+        record,
+        timeoutMs: options.timeoutMs,
+      });
       const models = advertisedModelState(record.acpx);
       const response = await withTimeout(
         client.setSessionModel(sessionId, options.modelId, models),
@@ -159,6 +226,12 @@ export async function runSessionSetConfigOptionDirect(
 ): Promise<SessionSetConfigOptionResult> {
   const result = await withConnectedSession(
     buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
+      await reapplyPinnedModelAfterConnect({
+        client,
+        sessionId,
+        record,
+        timeoutMs: options.timeoutMs,
+      });
       const modelConfigId = advertisedModelState(record.acpx)?.configId;
       const response = await withTimeout(
         client.setSessionConfigOption(sessionId, options.configId, options.value),

--- a/test/prompt-runner.test.ts
+++ b/test/prompt-runner.test.ts
@@ -228,6 +228,54 @@ test("runSessionSetConfigOptionDirect promotes a custom model config preference"
   });
 });
 
+test("runSessionSetConfigOptionDirect re-applies pinned model after reconnect", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+
+    // Simulate a prior session pinned to smart-model. On reconnect the mock
+    // agent creates a fresh in-process session at default-model (new process).
+    const record = makeSessionRecord({
+      acpxRecordId: "prompt-runner-pinned-model-set",
+      acpSessionId: "prompt-runner-pinned-model-set-session",
+      agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --supports-load-session --advertise-models --model-config-id model`,
+      cwd,
+      closed: true,
+      closedAt: "2026-01-01T00:05:00.000Z",
+      acpx: {
+        current_model_id: "smart-model",
+        session_options: {
+          model: "smart-model",
+        },
+      },
+    });
+    await writeSessionRecord(homeDir, record);
+
+    const result = await runSessionSetConfigOptionDirect({
+      sessionRecordId: record.acpxRecordId,
+      configId: "reasoning_effort",
+      value: "high",
+      timeoutMs: 5_000,
+    });
+
+    assert.equal(result.resumed, true);
+    assert.equal(result.record.acpx?.current_model_id, "smart-model");
+    assert.equal(result.record.acpx?.session_options?.model, "smart-model");
+    assert.equal(
+      result.record.acpx?.config_options?.find((option) => option.id === "model")?.currentValue,
+      "smart-model",
+    );
+    assert.equal(
+      result.record.acpx?.config_options?.find((option) => option.id === "reasoning_effort")
+        ?.currentValue,
+      "high",
+    );
+    assert.deepEqual(result.record.acpx?.desired_config_options, {
+      reasoning_effort: "high",
+    });
+  });
+});
+
 test("runSessionSetModelDirect updates current and desired model", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who pin a non-default model at session creation (`--model`) then run `acpx <agent> set <configId> <value>` against that session would hit agent rejection for model-dependent options (for example opencode `effort`). Each set is a new process that resumes the ACP session; some agents restore their default model on resume, and the set paths never re-applied the pin. The prompt path already did.

## Why This Change Was Made

After reconnect, the set paths (`set_mode`, `set_model`, `set_config_option`) now re-apply `session_options.model` before mutating config, matching the prompt path. Scope is intentionally narrow: only the set entrypoints, not a full reconnect-preference policy change.

## User Impact

Pinned-model sessions keep working for config sets after process restart. Operators no longer need to re-prompt solely to restore the model before a set.

## Evidence

Production path: `withConnectedSession` → set direct helpers in `prompt-runner.ts`. After this patch, a resumed set re-pins `session_options.model` before `session/set_config_option`.

Red/green on a load-capable agent that starts each process at the default model while the session record keeps `session_options.model = smart-model`:

```console
$ node --test dist-test/test/prompt-runner.test.js
(without fix) re-applies pinned model after reconnect FAIL
  Expected current_model_id smart-model, got default-model

(with fix) re-applies pinned model after reconnect PASS
  current_model_id = smart-model
  model option currentValue = smart-model
  reasoning_effort = high
```

## Real behavior proof

- **Behavior or issue addressed:** Re-apply the session-pinned model on set after reconnect so model-dependent config options are advertised for the pin, not the agent default.
- **Real environment tested:** macOS arm64, Node 26, worktree `/tmp/acpx-489` on `fix/489-reapply-pinned-model-on-set` from `upstream/main`.
- **Exact steps or command run after this patch:** `pnpm run build:test` then `node --test dist-test/test/prompt-runner.test.js` (red without the re-apply helper, green with it).
- **Evidence after fix:** console output above; after reconnect, set reasoning_effort high leaves current_model_id and model option at smart-model.
- **Observed result after fix:** pinned model survives set; desired_config_options and advertised options stay on the pin.
- **What was not tested:** live opencode binary with deepseek-v4-flash effort options (issue repro uses that agent; this path uses the in-repo load-capable agent that resets model on new process, matching the same failure mode).

## Summary

- Add `reapplyPinnedModelAfterConnect` before set_mode / set_model / set_config_option
- Regression covering reconnect + set config with session_options.model pin
- Changelog under Unreleased Fixes

## Testing

- Red: new case failed without the fix (current_model_id fell back to default-model)
- Green: `node --test dist-test/test/prompt-runner.test.js` → 5 passed
- oxlint/oxfmt clean on changed files; typecheck via build:test

Closes #489
