### PR TITLE
fix(session): completed turn stays successful when session save fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Runtime/embedding: settle turn results only after lifecycle persistence and client cleanup attempts finish, including unexpected finalization failures.
+- Runtime/sessions: surface checkpoint flush and session-store save failures during turn finalization instead of dropping them. Thanks @SebTardif.
 - Replay viewer: contain manifest-selected projection reads within their run bundle, including symlink targets. Thanks @bunlongheng.
 - CLI/session: re-apply a session-pinned model before set_mode/set_model/set_config_option after reconnect, matching the prompt path so model-dependent options work. Fixes #489. Thanks @SebTardif.
 - Runtime: preserve non-empty `messageId` and a safe subset of ACP update `_meta` on `text_delta` events so consumers can distinguish model prose from adapter diagnostics that still use `agent_message_chunk`. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Runtime/embedding: settle turn results only after lifecycle persistence and client cleanup attempts finish, including unexpected finalization failures.
-- Runtime/sessions: surface checkpoint flush and session-store save failures during turn finalization instead of dropping them. Thanks @SebTardif.
 - Replay viewer: contain manifest-selected projection reads within their run bundle, including symlink targets. Thanks @bunlongheng.
 - CLI/session: re-apply a session-pinned model before set_mode/set_model/set_config_option after reconnect, matching the prompt path so model-dependent options work. Fixes #489. Thanks @SebTardif.
 - Runtime: preserve non-empty `messageId` and a safe subset of ACP update `_meta` on `text_delta` events so consumers can distinguish model prose from adapter diagnostics that still use `agent_message_chunk`. Thanks @SebTardif.
 - Runtime/sessions: keep atomic-write temporary filenames within filesystem component limits when valid session IDs have long basenames. Thanks @henkterharmsel.
 - Runtime/embedding: snapshot permission policies at client configuration boundaries so caller-side mutation cannot change an in-flight turn after prompt readiness.
 - Replay viewer: return the same not-found response for missing files and containment-denied paths, preventing outside-target existence probes.
+- Runtime/sessions: surface checkpoint flush and session-store save failures during turn finalization instead of dropping them. Thanks @SebTardif.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -1342,9 +1342,9 @@ export class AcpRuntimeManager {
     turn.record.acpx = turn.acpxState;
     applyConversation(turn.record, turn.conversation);
     turn.record.lastUsedAt = isoNow();
-    await turn.liveCheckpoint.flush().catch(() => {});
+    await turn.liveCheckpoint.flush();
     const closed = await this.refreshClosedState(turn.record);
-    await this.options.sessionStore.save(turn.record).catch(() => {});
+    await this.options.sessionStore.save(turn.record);
     if (closed) {
       return false;
     }

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -2878,96 +2878,102 @@ test("AcpRuntimeManager closes the stream and client before reporting an unexpec
   assert.equal(clientClosedAtResult, true);
 });
 
-test("AcpRuntimeManager fails the turn when final session persist throws", async () => {
-  const record = makeSessionRecord({
-    acpxRecordId: "finalize-persist-session",
-    acpSessionId: "finalize-persist-sid",
-    agentCommand: "codex --acp",
-    cwd: "/workspace",
-  });
-  let promptFinished = false;
-  let savesAfterPrompt = 0;
-  class FinalizePersistFailStore extends InMemorySessionStore {
-    override async save(next: AcpSessionRecord): Promise<void> {
-      if (promptFinished) {
-        savesAfterPrompt += 1;
-        if (savesAfterPrompt >= 2) {
-          throw new Error("ENOSPC: no space left on device");
+for (const { stage, failAtSave } of [
+  { stage: "checkpoint flush", failAtSave: 2 },
+  { stage: "final session persist", failAtSave: 3 },
+]) {
+  test(`AcpRuntimeManager fails the turn when ${stage} throws`, async () => {
+    const record = makeSessionRecord({
+      acpxRecordId: "finalize-persist-session",
+      acpSessionId: "finalize-persist-sid",
+      agentCommand: "codex --acp",
+      cwd: "/workspace",
+    });
+    let promptFinished = false;
+    let savesAfterPrompt = 0;
+    class FinalizePersistFailStore extends InMemorySessionStore {
+      override async save(next: AcpSessionRecord): Promise<void> {
+        if (promptFinished) {
+          savesAfterPrompt += 1;
+          if (savesAfterPrompt >= failAtSave) {
+            throw new Error("ENOSPC: no space left on device");
+          }
         }
+        await super.save(next);
       }
-      await super.save(next);
     }
-  }
-  const store = new FinalizePersistFailStore([record]);
-  let closeCalls = 0;
-  let handlers: FakeClientHandlers = {};
-  const client: FakeClient = {
-    initializeResult: {
-      protocolVersion: 1,
-      agentCapabilities: { prompt: true },
-    },
-    start: async () => {},
-    close: async () => {
-      closeCalls += 1;
-    },
-    createSession: async () => ({ sessionId: "unused" }),
-    loadSession: async () => ({ agentSessionId: "unused" }),
-    hasReusableSession: (sessionId) => sessionId === "finalize-persist-sid",
-    supportsLoadSession: () => true,
-    supportsResumeSession: () => false,
-    loadSessionWithOptions: async () => ({ agentSessionId: "finalize-persist-agent" }),
-    getAgentLifecycleSnapshot: () => ({
-      pid: 77_001,
-      startedAt: "2026-01-01T00:00:00.000Z",
-      running: true,
-    }),
-    prompt: async () => {
-      handlers.onSessionUpdate?.({
-        sessionId: "finalize-persist-sid",
-        update: {
-          sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: "done" },
-        },
-      });
-      promptFinished = true;
-      return { stopReason: "end_turn" };
-    },
-    waitForSessionUpdatesIdle: async () => {},
-    requestCancelActivePrompt: async () => false,
-    hasActivePrompt: () => false,
-    setSessionMode: async () => {},
-    setSessionConfigOption: async () => {},
-    clearEventHandlers: () => {
-      handlers = {};
-    },
-    setEventHandlers: (nextHandlers) => {
-      handlers = nextHandlers;
-    },
-  };
-  const manager = new AcpRuntimeManager(
-    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
-    { clientFactory: () => client as never },
-  );
+    const store = new FinalizePersistFailStore([record]);
+    let closeCalls = 0;
+    let handlers: FakeClientHandlers = {};
+    const client: FakeClient = {
+      initializeResult: {
+        protocolVersion: 1,
+        agentCapabilities: { prompt: true },
+      },
+      start: async () => {},
+      close: async () => {
+        closeCalls += 1;
+      },
+      createSession: async () => ({ sessionId: "unused" }),
+      loadSession: async () => ({ agentSessionId: "unused" }),
+      hasReusableSession: (sessionId) => sessionId === "finalize-persist-sid",
+      supportsLoadSession: () => true,
+      supportsResumeSession: () => false,
+      loadSessionWithOptions: async () => ({ agentSessionId: "finalize-persist-agent" }),
+      getAgentLifecycleSnapshot: () => ({
+        pid: 77_001,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        running: true,
+      }),
+      prompt: async () => {
+        handlers.onSessionUpdate?.({
+          sessionId: "finalize-persist-sid",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "done" },
+          },
+        });
+        promptFinished = true;
+        return { stopReason: "end_turn" };
+      },
+      waitForSessionUpdatesIdle: async () => {},
+      requestCancelActivePrompt: async () => false,
+      hasActivePrompt: () => false,
+      setSessionMode: async () => {},
+      setSessionConfigOption: async () => {},
+      clearEventHandlers: () => {
+        handlers = {};
+      },
+      setEventHandlers: (nextHandlers) => {
+        handlers = nextHandlers;
+      },
+    };
+    const manager = new AcpRuntimeManager(
+      createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+      { clientFactory: () => client as never },
+    );
 
-  const turn = manager.startTurn({
-    handle: createHandle("finalize-persist-session"),
-    text: "hello",
-    mode: "prompt",
-    sessionMode: "persistent",
-    requestId: "req-finalize-persist",
-  });
-  const { events, result } = await collectTurn(turn);
+    const turn = manager.startTurn({
+      handle: createHandle("finalize-persist-session"),
+      text: "hello",
+      mode: "prompt",
+      sessionMode: "persistent",
+      requestId: "req-finalize-persist",
+    });
+    const { events, result } = await collectTurn(turn);
 
-  assert.deepEqual(result, {
-    status: "failed",
-    error: {
-      code: "RUNTIME",
-      message: "ENOSPC: no space left on device",
-    },
+    assert.deepEqual(result, {
+      status: "failed",
+      error: {
+        code: "RUNTIME",
+        message: "ENOSPC: no space left on device",
+      },
+    });
+    assert.equal(closeCalls, 1);
+    assert.equal(savesAfterPrompt, failAtSave);
+    assert.ok(events.some((event) => event.type === "text_delta"));
   });
-  assert.equal(closeCalls, 1);
-  assert.ok(events.some((event) => event.type === "text_delta"));
-});
+}
 
 test("AcpRuntimeManager fails persistent turns clearly when session reuse is unavailable", async () => {
   const record = makeSessionRecord({

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -2878,102 +2878,105 @@ test("AcpRuntimeManager closes the stream and client before reporting an unexpec
   assert.equal(clientClosedAtResult, true);
 });
 
-for (const { stage, failAtSave } of [
-  { stage: "checkpoint flush", failAtSave: 2 },
-  { stage: "final session persist", failAtSave: 3 },
-]) {
-  test(`AcpRuntimeManager fails the turn when ${stage} throws`, async () => {
-    const record = makeSessionRecord({
-      acpxRecordId: "finalize-persist-session",
-      acpSessionId: "finalize-persist-sid",
-      agentCommand: "codex --acp",
-      cwd: "/workspace",
-    });
-    let promptFinished = false;
-    let savesAfterPrompt = 0;
-    class FinalizePersistFailStore extends InMemorySessionStore {
-      override async save(next: AcpSessionRecord): Promise<void> {
-        if (promptFinished) {
-          savesAfterPrompt += 1;
-          if (savesAfterPrompt >= failAtSave) {
-            throw new Error("ENOSPC: no space left on device");
-          }
-        }
-        await super.save(next);
-      }
-    }
-    const store = new FinalizePersistFailStore([record]);
-    let closeCalls = 0;
-    let handlers: FakeClientHandlers = {};
-    const client: FakeClient = {
-      initializeResult: {
-        protocolVersion: 1,
-        agentCapabilities: { prompt: true },
-      },
-      start: async () => {},
-      close: async () => {
-        closeCalls += 1;
-      },
-      createSession: async () => ({ sessionId: "unused" }),
-      loadSession: async () => ({ agentSessionId: "unused" }),
-      hasReusableSession: (sessionId) => sessionId === "finalize-persist-sid",
-      supportsLoadSession: () => true,
-      supportsResumeSession: () => false,
-      loadSessionWithOptions: async () => ({ agentSessionId: "finalize-persist-agent" }),
-      getAgentLifecycleSnapshot: () => ({
-        pid: 77_001,
-        startedAt: "2026-01-01T00:00:00.000Z",
-        running: true,
-      }),
-      prompt: async () => {
-        handlers.onSessionUpdate?.({
-          sessionId: "finalize-persist-sid",
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "done" },
-          },
-        });
-        promptFinished = true;
-        return { stopReason: "end_turn" };
-      },
-      waitForSessionUpdatesIdle: async () => {},
-      requestCancelActivePrompt: async () => false,
-      hasActivePrompt: () => false,
-      setSessionMode: async () => {},
-      setSessionConfigOption: async () => {},
-      clearEventHandlers: () => {
-        handlers = {};
-      },
-      setEventHandlers: (nextHandlers) => {
-        handlers = nextHandlers;
-      },
-    };
-    const manager = new AcpRuntimeManager(
-      createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
-      { clientFactory: () => client as never },
-    );
-
-    const turn = manager.startTurn({
-      handle: createHandle("finalize-persist-session"),
-      text: "hello",
-      mode: "prompt",
-      sessionMode: "persistent",
-      requestId: "req-finalize-persist",
-    });
-    const { events, result } = await collectTurn(turn);
-
-    assert.deepEqual(result, {
-      status: "failed",
-      error: {
-        code: "RUNTIME",
-        message: "ENOSPC: no space left on device",
-      },
-    });
-    assert.equal(closeCalls, 1);
-    assert.equal(savesAfterPrompt, failAtSave);
-    assert.ok(events.some((event) => event.type === "text_delta"));
+async function assertFinalPersistenceFailure(failAtSave: number): Promise<void> {
+  const record = makeSessionRecord({
+    acpxRecordId: "finalize-persist-session",
+    acpSessionId: "finalize-persist-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
   });
+  let promptFinished = false;
+  let savesAfterPrompt = 0;
+  class FinalizePersistFailStore extends InMemorySessionStore {
+    override async save(next: AcpSessionRecord): Promise<void> {
+      if (promptFinished) {
+        savesAfterPrompt += 1;
+        if (savesAfterPrompt >= failAtSave) {
+          throw new Error("ENOSPC: no space left on device");
+        }
+      }
+      await super.save(next);
+    }
+  }
+  const store = new FinalizePersistFailStore([record]);
+  let closeCalls = 0;
+  let handlers: FakeClientHandlers = {};
+  const client: FakeClient = {
+    initializeResult: {
+      protocolVersion: 1,
+      agentCapabilities: { prompt: true },
+    },
+    start: async () => {},
+    close: async () => {
+      closeCalls += 1;
+    },
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: (sessionId) => sessionId === "finalize-persist-sid",
+    supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
+    loadSessionWithOptions: async () => ({ agentSessionId: "finalize-persist-agent" }),
+    getAgentLifecycleSnapshot: () => ({
+      pid: 77_001,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      running: true,
+    }),
+    prompt: async () => {
+      handlers.onSessionUpdate?.({
+        sessionId: "finalize-persist-sid",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "done" },
+        },
+      });
+      promptFinished = true;
+      return { stopReason: "end_turn" };
+    },
+    waitForSessionUpdatesIdle: async () => {},
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      handlers = {};
+    },
+    setEventHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    { clientFactory: () => client as never },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("finalize-persist-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-finalize-persist",
+  });
+  const { events, result } = await collectTurn(turn);
+
+  assert.deepEqual(result, {
+    status: "failed",
+    error: {
+      code: "RUNTIME",
+      message: "ENOSPC: no space left on device",
+    },
+  });
+  assert.equal(closeCalls, 1);
+  assert.equal(savesAfterPrompt, failAtSave);
+  assert.ok(events.some((event) => event.type === "text_delta"));
 }
+
+test("AcpRuntimeManager fails the turn when checkpoint flush throws", async () => {
+  await assertFinalPersistenceFailure(2);
+});
+
+test("AcpRuntimeManager fails the turn when final session persist throws", async () => {
+  await assertFinalPersistenceFailure(3);
+});
 
 test("AcpRuntimeManager fails persistent turns clearly when session reuse is unavailable", async () => {
   const record = makeSessionRecord({

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -2878,6 +2878,97 @@ test("AcpRuntimeManager closes the stream and client before reporting an unexpec
   assert.equal(clientClosedAtResult, true);
 });
 
+test("AcpRuntimeManager fails the turn when final session persist throws", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "finalize-persist-session",
+    acpSessionId: "finalize-persist-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  let promptFinished = false;
+  let savesAfterPrompt = 0;
+  class FinalizePersistFailStore extends InMemorySessionStore {
+    override async save(next: AcpSessionRecord): Promise<void> {
+      if (promptFinished) {
+        savesAfterPrompt += 1;
+        if (savesAfterPrompt >= 2) {
+          throw new Error("ENOSPC: no space left on device");
+        }
+      }
+      await super.save(next);
+    }
+  }
+  const store = new FinalizePersistFailStore([record]);
+  let closeCalls = 0;
+  let handlers: FakeClientHandlers = {};
+  const client: FakeClient = {
+    initializeResult: {
+      protocolVersion: 1,
+      agentCapabilities: { prompt: true },
+    },
+    start: async () => {},
+    close: async () => {
+      closeCalls += 1;
+    },
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: (sessionId) => sessionId === "finalize-persist-sid",
+    supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
+    loadSessionWithOptions: async () => ({ agentSessionId: "finalize-persist-agent" }),
+    getAgentLifecycleSnapshot: () => ({
+      pid: 77_001,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      running: true,
+    }),
+    prompt: async () => {
+      handlers.onSessionUpdate?.({
+        sessionId: "finalize-persist-sid",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "done" },
+        },
+      });
+      promptFinished = true;
+      return { stopReason: "end_turn" };
+    },
+    waitForSessionUpdatesIdle: async () => {},
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      handlers = {};
+    },
+    setEventHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    { clientFactory: () => client as never },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("finalize-persist-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-finalize-persist",
+  });
+  const { events, result } = await collectTurn(turn);
+
+  assert.deepEqual(result, {
+    status: "failed",
+    error: {
+      code: "RUNTIME",
+      message: "ENOSPC: no space left on device",
+    },
+  });
+  assert.equal(closeCalls, 1);
+  assert.ok(events.some((event) => event.type === "text_delta"));
+});
+
 test("AcpRuntimeManager fails persistent turns clearly when session reuse is unavailable", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "persistent-session",


### PR DESCRIPTION
Fixes an issue where a persistent ACP turn could finish as successful after the final session write failed.

Related: https://github.com/openclaw/acpx/pull/495

## What Problem This Solves

Fixes an issue where users running a persistent ACP turn would see the turn complete successfully even when the final session checkpoint flush or session-store save failed (for example, disk full). The next restart then resumed from stale or missing state.

## Why This Change Was Made

https://github.com/openclaw/acpx/pull/495 already fails the turn when unexpected finalization work throws. The last checkpoint flush and session-store save still used empty `.catch(() => {})`, so persist failures never reached that path. This change lets those errors propagate. Streamed ACP events remain available; `result` now matches whether the session was actually saved.

## User Impact

`startTurn()` and `runTurn()` callers get `status: failed` when the post-turn persist step cannot write the session. The client is not left pooled as if the save succeeded. CLI process-exit best-effort flush is unchanged.

## Evidence

terminal output from production `createAcpRuntime` + `createFileSessionStore` against a real mock-agent child. First turn writes `~state/sessions/proof-498-persist.json`. On the next turn, the finalize persist step is injected with `ENOSPC`.

Unpatched `upstream/main` `1402be3` still reports that turn completed:

```console
$ node /tmp/proof-498-persist.mjs /tmp/acpx-498-main/dist/runtime.js dist-test/test/mock-agent.js main
{
  "label": "main",
  "first": { "status": "completed", "stopReason": "end_turn", "sessionBytes": 1743 },
  "second": {
    "status": "completed",
    "stopReason": "end_turn",
    "error": null,
    "text": "unrecognized prompt: second persist",
    "savesAfterPrompt": 3
  }
}
```

Patched `4bd1bf5` (same tree as `2967601`) fails the same finalize persist and still delivers the agent text first:

```console
$ node /tmp/proof-498-persist.mjs /tmp/acpx-498/dist/runtime.js dist-test/test/mock-agent.js patched
{
  "label": "patched",
  "first": { "status": "completed", "stopReason": "end_turn", "sessionBytes": 1746 },
  "second": {
    "status": "failed",
    "error": { "message": "ENOSPC: no space left on device", "code": "RUNTIME" },
    "text": "unrecognized prompt: second persist",
    "savesAfterPrompt": 3
  }
}
```

## Real behavior proof

- **Behavior or issue addressed:** After a completed persistent turn, a failed finalize checkpoint flush or session-store save no longer disappears. The turn result becomes failed instead of completed with a pooled client.
- **Real environment tested:** macOS arm64, Node v26.7.0, acpx built from patched source at `/tmp/acpx-498` (`4bd1bf5` on `fix/session-finalize-persist-errors`, same tree as `2967601`) and from `upstream/main` `1402be3` at `/tmp/acpx-498-main`. Agent: compiled mock-agent child (`dist-test/test/mock-agent.js --supports-load-session`). Store: production `createFileSessionStore` on a temp state dir.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/acpx-498
  pnpm build
  node /tmp/proof-498-persist.mjs /tmp/acpx-498-main/dist/runtime.js dist-test/test/mock-agent.js main
  node /tmp/proof-498-persist.mjs dist/runtime.js dist-test/test/mock-agent.js patched
  ```

- **Evidence after fix:** terminal output from the patched build (see Evidence). First turn writes a real session JSON file. Second turn streams `unrecognized prompt: second persist`, then finalize persist throws `ENOSPC: no space left on device` and `result` is `{ status: "failed", error: { code: "RUNTIME", message: "ENOSPC: no space left on device" } }`. Same script on main keeps `status: "completed"` / `stopReason: "end_turn"` with `error: null`.
- **Observed result after fix:** A disk-full finalize save after a completed prompt fails the turn result. Agent text already streamed on `events` is kept. Main still reports that turn as completed.
- **What was not tested:** Live `acpx` CLI against a third-party ACP agent with a real full disk (the persist failure was injected on the finalize save after production FileSessionStore had already written the session file).
