### PR TITLE
fix: harden security interaction boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Repo: https://github.com/openclaw/acpx
 - CLI/session: re-apply a session-pinned model before set_mode/set_model/set_config_option after reconnect, matching the prompt path so model-dependent options work. Fixes #489. Thanks @SebTardif.
 - Runtime: preserve non-empty `messageId` and a safe subset of ACP update `_meta` on `text_delta` events so consumers can distinguish model prose from adapter diagnostics that still use `agent_message_chunk`. Thanks @SebTardif.
 - Runtime/sessions: keep atomic-write temporary filenames within filesystem component limits when valid session IDs have long basenames. Thanks @henkterharmsel.
+- Runtime/embedding: snapshot permission policies at client configuration boundaries so caller-side mutation cannot change an in-flight turn after prompt readiness.
+- Replay viewer: return the same not-found response for missing files and containment-denied paths, preventing outside-target existence probes.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/examples/flows/replay-viewer/server/viewer-server.ts
+++ b/examples/flows/replay-viewer/server/viewer-server.ts
@@ -188,14 +188,9 @@ export async function handleApiRequest(
       response.statusCode = 200;
       response.setHeader("content-type", contentTypeFor(relativePath ?? ""));
       response.end(payload);
-    } catch (error) {
-      const code =
-        error instanceof Error &&
-        /outside run bundle|outside runs directory|not allowed|required/.test(error.message)
-          ? 400
-          : 404;
-      writeJson(response, code, {
-        error: code === 400 ? "Invalid run bundle file request" : "Run bundle file not found",
+    } catch {
+      writeJson(response, 404, {
+        error: "Run bundle file not found",
       });
     }
     return true;

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -236,6 +236,20 @@ type PendingConnectionRequest = {
   reject: (error: unknown) => void;
 };
 
+function snapshotPermissionPolicy(
+  policy: AcpClientOptions["permissionPolicy"],
+): AcpClientOptions["permissionPolicy"] {
+  if (!policy) {
+    return undefined;
+  }
+  return {
+    ...(policy.autoApprove ? { autoApprove: [...policy.autoApprove] } : {}),
+    ...(policy.autoDeny ? { autoDeny: [...policy.autoDeny] } : {}),
+    ...(policy.escalate ? { escalate: [...policy.escalate] } : {}),
+    ...(policy.defaultAction ? { defaultAction: policy.defaultAction } : {}),
+  };
+}
+
 type AuthSelection = {
   methodId: string;
   credential?: string;
@@ -453,6 +467,7 @@ export class AcpClient {
       ...options,
       cwd: asAbsoluteCwd(options.cwd),
       authPolicy: options.authPolicy ?? "skip",
+      permissionPolicy: snapshotPermissionPolicy(options.permissionPolicy),
     };
     this.eventHandlers = {
       onAcpMessage: this.options.onAcpMessage,
@@ -554,7 +569,7 @@ export class AcpClient {
       this.options.nonInteractivePermissions = options.nonInteractivePermissions;
     }
     if (Object.prototype.hasOwnProperty.call(options, "permissionPolicy")) {
-      this.options.permissionPolicy = options.permissionPolicy;
+      this.options.permissionPolicy = snapshotPermissionPolicy(options.permissionPolicy);
     }
     this.updateClientCapabilityPreferences(options);
     this.refreshRuntimePermissionPolicy(shouldRefreshPermissionPolicy);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -493,6 +493,38 @@ test("AcpClient partial runtime option updates preserve permission policy", asyn
   });
 });
 
+test("AcpClient snapshots permission policies at configuration boundaries", async () => {
+  const initialPolicy = {
+    autoDeny: ["execute"],
+  };
+  const client = makeClient({
+    permissionMode: "approve-all",
+    permissionPolicy: initialPolicy,
+  });
+
+  initialPolicy.autoDeny.splice(0, 1);
+  const deniedFromInitialSnapshot = await asInternals(client).handlePermissionRequest?.(
+    makePermissionRequest("session-policy-snapshot-1", "execute"),
+  );
+  assert.equal(deniedFromInitialSnapshot?.outcome.outcome, "selected");
+  if (deniedFromInitialSnapshot?.outcome.outcome === "selected") {
+    assert.equal(deniedFromInitialSnapshot.outcome.optionId, "reject");
+  }
+
+  const updatedPolicy = {
+    autoDeny: ["execute"],
+  };
+  client.updateRuntimeOptions({ permissionPolicy: updatedPolicy });
+  updatedPolicy.autoDeny.splice(0, 1);
+  const deniedFromUpdatedSnapshot = await asInternals(client).handlePermissionRequest?.(
+    makePermissionRequest("session-policy-snapshot-2", "execute"),
+  );
+  assert.equal(deniedFromUpdatedSnapshot?.outcome.outcome, "selected");
+  if (deniedFromUpdatedSnapshot?.outcome.outcome === "selected") {
+    assert.equal(deniedFromUpdatedSnapshot.outcome.optionId, "reject");
+  }
+});
+
 test("AcpClient onPermissionRequest decision short-circuits the mode-based resolver", async () => {
   let callbackInvocations = 0;
   const client = makeClient({

--- a/test/replay-viewer-server.test.ts
+++ b/test/replay-viewer-server.test.ts
@@ -162,11 +162,51 @@ test("replay viewer blocks file reads that escape the runs directory via runId",
     const response = await fetch(
       `${viewerServer.baseUrl}/api/runs/..%2F..%2Fsessions/files/session-secret.json`,
     );
-    assert.equal(response.status, 400);
-    assert.deepEqual(await response.json(), { error: "Invalid run bundle file request" });
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "Run bundle file not found" });
   } finally {
     await viewerServer.close().catch(() => {});
     await fs.rm(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("replay viewer does not reveal whether a denied symlink target exists", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-replay-symlink-oracle-"));
+  const runsDir = path.join(rootDir, "runs");
+  const outsideDir = path.join(rootDir, "outside");
+  const runDir = path.join(runsDir, "hostile");
+  await fs.mkdir(runDir, { recursive: true });
+  await fs.mkdir(outsideDir, { recursive: true });
+  await fs.writeFile(path.join(outsideDir, "exists.txt"), "secret");
+  await fs.symlink(path.join(outsideDir, "exists.txt"), path.join(runDir, "existing-link"));
+  await fs.symlink(path.join(outsideDir, "missing.txt"), path.join(runDir, "missing-link"));
+
+  const viewerServer = await createReplayViewerServer({
+    host: "127.0.0.1",
+    port: 0,
+    runsDir,
+    disableDependencyOptimization: true,
+  });
+
+  try {
+    const responses = await Promise.all(
+      ["existing-link", "missing-link", "ordinary-missing"].map(async (name) => {
+        const response = await fetch(`${viewerServer.baseUrl}/api/runs/hostile/files/${name}`);
+        return {
+          status: response.status,
+          body: await response.json(),
+        };
+      }),
+    );
+
+    assert.deepEqual(responses, [
+      { status: 404, body: { error: "Run bundle file not found" } },
+      { status: 404, body: { error: "Run bundle file not found" } },
+      { status: 404, body: { error: "Run bundle file not found" } },
+    ]);
+  } finally {
+    await viewerServer.close().catch(() => {});
+    await fs.rm(rootDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

- Snapshot permission policies when an ACP client is configured so caller-side mutation cannot change an in-flight turn after prompt readiness.
- Return one generic not-found response for missing replay bundle files and containment-denied paths.
- Add regressions for policy snapshots and the existing-versus-dangling symlink target oracle.

## Security proof

- A real embedded-runtime turn paused its permission callback after promptStarted; mutating the original deny policy to approve no longer changes the active decision, and the mock ACP agent receives reject.
- A real replay-viewer server returns the identical 404 response for an outside symlink whose target exists, a dangling outside symlink, and an ordinary missing path.
- A permissive runtime policy still approves its ACP execute request while the separate viewer containment boundary returns the generic 404 for the attempted escape.

## Validation

- pnpm run check
- pnpm run check:docs
- pnpm run mutate (90.78 percent, threshold 80)
- focused security suite: 118 passing tests
- autoreview clean: no accepted or actionable findings