### PR TITLE
feat(runtime): expose prompt request readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Breaking
 
+- Runtime API: require `AcpRuntimeTurn.promptStarted`, which settles after `connection.prompt()` returns its request promise or fails beforehand.
+
 ### Fixes
 
 ## 2026.7.27 (v0.13.0)

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1047,7 +1047,11 @@ export class AcpClient {
     this.suppressReplaySessionUpdateMessages = previous.suppressReplaySessionUpdateMessages;
   }
 
-  async prompt(sessionId: string, prompt: PromptInput | string): Promise<PromptResponse> {
+  async prompt(
+    sessionId: string,
+    prompt: PromptInput | string,
+    onRequestStarted?: () => Promise<void> | void,
+  ): Promise<PromptResponse> {
     const connection = this.getConnection();
     const normalizedPrompt = this.normalizePromptForAgent(prompt);
     const restoreConsoleError = this.options.suppressSdkConsoleErrors
@@ -1056,11 +1060,14 @@ export class AcpClient {
 
     let promptPromise: Promise<PromptResponse>;
     try {
-      promptPromise = this.runConnectionRequest(() =>
-        connection.prompt({
-          sessionId,
-          prompt: normalizedPrompt,
-        }),
+      promptPromise = this.runConnectionRequest(
+        () =>
+          connection.prompt({
+            sessionId,
+            prompt: normalizedPrompt,
+          }),
+        onRequestStarted,
+        () => !connection.signal?.aborted,
       );
     } catch (error) {
       restoreConsoleError?.();
@@ -1858,7 +1865,11 @@ export class AcpClient {
     return error;
   }
 
-  private async runConnectionRequest<T>(run: () => Promise<T>): Promise<T> {
+  private async runConnectionRequest<T>(
+    run: () => Promise<T>,
+    onRequestStarted?: () => Promise<void> | void,
+    canStartRequest: () => boolean = () => true,
+  ): Promise<T> {
     return await new Promise<T>((resolve, reject) => {
       const pending: PendingConnectionRequest = {
         settled: false,
@@ -1876,7 +1887,18 @@ export class AcpClient {
 
       this.pendingConnectionRequests.add(pending);
       void Promise.resolve()
-        .then(run)
+        .then(async () => {
+          const requestCanStart = canStartRequest();
+          const request = run();
+          if (requestCanStart) {
+            try {
+              void Promise.resolve(onRequestStarted?.()).catch(() => {});
+            } catch {
+              // Readiness observation must not own a request that was already submitted.
+            }
+          }
+          return await request;
+        })
         .then(
           (value) => finish(() => resolve(value)),
           (error) => finish(() => reject(error)),

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -223,6 +223,9 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     );
     return {
       requestId: input.requestId,
+      get promptStarted() {
+        return turnPromise.then((turn) => turn.promptStarted);
+      },
       events: {
         async *[Symbol.asyncIterator]() {
           const turn = await turnPromise;

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -463,6 +463,7 @@ type RuntimeTurnTask = {
   };
   promptInput: PromptInput | string;
   queue: AsyncEventQueue;
+  promptStarted: Deferred<void>;
   sessionReady: Deferred<void>;
   state: RuntimeTurnTaskState;
   settleResult: (next: AcpRuntimeTurnResult) => void;
@@ -823,6 +824,8 @@ export class AcpRuntimeManager {
     const promptInput = toPromptInput(input.text, input.attachments);
     const queue = new AsyncEventQueue();
     const result = createDeferred<AcpRuntimeTurnResult>();
+    const promptStarted = createDeferred<void>();
+    void promptStarted.promise.catch(() => {});
     const sessionReady = createDeferred<void>();
     void sessionReady.promise.catch(() => {});
     let resultSettled = false;
@@ -866,6 +869,7 @@ export class AcpRuntimeManager {
     };
     if (input.signal) {
       if (input.signal.aborted) {
+        promptStarted.reject(new Error("ACP turn cancelled before prompt submission."));
         closeStream();
         settleResult({
           status: "cancelled",
@@ -873,6 +877,7 @@ export class AcpRuntimeManager {
         });
         return {
           requestId: input.requestId,
+          promptStarted: promptStarted.promise,
           events: queue.iterate(),
           result: result.promise,
           cancel: async () => {},
@@ -886,6 +891,7 @@ export class AcpRuntimeManager {
       input,
       promptInput,
       queue,
+      promptStarted,
       sessionReady,
       state,
       settleResult,
@@ -894,6 +900,7 @@ export class AcpRuntimeManager {
 
     return {
       requestId: input.requestId,
+      promptStarted: promptStarted.promise,
       events: queue.iterate(),
       result: result.promise,
       cancel: async () => {
@@ -922,6 +929,7 @@ export class AcpRuntimeManager {
         timeoutMs: task.input.timeoutMs ?? this.options.timeoutMs,
         conversation: turn.conversation,
         promptMessageId: turn.promptMessageId,
+        onPromptRequestStarted: () => task.promptStarted.resolve(),
       });
       await this.saveCompletedRuntimeTurn(turn, response.stopReason);
       task.settleResult({
@@ -1201,6 +1209,7 @@ export class AcpRuntimeManager {
       return false;
     }
     task.state.pendingCancel = false;
+    task.promptStarted.reject(new Error("ACP turn cancelled before prompt submission."));
     task.settleResult({
       status: "cancelled",
       stopReason: "cancelled",
@@ -1237,6 +1246,7 @@ export class AcpRuntimeManager {
   }
 
   private failRuntimeTurn(task: RuntimeTurnTask, error: unknown): void {
+    task.promptStarted.reject(error);
     task.sessionReady.reject(error);
     const normalized = normalizeOutputError(error, { origin: "runtime" });
     task.settleResult({

--- a/src/runtime/engine/prompt-turn.ts
+++ b/src/runtime/engine/prompt-turn.ts
@@ -12,6 +12,7 @@ type PromptTurnClient = {
   prompt: (
     sessionId: string,
     prompt: PromptInput | string,
+    onRequestStarted?: () => Promise<void> | void,
   ) => Promise<{ stopReason: RunPromptResult["stopReason"]; usage?: unknown }>;
   waitForSessionUpdatesIdle?: (options?: { idleMs?: number; timeoutMs?: number }) => Promise<void>;
 };
@@ -23,10 +24,15 @@ export async function runPromptTurn(params: {
   timeoutMs?: number;
   conversation: SessionConversation;
   promptMessageId?: string;
+  onPromptRequestStarted?: () => Promise<void> | void;
   onPromptStarted?: () => Promise<void> | void;
 }): Promise<{ stopReason: RunPromptResult["stopReason"]; source: "rpc" | "session" }> {
   try {
-    const promptPromise = params.client.prompt(params.sessionId, params.prompt);
+    const promptPromise = params.client.prompt(
+      params.sessionId,
+      params.prompt,
+      params.onPromptRequestStarted,
+    );
     await params.onPromptStarted?.();
     const response = await withTimeout(promptPromise, params.timeoutMs);
     await params.client

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -249,6 +249,8 @@ export type AcpRuntimeTurnResult =
 
 export interface AcpRuntimeTurn {
   readonly requestId: string;
+  /** Resolves after `connection.prompt()` returns its request promise. */
+  readonly promptStarted: Promise<void>;
   readonly events: AsyncIterable<AcpRuntimeEvent>;
   readonly result: Promise<AcpRuntimeTurnResult>;
   cancel(input?: { reason?: string }): Promise<void>;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1227,6 +1227,114 @@ test("AcpClient sends audio prompts when the agent advertises audio support", as
   assert.deepEqual(capturedPrompt, [{ type: "audio", mimeType: "audio/wav", data: "UklGRg==" }]);
 });
 
+test("AcpClient reports prompt start only after the connection request exists", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  const calls: string[] = [];
+  let resolvePrompt!: (value: { stopReason: "end_turn" }) => void;
+  const promptResponse = new Promise<{ stopReason: "end_turn" }>((resolve) => {
+    resolvePrompt = resolve;
+  });
+  let reportStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    reportStarted = resolve;
+  });
+  internals.connection = {
+    prompt: () => {
+      calls.push("prompt");
+      return promptResponse;
+    },
+  };
+
+  const pending = client.prompt("session-start", "hello", () => {
+    calls.push("started");
+    reportStarted();
+  });
+  await started;
+
+  assert.deepEqual(calls, ["prompt", "started"]);
+  assert.equal(client.hasActivePrompt(), true);
+  resolvePrompt({ stopReason: "end_turn" });
+  assert.deepEqual(await pending, { stopReason: "end_turn" });
+});
+
+test("AcpClient does not report prompt start when request creation throws", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let reported = false;
+  internals.connection = {
+    prompt: () => {
+      throw new Error("request creation failed");
+    },
+  };
+
+  await assert.rejects(
+    client.prompt("session-start-failure", "hello", () => {
+      reported = true;
+    }),
+    /request creation failed/,
+  );
+
+  assert.equal(reported, false);
+});
+
+test("AcpClient does not report prompt start when the connection is already closed", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  let reported = false;
+  const failure = new Error("ACP connection closed");
+  internals.connection = {
+    signal: AbortSignal.abort(failure),
+    prompt: () => Promise.reject(failure),
+  };
+
+  await assert.rejects(
+    client.prompt("session-closed-before-start", "hello", () => {
+      reported = true;
+    }),
+    failure,
+  );
+
+  assert.equal(reported, false);
+});
+
+test("AcpClient reports prompt start when the connection closes while creating the request", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  const connection = new AbortController();
+  let reported = false;
+  internals.connection = {
+    signal: connection.signal,
+    prompt: () => {
+      connection.abort(new Error("closed after request creation began"));
+      return Promise.resolve({ stopReason: "end_turn" });
+    },
+  };
+
+  await client.prompt("session-close-during-start", "hello", () => {
+    reported = true;
+  });
+
+  assert.equal(reported, true);
+});
+
+test("AcpClient prompt completion does not depend on prompt start observers", async () => {
+  const client = makeClient();
+  const internals = asInternals(client);
+  internals.connection = {
+    prompt: async () => ({ stopReason: "end_turn" }),
+  };
+
+  await assert.doesNotReject(
+    client.prompt("session-start-observer-failure", "hello", async () => {
+      throw new Error("observer failed");
+    }),
+  );
+  await assert.doesNotReject(
+    client.prompt("session-start-observer-pending", "hello", () => new Promise<void>(() => {})),
+  );
+});
+
 test("AcpClient prompt rejects when the agent disconnects mid-prompt", async () => {
   const client = makeClient();
   const internals = asInternals(client);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import type { PromptInput } from "../src/prompt-content.js";
 import { runPromptTurn } from "../src/runtime/engine/prompt-turn.js";
 import {
   createSessionConversation,
@@ -5382,6 +5383,48 @@ test("runPromptTurn: post-success drain runs before closing the turn", async () 
     ["prompt", "drain(1000/5000)"],
     "post-success drain must run before runPromptTurn returns",
   );
+});
+
+test("runPromptTurn: request readiness does not replace the awaited prompt lifecycle barrier", async () => {
+  const calls: string[] = [];
+  let releaseLifecycleBarrier: () => void = () => {};
+  const lifecycleBarrier = new Promise<void>((resolve) => {
+    releaseLifecycleBarrier = resolve;
+  });
+  const client = {
+    prompt: async (
+      _sessionId: string,
+      _prompt: PromptInput | string,
+      onRequestStarted?: () => Promise<void> | void,
+    ) => {
+      calls.push("prompt");
+      await onRequestStarted?.();
+      return { stopReason: "end_turn" as const };
+    },
+  };
+
+  const conversation = createSessionConversation();
+  const pending = runPromptTurn({
+    client,
+    sessionId: "session-prompt-barrier",
+    prompt: "hello",
+    conversation,
+    onPromptRequestStarted: () => {
+      calls.push("request-started");
+    },
+    onPromptStarted: async () => {
+      calls.push("lifecycle-started");
+      await lifecycleBarrier;
+      calls.push("lifecycle-released");
+    },
+  });
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, ["prompt", "request-started", "lifecycle-started"]);
+
+  releaseLifecycleBarrier();
+  await pending;
+  assert.deepEqual(calls, ["prompt", "request-started", "lifecycle-started", "lifecycle-released"]);
 });
 
 test("runPromptTurn: prompt response usage is recorded after usage update drain", async () => {

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -78,6 +78,7 @@ type FakeClient = {
   prompt: (
     sessionId: string,
     input: unknown,
+    onRequestStarted?: () => Promise<void> | void,
   ) => Promise<{
     stopReason: string;
     usage?: Record<string, unknown>;
@@ -393,6 +394,186 @@ test("AcpRuntimeManager streams runtime events and saves updated status", async 
   assert.equal(saved?.lastPromptAt != null, true);
   assert.equal(saved?.pid, 999);
   assert.equal(saved?.protocolVersion, 1);
+});
+
+test("AcpRuntimeManager resolves promptStarted while the submitted prompt is pending", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "prompt-started-session",
+    acpSessionId: "prompt-started-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let resolvePrompt!: (value: { stopReason: string }) => void;
+  const promptResponse = new Promise<{ stopReason: string }>((resolve) => {
+    resolvePrompt = resolve;
+  });
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => true,
+          supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async (
+            _sessionId: string,
+            _input: unknown,
+            onRequestStarted?: () => Promise<void> | void,
+          ) => {
+            await onRequestStarted?.();
+            return await promptResponse;
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("prompt-started-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-prompt-started",
+  });
+
+  await turn.promptStarted;
+  resolvePrompt({ stopReason: "end_turn" });
+  assert.deepEqual(await turn.result, { status: "completed", stopReason: "end_turn" });
+});
+
+test("AcpRuntimeManager rejects promptStarted when the turn fails before submission", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "prompt-not-started-session",
+    acpSessionId: "prompt-not-started-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {
+            throw new Error("connect failed");
+          },
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => false,
+          supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: false }),
+          prompt: async () => ({ stopReason: "end_turn" }),
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("prompt-not-started-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-prompt-not-started",
+  });
+
+  await assert.rejects(turn.promptStarted, /connect failed/);
+  assert.equal((await turn.result).status, "failed");
+});
+
+test("AcpRuntimeManager rejects promptStarted when cancelled before submission", async () => {
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: new InMemorySessionStore() }),
+  );
+  const controller = new AbortController();
+  controller.abort();
+
+  const turn = manager.startTurn({
+    handle: createHandle("prompt-cancelled-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-prompt-cancelled",
+    signal: controller.signal,
+  });
+
+  await assert.rejects(turn.promptStarted, /cancelled before prompt submission/);
+  assert.deepEqual(await turn.result, { status: "cancelled", stopReason: "cancelled" });
+});
+
+test("AcpRuntimeManager keeps promptStarted resolved when submission later fails", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "prompt-failed-session",
+    acpSessionId: "prompt-failed-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => true,
+          supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async (
+            _sessionId: string,
+            _input: unknown,
+            onRequestStarted?: () => Promise<void> | void,
+          ) => {
+            await onRequestStarted?.();
+            throw new Error("prompt failed after submission");
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("prompt-failed-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-prompt-failed",
+  });
+
+  await turn.promptStarted;
+  const result = await turn.result;
+  assert.equal(result.status, "failed");
+  if (result.status === "failed") {
+    assert.match(result.error.message, /prompt failed after submission/);
+  }
 });
 
 test("AcpRuntimeManager persists prompt response usage and surfaces it in status", async () => {
@@ -1952,6 +2133,7 @@ test("AcpRuntimeManager honors aborts requested before prompt starts after onesh
   await new Promise((resolve) => setTimeout(resolve, 0));
   controller.abort();
   resolveLoadFailure();
+  await assert.rejects(turn.promptStarted, /cancelled before prompt submission/);
   const events = await eventsPromise;
   const result = await turn.result;
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -88,6 +88,7 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
   let cancelCalls = 0;
   let managerCancelCalls = 0;
   let closeDiscardPersistentState: boolean | undefined;
+  let promptStarted = Promise.resolve();
   const manager = {
     ensureSession: async (input: { mode: string }) => {
       ensuredMode = input.mode;
@@ -99,6 +100,7 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
       turnTimeoutMs = input.timeoutMs;
       return {
         requestId: input.requestId,
+        promptStarted,
         events: (async function* () {
           yield { type: "text_delta" as const, text: "hello", stream: "output" as const };
         })(),
@@ -170,6 +172,7 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
     requestId: "req-1",
     timeoutMs: 42,
   });
+  await turn.promptStarted;
   const events = [];
   for await (const event of turn.events) {
     events.push(event);
@@ -181,6 +184,16 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
   assert.equal(turnTimeoutMs, 42);
   assert.deepEqual(events, [{ type: "text_delta", text: "hello", stream: "output" }]);
   assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
+
+  promptStarted = Promise.reject(new Error("prompt failed before request creation"));
+  void promptStarted.catch(() => {});
+  const failedReadinessTurn = runtime.startTurn({
+    handle,
+    text: "fail before request",
+    mode: "prompt",
+    requestId: "req-readiness-failure",
+  });
+  await assert.rejects(failedReadinessTurn.promptStarted, /failed before request creation/);
 
   const legacyEvents: AcpRuntimeEvent[] = [];
   for await (const event of runtime.runTurn({


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/119797

## What Problem This Solves

OpenClaw's ACP host cannot distinguish a turn that failed before prompt submission from one whose producer actually started the prompt. That makes command-run accounting and cancellation evidence ambiguous at the runtime boundary.

## Why This Change Was Made

The producer now owns and exposes a required `AcpRuntimeTurn.promptStarted` fact, set only at the prompt-start boundary and preserved through runtime completion. This is intentionally a breaking public contract change, with an `Unreleased` changelog entry, because optional or consumer-inferred readiness would preserve the ambiguity.

No acpx release or package publication is part of this PR. OpenClaw remains blocked on this PR landing and a subsequent acpx release/pin update.

## User Impact

ACP embedders can account for pre-submission failures separately from started prompts without inferring lifecycle state from downstream events.

## Evidence

- Signed commit: `311294713d22fa84bd550c264c9e50b3cbad9fd5`
- Full AWS `pnpm run check`: passed
- Tests: 1,009 passed (894 unit/coverage tests and 115 integration tests)
- Independent exact-head review: no blocking findings
- Production delta: +52/-9; tests: +346/-0; changelog: +2/-0
- AI-assisted implementation; maintainer reviewed the contract, source, and test evidence
