### PR TITLE
fix(runtime): settle turns after lifecycle cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Runtime/embedding: settle turn results only after lifecycle persistence and client cleanup attempts finish, including unexpected finalization failures.
+
 ## 2026.7.27 (v0.13.0)
 
 ### Highlights

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -100,6 +100,9 @@ type Deferred<T> = {
   reject: (error: unknown) => void;
 };
 
+type SettledAttempt<T> = { ok: true; value: T } | { ok: false; error: unknown };
+type FailedAttempt = Extract<SettledAttempt<unknown>, { ok: false }>;
+
 function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -108,6 +111,20 @@ function createDeferred<T>(): Deferred<T> {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+async function settleAttempt<T>(run: () => T | Promise<T>): Promise<SettledAttempt<T>> {
+  try {
+    return { ok: true, value: await run() };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function firstFailedAttempt(
+  attempts: readonly SettledAttempt<unknown>[],
+): FailedAttempt | undefined {
+  return attempts.find((attempt): attempt is FailedAttempt => !attempt.ok);
 }
 
 class AsyncEventQueue {
@@ -907,32 +924,41 @@ export class AcpRuntimeManager {
 
   private async runRuntimeTurnTask(task: RuntimeTurnTask): Promise<void> {
     let turn: RunningRuntimeTurn | undefined;
+    let terminalResult: AcpRuntimeTurnResult;
     try {
       turn = await this.prepareRuntimeTurn(task);
       const { sessionId, resumed, loadError } = await this.connectRuntimeTurn(task, turn);
       await this.resolveRuntimeTurnReady(task, turn, resumed, loadError);
       if (this.cancelRuntimeTurnBeforePrompt(task)) {
-        return;
+        terminalResult = {
+          status: "cancelled",
+          stopReason: "cancelled",
+        };
+      } else {
+        await this.applyPendingRuntimeTurnCancel(task, turn);
+        const response = await runPromptTurn({
+          client: turn.client,
+          sessionId,
+          prompt: task.promptInput,
+          timeoutMs: task.input.timeoutMs ?? this.options.timeoutMs,
+          conversation: turn.conversation,
+          promptMessageId: turn.promptMessageId,
+        });
+        await this.saveCompletedRuntimeTurn(turn, response.stopReason);
+        terminalResult = {
+          status: response.stopReason === "cancelled" ? "cancelled" : "completed",
+          ...(response.stopReason ? { stopReason: response.stopReason } : {}),
+        };
       }
-      await this.applyPendingRuntimeTurnCancel(task, turn);
-      const response = await runPromptTurn({
-        client: turn.client,
-        sessionId,
-        prompt: task.promptInput,
-        timeoutMs: task.input.timeoutMs ?? this.options.timeoutMs,
-        conversation: turn.conversation,
-        promptMessageId: turn.promptMessageId,
-      });
-      await this.saveCompletedRuntimeTurn(turn, response.stopReason);
-      task.settleResult({
-        status: response.stopReason === "cancelled" ? "cancelled" : "completed",
-        ...(response.stopReason ? { stopReason: response.stopReason } : {}),
-      });
     } catch (error) {
-      this.failRuntimeTurn(task, error);
-    } finally {
-      await this.finalizeRuntimeTurn(task, turn);
+      terminalResult = this.failRuntimeTurn(task, error);
     }
+    try {
+      await this.finalizeRuntimeTurn(task, turn);
+    } catch (error) {
+      terminalResult = this.failRuntimeTurn(task, error);
+    }
+    task.settleResult(terminalResult);
   }
 
   private async prepareRuntimeTurn(task: RuntimeTurnTask): Promise<RunningRuntimeTurn> {
@@ -1201,10 +1227,6 @@ export class AcpRuntimeManager {
       return false;
     }
     task.state.pendingCancel = false;
-    task.settleResult({
-      status: "cancelled",
-      stopReason: "cancelled",
-    });
     return true;
   }
 
@@ -1236,10 +1258,10 @@ export class AcpRuntimeManager {
     await this.options.sessionStore.save(turn.record);
   }
 
-  private failRuntimeTurn(task: RuntimeTurnTask, error: unknown): void {
+  private failRuntimeTurn(task: RuntimeTurnTask, error: unknown): AcpRuntimeTurnResult {
     task.sessionReady.reject(error);
     const normalized = normalizeOutputError(error, { origin: "runtime" });
-    task.settleResult({
+    return {
       status: "failed",
       error: {
         message: normalized.message,
@@ -1247,7 +1269,7 @@ export class AcpRuntimeManager {
         ...(normalized.detailCode ? { detailCode: normalized.detailCode } : {}),
         ...(normalized.retryable !== undefined ? { retryable: normalized.retryable } : {}),
       },
-    });
+    };
   }
 
   private async finalizeRuntimeTurn(
@@ -1255,12 +1277,46 @@ export class AcpRuntimeManager {
     turn: RunningRuntimeTurn | undefined,
   ): Promise<void> {
     task.state.turnActive = false;
-    task.input.signal?.removeEventListener("abort", task.abortHandler);
-    turn?.client.clearEventHandlers();
-    const pooled = turn ? await this.finalizeRuntimeTurnRecord(turn) : false;
-    if (!pooled) {
-      await turn?.client.close().catch(() => {});
+    const abortHandlerAttempt = await settleAttempt(() =>
+      task.input.signal?.removeEventListener("abort", task.abortHandler),
+    );
+    const clearHandlersAttempt = await settleAttempt(() => turn?.client.clearEventHandlers());
+    const recordAttempt = await settleAttempt(async () =>
+      turn ? await this.finalizeRuntimeTurnRecord(turn) : false,
+    );
+    const failure = firstFailedAttempt([abortHandlerAttempt, clearHandlersAttempt, recordAttempt]);
+    let pooled = recordAttempt.ok ? recordAttempt.value : false;
+    if (failure) {
+      this.discardRetainedRuntimeTurnClient(turn);
+      pooled = false;
     }
+    await this.closeRuntimeTurnClient(turn, pooled);
+    this.cleanupRuntimeTurn(task, turn);
+    if (failure) {
+      throw failure.error;
+    }
+  }
+
+  private discardRetainedRuntimeTurnClient(turn: RunningRuntimeTurn | undefined): void {
+    if (!turn || this.pendingPersistentClients.get(turn.record.acpxRecordId) !== turn.client) {
+      return;
+    }
+    this.pendingPersistentClients.delete(turn.record.acpxRecordId);
+  }
+
+  private async closeRuntimeTurnClient(
+    turn: RunningRuntimeTurn | undefined,
+    pooled: boolean,
+  ): Promise<void> {
+    if (!turn || pooled) {
+      return;
+    }
+    try {
+      await turn.client.close();
+    } catch {}
+  }
+
+  private cleanupRuntimeTurn(task: RuntimeTurnTask, turn: RunningRuntimeTurn | undefined): void {
     if (turn) {
       this.activeControllers.delete(turn.record.acpxRecordId);
       this.closingActiveRecords.delete(turn.record.acpxRecordId);

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -250,6 +250,11 @@ export type AcpRuntimeTurnResult =
 export interface AcpRuntimeTurn {
   readonly requestId: string;
   readonly events: AsyncIterable<AcpRuntimeEvent>;
+  /**
+   * Canonical completion signal for the turn. Resolves only after final record
+   * checkpoint/persistence and runtime client pooling or close cleanup attempts
+   * have settled.
+   */
   readonly result: Promise<AcpRuntimeTurnResult>;
   cancel(input?: { reason?: string }): Promise<void>;
   closeStream(input?: { reason?: string }): Promise<void>;

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -12,6 +12,7 @@ import {
 import type {
   AcpRuntimeEvent,
   AcpRuntimeHandle,
+  AcpSessionRecord,
   AcpRuntimeTurn,
   AcpRuntimeTurnResult,
 } from "../src/runtime/public/contract.js";
@@ -2473,6 +2474,190 @@ test("AcpRuntimeManager maps audio attachments into ACP prompt blocks", async ()
     { type: "text", text: "transcribe" },
     { type: "audio", mimeType: "audio/wav", data: "UklGRg==" },
   ]);
+});
+
+test("AcpRuntimeManager keeps failed reconnect results pending until PID persistence and client cleanup complete", async () => {
+  const runtimePid = 424_242;
+  let releaseFinalSave!: () => void;
+  const finalSaveGate = new Promise<void>((resolve) => {
+    releaseFinalSave = resolve;
+  });
+  let signalFinalSaveStarted!: () => void;
+  const finalSaveStarted = new Promise<void>((resolve) => {
+    signalFinalSaveStarted = resolve;
+  });
+  let finalSaveBlocked = false;
+  class LeaseRaceSessionStore extends InMemorySessionStore {
+    override async save(record: AcpSessionRecord): Promise<void> {
+      if (record.pid === runtimePid && !finalSaveBlocked) {
+        finalSaveBlocked = true;
+        signalFinalSaveStarted();
+        await finalSaveGate;
+      }
+      await super.save(record);
+    }
+  }
+
+  const record = makeSessionRecord({
+    acpxRecordId: "failed-reconnect-lease-session",
+    acpSessionId: "stale-backend-session",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+    pid: 2_147_483_647,
+  });
+  const store = new LeaseRaceSessionStore([record]);
+  let clientCloseCompleted = false;
+  let promptCalled = false;
+  const client: FakeClient = {
+    start: async () => {},
+    close: async () => {
+      clientCloseCompleted = true;
+    },
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: () => false,
+    supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
+    loadSessionWithOptions: async () => {
+      throw new Error("saved session cannot be loaded");
+    },
+    getAgentLifecycleSnapshot: () => ({
+      pid: runtimePid,
+      startedAt: "2026-01-01T00:01:00.000Z",
+      running: true,
+    }),
+    prompt: async () => {
+      promptCalled = true;
+      return { stopReason: "end_turn" };
+    },
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {},
+    setEventHandlers: () => {},
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    { clientFactory: () => client as never },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("failed-reconnect-lease-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-failed-reconnect-lease",
+  });
+  const eventsPromise = collectEvents(turn.events);
+  let resultSettled = false;
+  let persistedPidAtResult: number | undefined;
+  let clientClosedAtResult = false;
+  const resultPromise = turn.result.then((result) => {
+    resultSettled = true;
+    persistedPidAtResult = store.records.get(record.acpxRecordId)?.pid;
+    clientClosedAtResult = clientCloseCompleted;
+    return result;
+  });
+
+  await finalSaveStarted;
+  await Promise.resolve();
+  assert.equal(resultSettled, false);
+  releaseFinalSave();
+
+  const result = await resultPromise;
+  assert.deepEqual(result, {
+    status: "failed",
+    error: {
+      code: "RUNTIME",
+      detailCode: "SESSION_RESUME_REQUIRED",
+      message:
+        "Persistent ACP session stale-backend-session could not be resumed: saved session cannot be loaded",
+      retryable: true,
+    },
+  });
+  assert.deepEqual(await eventsPromise, []);
+  assert.equal(promptCalled, false);
+  assert.equal(persistedPidAtResult, runtimePid);
+  assert.equal(clientClosedAtResult, true);
+});
+
+test("AcpRuntimeManager closes the stream and client before reporting an unexpected finalization failure", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "finalization-failure-session:oneshot:1",
+    acpSessionId: "finalization-failure-backend-session",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let signalFinalizationHookReached!: () => void;
+  const finalizationHookReached = new Promise<void>((resolve) => {
+    signalFinalizationHookReached = resolve;
+  });
+  let closeCalls = 0;
+  const client: FakeClient = {
+    start: async () => {},
+    close: async () => {
+      closeCalls += 1;
+    },
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: () => false,
+    supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
+    loadSessionWithOptions: async () => ({ agentSessionId: "finalization-failure-agent" }),
+    getAgentLifecycleSnapshot: () => ({ running: true }),
+    prompt: async () => ({ stopReason: "end_turn" }),
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      signalFinalizationHookReached();
+      throw new Error("finalization hook exploded");
+    },
+    setEventHandlers: () => {},
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    { clientFactory: () => client as never },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle(record.acpxRecordId),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "oneshot",
+    requestId: "req-finalization-failure",
+  });
+  let eventStreamClosed = false;
+  const eventsPromise = collectEvents(turn.events).then((events) => {
+    eventStreamClosed = true;
+    return events;
+  });
+  let resultSettled = false;
+  let clientClosedAtResult = false;
+  const resultPromise = turn.result.then((result) => {
+    resultSettled = true;
+    clientClosedAtResult = closeCalls === 1;
+    return result;
+  });
+
+  await finalizationHookReached;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(eventStreamClosed, true);
+  assert.equal(resultSettled, true);
+
+  assert.deepEqual(await eventsPromise, []);
+  assert.deepEqual(await resultPromise, {
+    status: "failed",
+    error: {
+      code: "RUNTIME",
+      message: "finalization hook exploded",
+    },
+  });
+  assert.equal(closeCalls, 1);
+  assert.equal(clientClosedAtResult, true);
 });
 
 test("AcpRuntimeManager fails persistent turns clearly when session reuse is unavailable", async () => {


### PR DESCRIPTION
## What Problem This Solves

`turn.result` could settle before ACPX finished final persistence, pooling, and client-close work. That allowed OpenClaw to delete a pending process lease before a late PID save recreated it.

## Why This Change Was Made

The result promise is now the canonical lifecycle-completion signal. It settles only after mandatory local cleanup attempts finish, and unexpected finalizer failures produce failed results after those cleanup attempts.

## User Impact

Embedders can safely finalize ownership and leases after `turn.result` settles. This adds no new promise or result shape.

## Evidence

- Focused lifecycle regressions: 2/2 pass.
- `pnpm run check`: 886 repository tests and 113 coverage tests pass; 94.21% lines/statements, 87.52% branches, and 96.15% functions.
- Final repository-local autoreview: clean, with no accepted or actionable findings.
- OpenClaw A/B ordering proof: pinned ACPX 0.13.0 settles before late PID persistence and client close; the packed patched artifact orders PID persistence, client close, event-stream close, then result settlement.
- AI-assisted and fully tested. The package remains 0.13.0; this PR does not publish it.
