### PR TITLE
refactor: post-batch coherence pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Repo: https://github.com/openclaw/acpx
 
 - Runtime/embedding: settle turn results only after lifecycle persistence and client cleanup attempts finish, including unexpected finalization failures.
 - Runtime: preserve non-empty `messageId` and a safe subset of ACP update `_meta` on `text_delta` events so consumers can distinguish model prose from adapter diagnostics that still use `agent_message_chunk`. Thanks @SebTardif.
+- Runtime/sessions: keep atomic-write temporary filenames within filesystem component limits when valid session IDs have long basenames. Thanks @henkterharmsel.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -122,7 +122,11 @@ function planStatusText(payload: Record<string, unknown>): string | null {
  * Only these keys may be copied from ACP update `_meta`.
  * Unknown keys (including secret-like producer-controlled names) are dropped.
  */
-const ORIGIN_META_ALLOWLIST = new Set(["origin", "kind", "source"]);
+const ORIGIN_META_KEYS = [
+  "origin",
+  "kind",
+  "source",
+] as const satisfies readonly (keyof AcpTextDeltaOriginMeta)[];
 
 /**
  * Preserve a fail-closed subset of ACP update origin fields for text_delta
@@ -148,8 +152,8 @@ function sanitizeOriginMeta(value: unknown): AcpTextDeltaOriginMeta | undefined 
   if (!isRecord(value)) {
     return undefined;
   }
-  const out: Partial<Record<"origin" | "kind" | "source", string>> = {};
-  for (const key of ORIGIN_META_ALLOWLIST) {
+  const out: AcpTextDeltaOriginMeta = {};
+  for (const key of ORIGIN_META_KEYS) {
     const entry = value[key];
     if (typeof entry !== "string") {
       continue;
@@ -158,7 +162,7 @@ function sanitizeOriginMeta(value: unknown): AcpTextDeltaOriginMeta | undefined 
     if (!trimmed) {
       continue;
     }
-    out[key as "origin" | "kind" | "source"] = trimmed;
+    out[key] = trimmed;
   }
   return Object.keys(out).length > 0 ? out : undefined;
 }


### PR DESCRIPTION
## Summary

- tie the `text_delta.meta` allowlist iteration directly to the exported `AcpTextDeltaOriginMeta` keys, removing the parallel literal-key type and cast
- add the missing Unreleased changelog entry for #476's user-visible long-session-ID persistence fix

## Batch review

This follows a combined deep review of the five PRs present on `main` at fetch time: #492, #490, #457, #476, and #481.

The dependency and action updates are consistent across their call sites; the dead-code removal preserves the live legacy Codex ACP detector; and the atomic-write change retains same-directory rename semantics and UUID uniqueness. The runtime origin-metadata change uses the ACP field names, applies a narrow key allowlist, redacts all other metadata, documents the values as producer-controlled hints, and exports the matching public type.

#488, #491, #493, #468, and #494 were still open at the final fetch and are not part of this branch.

## Proof

- `pnpm run check` — 892 tests passed; coverage target passed at 94.24% statements and 87.64% branches
- `pnpm run mutate` — 90.78% mutation score (80% threshold)
- `pnpm run check:docs` — formatting, markdown lint, and docs site build passed
- focused runtime/atomic-write tests — 24 passed
- AutoReview — clean, no accepted/actionable findings
- built runtime live filesystem probe — 100 concurrent saves with a 220-byte session ID; reload succeeded; one JSON file and zero temporary files remained
- built event-parser probe — model and diagnostic chunks retained `messageId`, `origin`, and `kind` while unknown secret-shaped keys were omitted
- packaged CLI smoke — `node dist/cli.js --version` printed `0.13.0`
