### PR TITLE
fix(security): contain replay viewer bundle projection paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Runtime/embedding: settle turn results only after lifecycle persistence and client cleanup attempts finish, including unexpected finalization failures.
+- Replay viewer: contain manifest-selected projection reads within their run bundle, including symlink targets. Thanks @bunlongheng.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/examples/flows/replay-viewer/server/filesystem-bundle-reader.ts
+++ b/examples/flows/replay-viewer/server/filesystem-bundle-reader.ts
@@ -1,15 +1,16 @@
-import fs from "node:fs/promises";
 import type { BundleReader } from "../src/lib/bundle-reader.js";
 import type { RunBundleSummary } from "../src/types.js";
-import { resolveRunBundleFilePath } from "./run-bundles.js";
+import {
+  readRunBundleFile as readContainedRunBundleFile,
+  readRunBundleTextFile,
+} from "./run-bundles.js";
 
 export function createFilesystemBundleReader(
   runsDir: string,
   run: Pick<RunBundleSummary, "runId">,
 ): BundleReader {
   async function readText(relativePath: string): Promise<string> {
-    const filePath = await resolveRunBundleFilePath(runsDir, run.runId, relativePath);
-    return fs.readFile(filePath, "utf8");
+    return await readRunBundleTextFile(runsDir, run.runId, relativePath);
   }
 
   return {
@@ -28,6 +29,5 @@ export async function readBundleFile(
   runId: string,
   relativePath: string,
 ): Promise<Buffer> {
-  const filePath = await resolveRunBundleFilePath(runsDir, runId, relativePath);
-  return fs.readFile(filePath);
+  return await readContainedRunBundleFile(runsDir, runId, relativePath);
 }

--- a/examples/flows/replay-viewer/server/filesystem-bundle-reader.ts
+++ b/examples/flows/replay-viewer/server/filesystem-bundle-reader.ts
@@ -8,7 +8,7 @@ export function createFilesystemBundleReader(
   run: Pick<RunBundleSummary, "runId">,
 ): BundleReader {
   async function readText(relativePath: string): Promise<string> {
-    const filePath = resolveRunBundleFilePath(runsDir, run.runId, relativePath);
+    const filePath = await resolveRunBundleFilePath(runsDir, run.runId, relativePath);
     return fs.readFile(filePath, "utf8");
   }
 
@@ -28,6 +28,6 @@ export async function readBundleFile(
   runId: string,
   relativePath: string,
 ): Promise<Buffer> {
-  const filePath = resolveRunBundleFilePath(runsDir, runId, relativePath);
+  const filePath = await resolveRunBundleFilePath(runsDir, runId, relativePath);
   return fs.readFile(filePath);
 }

--- a/examples/flows/replay-viewer/server/run-bundles.ts
+++ b/examples/flows/replay-viewer/server/run-bundles.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { mergeLiveRunState } from "../src/lib/run-state.js";
@@ -77,23 +78,73 @@ export async function resolveRunBundleFilePath(
   return realPath;
 }
 
+export async function readRunBundleTextFile(
+  runsDir: string,
+  runId: string,
+  relativePath: string,
+): Promise<string> {
+  const file = await openContainedRunBundleFile(runsDir, runId, relativePath);
+  try {
+    return await file.readFile("utf8");
+  } finally {
+    await file.close();
+  }
+}
+
+export async function readRunBundleFile(
+  runsDir: string,
+  runId: string,
+  relativePath: string,
+): Promise<Buffer> {
+  const file = await openContainedRunBundleFile(runsDir, runId, relativePath);
+  try {
+    return await file.readFile();
+  } finally {
+    await file.close();
+  }
+}
+
+async function openContainedRunBundleFile(
+  runsDir: string,
+  runId: string,
+  relativePath: string,
+): Promise<FileHandle> {
+  const checkedPath = await resolveRunBundleFilePath(runsDir, runId, relativePath);
+  const realRunDir = await fs.realpath(path.resolve(runsDir, runId));
+  const noFollow = fsConstants.O_NOFOLLOW ?? 0;
+  const file = await fs.open(checkedPath, fsConstants.O_RDONLY | noFollow);
+  try {
+    const [openedStat, currentPath] = await Promise.all([
+      file.stat(),
+      fs.realpath(path.resolve(runsDir, runId, normalizeRelativePath(relativePath))),
+    ]);
+    if (!isPathInsideDirectory(realRunDir, currentPath)) {
+      throw new Error(`Refusing to read outside run bundle: ${relativePath}`);
+    }
+    const currentStat = await fs.stat(currentPath);
+    if (openedStat.dev !== currentStat.dev || openedStat.ino !== currentStat.ino) {
+      throw new Error(`Refusing changed run bundle path: ${relativePath}`);
+    }
+    return file;
+  } catch (error) {
+    await file.close();
+    throw error;
+  }
+}
+
 async function readRunBundleSummary(runsDir: string, runId: string): Promise<RunBundleSummary> {
   const runDir = path.join(runsDir, runId);
   const manifest = JSON.parse(
-    await fs.readFile(await resolveRunBundleFilePath(runsDir, runId, "manifest.json"), "utf8"),
+    await readRunBundleTextFile(runsDir, runId, "manifest.json"),
   ) as FlowRunManifest;
   // The manifest is bundle-controlled data, so its projection paths are
   // constrained to the run bundle before being read. Otherwise a crafted
   // manifest could point runProjection/liveProjection at an arbitrary file
   // outside the bundle (e.g. "../../../etc/passwd") during listRunBundles.
   const run = JSON.parse(
-    await fs.readFile(
-      await resolveRunBundleFilePath(runsDir, runId, manifest.paths.runProjection),
-      "utf8",
-    ),
+    await readRunBundleTextFile(runsDir, runId, manifest.paths.runProjection),
   ) as FlowRunState;
-  const live = await resolveRunBundleFilePath(runsDir, runId, manifest.paths.liveProjection)
-    .then(async (filePath) => await fs.readFile(filePath, "utf8"))
+  const live = await readRunBundleTextFile(runsDir, runId, manifest.paths.liveProjection)
     .then((text) => JSON.parse(text) as Partial<FlowRunState>)
     .catch(() => null);
   const mergedRun = mergeLiveRunState(run, live);

--- a/examples/flows/replay-viewer/server/run-bundles.ts
+++ b/examples/flows/replay-viewer/server/run-bundles.ts
@@ -45,11 +45,11 @@ export async function listRunBundles(
     });
 }
 
-export function resolveRunBundleFilePath(
+export async function resolveRunBundleFilePath(
   runsDir: string,
   runId: string,
   relativePath: string,
-): string {
+): Promise<string> {
   const normalizedRelativePath = normalizeRelativePath(relativePath);
   const resolvedRunsDir = path.resolve(runsDir);
   const runDir = path.resolve(resolvedRunsDir, runId);
@@ -62,13 +62,25 @@ export function resolveRunBundleFilePath(
     throw new Error(`Refusing to read outside run bundle: ${relativePath}`);
   }
 
-  return resolvedPath;
+  const [realRunsDir, realRunDir, realPath] = await Promise.all([
+    fs.realpath(resolvedRunsDir),
+    fs.realpath(runDir),
+    fs.realpath(resolvedPath),
+  ]);
+  if (!isPathInsideDirectory(realRunsDir, realRunDir, { allowSamePath: false })) {
+    throw new Error(`Refusing to read run bundle outside runs directory: ${runId}`);
+  }
+  if (!isPathInsideDirectory(realRunDir, realPath)) {
+    throw new Error(`Refusing to read outside run bundle: ${relativePath}`);
+  }
+
+  return realPath;
 }
 
 async function readRunBundleSummary(runsDir: string, runId: string): Promise<RunBundleSummary> {
   const runDir = path.join(runsDir, runId);
   const manifest = JSON.parse(
-    await fs.readFile(path.join(runDir, "manifest.json"), "utf8"),
+    await fs.readFile(await resolveRunBundleFilePath(runsDir, runId, "manifest.json"), "utf8"),
   ) as FlowRunManifest;
   // The manifest is bundle-controlled data, so its projection paths are
   // constrained to the run bundle before being read. Otherwise a crafted
@@ -76,12 +88,12 @@ async function readRunBundleSummary(runsDir: string, runId: string): Promise<Run
   // outside the bundle (e.g. "../../../etc/passwd") during listRunBundles.
   const run = JSON.parse(
     await fs.readFile(
-      resolveRunBundleFilePath(runsDir, runId, manifest.paths.runProjection),
+      await resolveRunBundleFilePath(runsDir, runId, manifest.paths.runProjection),
       "utf8",
     ),
   ) as FlowRunState;
-  const live = await fs
-    .readFile(resolveRunBundleFilePath(runsDir, runId, manifest.paths.liveProjection), "utf8")
+  const live = await resolveRunBundleFilePath(runsDir, runId, manifest.paths.liveProjection)
+    .then(async (filePath) => await fs.readFile(filePath, "utf8"))
     .then((text) => JSON.parse(text) as Partial<FlowRunState>)
     .catch(() => null);
   const mergedRun = mergeLiveRunState(run, live);

--- a/examples/flows/replay-viewer/server/run-bundles.ts
+++ b/examples/flows/replay-viewer/server/run-bundles.ts
@@ -51,6 +51,14 @@ export async function resolveRunBundleFilePath(
   runId: string,
   relativePath: string,
 ): Promise<string> {
+  return (await resolveRunBundleFileTarget(runsDir, runId, relativePath)).realPath;
+}
+
+async function resolveRunBundleFileTarget(
+  runsDir: string,
+  runId: string,
+  relativePath: string,
+): Promise<{ realPath: string; realRunDir: string }> {
   const normalizedRelativePath = normalizeRelativePath(relativePath);
   const resolvedRunsDir = path.resolve(runsDir);
   const runDir = path.resolve(resolvedRunsDir, runId);
@@ -75,7 +83,7 @@ export async function resolveRunBundleFilePath(
     throw new Error(`Refusing to read outside run bundle: ${relativePath}`);
   }
 
-  return realPath;
+  return { realPath, realRunDir };
 }
 
 export async function readRunBundleTextFile(
@@ -109,8 +117,11 @@ async function openContainedRunBundleFile(
   runId: string,
   relativePath: string,
 ): Promise<FileHandle> {
-  const checkedPath = await resolveRunBundleFilePath(runsDir, runId, relativePath);
-  const realRunDir = await fs.realpath(path.resolve(runsDir, runId));
+  const { realPath: checkedPath, realRunDir } = await resolveRunBundleFileTarget(
+    runsDir,
+    runId,
+    relativePath,
+  );
   const noFollow = fsConstants.O_NOFOLLOW ?? 0;
   const file = await fs.open(checkedPath, fsConstants.O_RDONLY | noFollow);
   try {

--- a/examples/flows/replay-viewer/server/run-bundles.ts
+++ b/examples/flows/replay-viewer/server/run-bundles.ts
@@ -70,11 +70,18 @@ async function readRunBundleSummary(runsDir: string, runId: string): Promise<Run
   const manifest = JSON.parse(
     await fs.readFile(path.join(runDir, "manifest.json"), "utf8"),
   ) as FlowRunManifest;
+  // The manifest is bundle-controlled data, so its projection paths are
+  // constrained to the run bundle before being read. Otherwise a crafted
+  // manifest could point runProjection/liveProjection at an arbitrary file
+  // outside the bundle (e.g. "../../../etc/passwd") during listRunBundles.
   const run = JSON.parse(
-    await fs.readFile(path.join(runDir, manifest.paths.runProjection), "utf8"),
+    await fs.readFile(
+      resolveRunBundleFilePath(runsDir, runId, manifest.paths.runProjection),
+      "utf8",
+    ),
   ) as FlowRunState;
   const live = await fs
-    .readFile(path.join(runDir, manifest.paths.liveProjection), "utf8")
+    .readFile(resolveRunBundleFilePath(runsDir, runId, manifest.paths.liveProjection), "utf8")
     .then((text) => JSON.parse(text) as Partial<FlowRunState>)
     .catch(() => null);
   const mergedRun = mergeLiveRunState(run, live);

--- a/test/replay-viewer-run-bundles.test.ts
+++ b/test/replay-viewer-run-bundles.test.ts
@@ -67,6 +67,48 @@ test("listRunBundles prefers live status over stale run projections", async () =
   }
 });
 
+test("listRunBundles ignores bundles whose manifest paths escape the bundle", async () => {
+  const runsDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-run-list-escape-"));
+  const secretDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-run-secret-"));
+
+  try {
+    const secretFile = path.join(secretDir, "secret.json");
+    await fs.writeFile(secretFile, JSON.stringify({ runTitle: "leaked", status: "completed" }));
+
+    const runId = "2026-03-27T090000000Z-malicious";
+    const runDir = path.join(runsDir, runId);
+    await fs.mkdir(runDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runDir, "manifest.json"),
+      JSON.stringify({
+        schema: "acpx.flow-run-bundle.v1",
+        runId,
+        flowName: "flow-malicious",
+        startedAt: "2026-03-27T09:00:00.000Z",
+        status: "completed",
+        traceSchema: "acpx.flow-trace-event.v1",
+        paths: {
+          flow: "flow.json",
+          trace: "trace.ndjson",
+          runProjection: path.relative(runDir, secretFile),
+          liveProjection: "projections/live.json",
+          stepsProjection: "projections/steps.json",
+          sessionsDir: "sessions",
+          artifactsDir: "artifacts",
+        },
+        sessions: [],
+      }),
+    );
+
+    const runs = await listRunBundles(runsDir);
+
+    assert.deepEqual(runs, []);
+  } finally {
+    await fs.rm(runsDir, { recursive: true, force: true });
+    await fs.rm(secretDir, { recursive: true, force: true });
+  }
+});
+
 test("resolveRunBundleFilePath rejects traversal outside a run bundle", () => {
   const runsDir = path.join(os.tmpdir(), "acpx-run-list");
 

--- a/test/replay-viewer-run-bundles.test.ts
+++ b/test/replay-viewer-run-bundles.test.ts
@@ -109,19 +109,98 @@ test("listRunBundles ignores bundles whose manifest paths escape the bundle", as
   }
 });
 
-test("resolveRunBundleFilePath rejects traversal outside a run bundle", () => {
+test("listRunBundles ignores bundles whose projection symlink escapes the bundle", async () => {
+  const runsDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-run-list-symlink-"));
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-run-outside-"));
+
+  try {
+    const runId = "2026-03-27T100000000Z-symlink";
+    const runDir = path.join(runsDir, runId);
+    const outsideFile = path.join(outsideDir, "outside.json");
+    await fs.mkdir(path.join(runDir, "projections"), { recursive: true });
+    await fs.writeFile(outsideFile, JSON.stringify({ runTitle: "leaked", status: "completed" }));
+    await fs.symlink(outsideFile, path.join(runDir, "projections", "run.json"));
+    await fs.writeFile(
+      path.join(runDir, "manifest.json"),
+      JSON.stringify({
+        schema: "acpx.flow-run-bundle.v1",
+        runId,
+        flowName: "flow-symlink",
+        startedAt: "2026-03-27T10:00:00.000Z",
+        status: "completed",
+        traceSchema: "acpx.flow-trace-event.v1",
+        paths: {
+          flow: "flow.json",
+          trace: "trace.ndjson",
+          runProjection: "projections/run.json",
+          liveProjection: "projections/live.json",
+          stepsProjection: "projections/steps.json",
+          sessionsDir: "sessions",
+          artifactsDir: "artifacts",
+        },
+        sessions: [],
+      }),
+    );
+
+    assert.deepEqual(await listRunBundles(runsDir), []);
+  } finally {
+    await fs.rm(runsDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("listRunBundles ignores bundles whose manifest symlink escapes the bundle", async () => {
+  const runsDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-run-manifest-symlink-"));
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-run-manifest-outside-"));
+
+  try {
+    const runId = "2026-03-27T110000000Z-manifest-symlink";
+    const runDir = path.join(runsDir, runId);
+    const outsideManifest = path.join(outsideDir, "manifest.json");
+    await fs.mkdir(runDir, { recursive: true });
+    await fs.writeFile(
+      outsideManifest,
+      JSON.stringify({
+        schema: "acpx.flow-run-bundle.v1",
+        runId,
+        flowName: "flow-manifest-symlink",
+        startedAt: "2026-03-27T11:00:00.000Z",
+        status: "completed",
+        traceSchema: "acpx.flow-trace-event.v1",
+        paths: {
+          flow: "flow.json",
+          trace: "trace.ndjson",
+          runProjection: "projections/run.json",
+          liveProjection: "projections/live.json",
+          stepsProjection: "projections/steps.json",
+          sessionsDir: "sessions",
+          artifactsDir: "artifacts",
+        },
+        sessions: [],
+      }),
+    );
+    await fs.symlink(outsideManifest, path.join(runDir, "manifest.json"));
+
+    assert.deepEqual(await listRunBundles(runsDir), []);
+  } finally {
+    await fs.rm(runsDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveRunBundleFilePath rejects traversal outside a run bundle", async () => {
   const runsDir = path.join(os.tmpdir(), "acpx-run-list");
 
-  assert.throws(
-    () => resolveRunBundleFilePath(runsDir, "run-id", "../manifest.json"),
+  await assert.rejects(
+    resolveRunBundleFilePath(runsDir, "run-id", "../manifest.json"),
     /not allowed/,
   );
-  assert.throws(
-    () => resolveRunBundleFilePath(runsDir, "run-id", "/tmp/manifest.json"),
+  await assert.rejects(
+    resolveRunBundleFilePath(runsDir, "run-id", "/tmp/manifest.json"),
     /not allowed/,
   );
-  assert.throws(
-    () => resolveRunBundleFilePath(runsDir, "../sessions", "session.json"),
+  await assert.rejects(
+    resolveRunBundleFilePath(runsDir, "../sessions", "session.json"),
     /outside runs directory/,
   );
 });


### PR DESCRIPTION
## Summary

`readRunBundleSummary` in the replay viewer read the manifest-supplied projection paths (`manifest.paths.runProjection` and `manifest.paths.liveProjection`) via `path.join(runDir, ...)` with **no containment check**, unlike the sibling `/api/runs/:runId/files/:path` reader which already routes through `resolveRunBundleFilePath`.

The `manifest.json` is bundle-controlled data. A crafted bundle placed in the runs directory (e.g. a shared/synced runs dir, or a downloaded run bundle -- exactly the artifacts this viewer is built to open) can set a projection path to an arbitrary location such as `../../../../etc/passwd`. Because `listRunBundles` powers the network-reachable `GET /api/runs` endpoint, this lets a malicious bundle make the viewer read a file **outside** its run bundle and leak fields from it into the run summary.

This is the remaining path-traversal gap in the same file hardened by #255 (which fixed `runId` traversal but left the manifest projection paths unguarded).

## Fix

Route both projection paths through the existing `resolveRunBundleFilePath(runsDir, runId, relativePath)` helper, which already enforces run-bundle containment (rejects absolute paths, `..` traversal, and anything resolving outside the bundle dir). Minimal, reuses in-module logic, no behavior change for well-formed bundles.

## Evidence / Reproduction

Added a regression test that writes a bundle whose `manifest.paths.runProjection` points at a JSON file **outside** the bundle directory.

**Before fix** -- the escaping bundle is accepted and leaks the outside file's fields:
```
actual:
  0:
    runId: '...-malicious'
    runTitle: 'leaked'      <-- read from a secret file OUTSIDE the bundle
    status: 'completed'
# pass 3 # fail 1
```

**After fix** -- `resolveRunBundleFilePath` throws, `listRunBundles` skips the bundle, summary is `[]`:
```
# tests 4 # pass 4 # fail 0
```

## Testing

- `node --test test/replay-viewer-run-bundles.test.ts` -- 4/4 pass
- `test/replay-viewer-server.test.ts` + loader -- 14/14 pass
- `oxfmt --check`, `oxlint --type-aware --deny-warnings`, viewer server `tsc --noEmit` -- all clean
