### PR TITLE
fix(acp): time out hung process-list helpers after terminal exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Repo: https://github.com/openclaw/acpx
 - Runtime/embedding: snapshot permission policies at client configuration boundaries so caller-side mutation cannot change an in-flight turn after prompt readiness.
 - Replay viewer: return the same not-found response for missing files and containment-denied paths, preventing outside-target existence probes.
 - Runtime/sessions: surface checkpoint flush and session-store save failures during turn finalization instead of dropping them. Thanks @SebTardif.
+- ACP/terminal: time out hung `ps` / PowerShell process-list helpers after a shell-backed terminal exits so wait_for_exit, kill, and release can finish. Thanks @SebTardif.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Repo: https://github.com/openclaw/acpx
 - Replay viewer: return the same not-found response for missing files and containment-denied paths, preventing outside-target existence probes.
 - Runtime/sessions: surface checkpoint flush and session-store save failures during turn finalization instead of dropping them. Thanks @SebTardif.
 - ACP/terminal: time out hung `ps` / PowerShell process-list helpers after a shell-backed terminal exits so wait_for_exit, kill, and release can finish. Thanks @SebTardif.
+- ACP/terminal: raise the process-list helper stdout cap above execFile's 1 MiB default so large `ps` listings are not dropped as empty. Thanks @SebTardif.
 
 ## 2026.7.27 (v0.13.0)
 

--- a/src/acp/client-process.ts
+++ b/src/acp/client-process.ts
@@ -6,6 +6,25 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+export const PROCESS_HELPER_TIMEOUT_MS = 8_000;
+
+export async function runTimedExecFile(
+  command: string,
+  args: readonly string[],
+  options: {
+    timeoutMs?: number;
+    windowsHide?: boolean;
+  } = {},
+): Promise<string> {
+  const { stdout } = await execFileAsync(command, [...args], {
+    encoding: "utf8",
+    timeout: options.timeoutMs ?? PROCESS_HELPER_TIMEOUT_MS,
+    killSignal: "SIGKILL",
+    windowsHide: options.windowsHide,
+  });
+  return stdout;
+}
+
 export type CommandParts = {
   command: string;
   args: string[];
@@ -319,10 +338,7 @@ function isWindowsExecutableCommand(command: string): boolean {
 }
 
 async function runWslpath(cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync("wslpath", ["-w", cwd], {
-    encoding: "utf8",
-  });
-  return stdout;
+  return await runTimedExecFile("wslpath", ["-w", cwd]);
 }
 
 export function basenameToken(value: string): string {

--- a/src/acp/client-process.ts
+++ b/src/acp/client-process.ts
@@ -2,9 +2,6 @@ import { execFile, type ChildProcess, type ChildProcessByStdio } from "node:chil
 import fs from "node:fs";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
 
 export const PROCESS_HELPER_TIMEOUT_MS = 8_000;
 export const PROCESS_HELPER_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
@@ -18,14 +15,53 @@ export async function runTimedExecFile(
     windowsHide?: boolean;
   } = {},
 ): Promise<string> {
-  const { stdout } = await execFileAsync(command, [...args], {
-    encoding: "utf8",
-    timeout: options.timeoutMs ?? PROCESS_HELPER_TIMEOUT_MS,
-    maxBuffer: options.maxBufferBytes ?? PROCESS_HELPER_MAX_BUFFER_BYTES,
-    killSignal: "SIGKILL",
-    windowsHide: options.windowsHide,
+  const timeoutMs = Math.max(1, Math.round(options.timeoutMs ?? PROCESS_HELPER_TIMEOUT_MS));
+  return await new Promise<string>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const child = execFile(
+      command,
+      [...args],
+      {
+        encoding: "utf8",
+        maxBuffer: options.maxBufferBytes ?? PROCESS_HELPER_MAX_BUFFER_BYTES,
+        killSignal: "SIGKILL",
+        windowsHide: options.windowsHide,
+      },
+      (error, stdout) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+
+    timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      const killed = child.kill("SIGKILL");
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      child.unref();
+      reject(
+        Object.assign(new Error(`${command} timed out after ${timeoutMs}ms`), {
+          code: "ETIMEDOUT",
+          killed,
+          signal: "SIGKILL" as const,
+        }),
+      );
+    }, timeoutMs);
   });
-  return stdout;
 }
 
 export type CommandParts = {

--- a/src/acp/client-process.ts
+++ b/src/acp/client-process.ts
@@ -7,18 +7,21 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export const PROCESS_HELPER_TIMEOUT_MS = 8_000;
+export const PROCESS_HELPER_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
 
 export async function runTimedExecFile(
   command: string,
   args: readonly string[],
   options: {
     timeoutMs?: number;
+    maxBufferBytes?: number;
     windowsHide?: boolean;
   } = {},
 ): Promise<string> {
   const { stdout } = await execFileAsync(command, [...args], {
     encoding: "utf8",
     timeout: options.timeoutMs ?? PROCESS_HELPER_TIMEOUT_MS,
+    maxBuffer: options.maxBufferBytes ?? PROCESS_HELPER_MAX_BUFFER_BYTES,
     killSignal: "SIGKILL",
     windowsHide: options.windowsHide,
   });

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -24,6 +24,7 @@ import {
   type TerminalSpawnCommand,
 } from "../spawn-command-options.js";
 import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } from "../types.js";
+import { PROCESS_HELPER_TIMEOUT_MS, runTimedExecFile } from "./client-process.js";
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
 const DEFAULT_KILL_GRACE_MS = 1_500;
@@ -33,6 +34,7 @@ type ManagedTerminal = {
   killProcessGroup: boolean;
   descendantPids: Set<number>;
   processGroupSnapshotPromise?: Promise<void>;
+  processHelperTimeoutMs: number;
   output: Buffer;
   truncated: boolean;
   outputByteLimit: number;
@@ -49,6 +51,7 @@ export type TerminalManagerOptions = {
   onOperation?: (operation: ClientOperation) => void;
   confirmExecute?: (commandLine: string) => Promise<boolean>;
   killGraceMs?: number;
+  processHelperTimeoutMs?: number;
 };
 
 type TerminalSpawnOptions = {
@@ -161,6 +164,7 @@ export class TerminalManager {
   private readonly usesDefaultConfirmExecute: boolean;
   private readonly confirmExecute: (commandLine: string) => Promise<boolean>;
   private readonly killGraceMs: number;
+  private readonly processHelperTimeoutMs: number;
   private readonly terminals = new Map<string, ManagedTerminal>();
 
   constructor(options: TerminalManagerOptions) {
@@ -171,6 +175,10 @@ export class TerminalManager {
     this.usesDefaultConfirmExecute = options.confirmExecute == null;
     this.confirmExecute = options.confirmExecute ?? defaultConfirmExecute;
     this.killGraceMs = Math.max(0, Math.round(options.killGraceMs ?? DEFAULT_KILL_GRACE_MS));
+    this.processHelperTimeoutMs = Math.max(
+      1,
+      Math.round(options.processHelperTimeoutMs ?? PROCESS_HELPER_TIMEOUT_MS),
+    );
   }
 
   updatePermissionPolicy(
@@ -212,6 +220,7 @@ export class TerminalManager {
         process: proc,
         killProcessGroup: spawnCommand.killProcessGroup,
         descendantPids: new Set(),
+        processHelperTimeoutMs: this.processHelperTimeoutMs,
         output: Buffer.alloc(0),
         truncated: false,
         outputByteLimit,
@@ -513,7 +522,7 @@ export class TerminalManager {
         // ignore best-effort process group snapshot failures
       });
     }
-    for (const descendantPid of await listDescendantPids(pid)) {
+    for (const descendantPid of await listDescendantPids(pid, terminal.processHelperTimeoutMs)) {
       terminal.descendantPids.add(descendantPid);
     }
   }
@@ -628,10 +637,10 @@ function commandPathExists(command: string, cwd: string): boolean {
   return fs.existsSync(resolvedPath);
 }
 
-async function listDescendantPids(rootPid: number): Promise<number[]> {
+async function listDescendantPids(rootPid: number, timeoutMs: number): Promise<number[]> {
   let output: string;
   try {
-    output = await runProcessListCommand();
+    output = await runProcessListCommand(timeoutMs);
   } catch {
     return [];
   }
@@ -679,40 +688,12 @@ function parseProcessListLine(line: string): { pid: number; parentPid: number } 
   return { pid, parentPid };
 }
 
-async function runProcessListCommand(): Promise<string> {
+async function runProcessListCommand(timeoutMs: number): Promise<string> {
   if (process.platform === "win32") {
-    return await runWindowsProcessListCommand();
+    return await runWindowsProcessListCommand(timeoutMs);
   }
 
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn("ps", ["-eo", "pid=,ppid="], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(`ps exited with code ${code ?? "null"} signal ${signal ?? "null"}: ${stderr}`),
-      );
-    });
-  });
+  return await runTimedExecFile("ps", ["-eo", "pid=,ppid="], { timeoutMs });
 }
 
 async function rememberProcessGroupPids(terminal: ManagedTerminal): Promise<void> {
@@ -722,23 +703,23 @@ async function rememberProcessGroupPids(terminal: ManagedTerminal): Promise<void
   }
 
   if (process.platform === "win32") {
-    for (const pid of await listDescendantPids(processGroupId)) {
+    for (const pid of await listDescendantPids(processGroupId, terminal.processHelperTimeoutMs)) {
       terminal.descendantPids.add(pid);
     }
     return;
   }
 
-  for (const pid of await listProcessGroupPids(processGroupId)) {
+  for (const pid of await listProcessGroupPids(processGroupId, terminal.processHelperTimeoutMs)) {
     if (pid !== processGroupId) {
       terminal.descendantPids.add(pid);
     }
   }
 }
 
-async function listProcessGroupPids(processGroupId: number): Promise<number[]> {
+async function listProcessGroupPids(processGroupId: number, timeoutMs: number): Promise<number[]> {
   let output: string;
   try {
-    output = await runProcessGroupListCommand();
+    output = await runProcessGroupListCommand(timeoutMs);
   } catch {
     return [];
   }
@@ -759,77 +740,20 @@ async function listProcessGroupPids(processGroupId: number): Promise<number[]> {
   return pids;
 }
 
-async function runProcessGroupListCommand(): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn("ps", ["-eo", "pid=,pgid="], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(`ps exited with code ${code ?? "null"} signal ${signal ?? "null"}: ${stderr}`),
-      );
-    });
-  });
+async function runProcessGroupListCommand(timeoutMs: number): Promise<string> {
+  return await runTimedExecFile("ps", ["-eo", "pid=,pgid="], { timeoutMs });
 }
 
-async function runWindowsProcessListCommand(): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const command = [
-      "Get-CimInstance Win32_Process |",
-      'ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
-    ].join(" ");
-    const child = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], {
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      reject(
-        new Error(
-          `powershell process list exited with code ${code ?? "null"} signal ${
-            signal ?? "null"
-          }: ${stderr}`,
-        ),
-      );
-    });
-  });
+async function runWindowsProcessListCommand(timeoutMs: number): Promise<string> {
+  const command = [
+    "Get-CimInstance Win32_Process |",
+    'ForEach-Object { "$($_.ProcessId) $($_.ParentProcessId)" }',
+  ].join(" ");
+  return await runTimedExecFile(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", command],
+    { timeoutMs, windowsHide: true },
+  );
 }
 
 async function killWindowsProcessTree(pid: number, signal: NodeJS.Signals): Promise<void> {

--- a/src/cli/session/session-control.ts
+++ b/src/cli/session/session-control.ts
@@ -1,8 +1,6 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
-import { splitCommandLine } from "../../acp/client-process.js";
+import { runTimedExecFile, splitCommandLine } from "../../acp/client-process.js";
 import { applyConfigOptionsToRecord } from "../../session/config-options.js";
 import {
   setCurrentModelId,
@@ -41,8 +39,6 @@ import {
   runSessionSetModelDirect,
   runSessionSetModeDirect,
 } from "./prompt-runner.js";
-
-const execFileAsync = promisify(execFile);
 
 export async function cancelSessionPrompt(
   options: SessionCancelOptions,
@@ -225,7 +221,7 @@ async function readProcCmdline(pid: number): Promise<string[] | undefined> {
 
 async function readPosixCommandLine(pid: number): Promise<string | undefined> {
   try {
-    const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "command="]);
+    const stdout = await runTimedExecFile("ps", ["-p", String(pid), "-o", "command="]);
     return stdout.trim() || undefined;
   } catch {
     return undefined;
@@ -234,7 +230,7 @@ async function readPosixCommandLine(pid: number): Promise<string | undefined> {
 
 async function readWindowsCommandLine(pid: number): Promise<string | undefined> {
   try {
-    const { stdout } = await execFileAsync(
+    const stdout = await runTimedExecFile(
       "powershell.exe",
       [
         "-NoProfile",

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -489,6 +489,15 @@ test("runTimedExecFile returns helper stdout", async () => {
   assert.equal(stdout, "helper-ok");
 });
 
+test("runTimedExecFile keeps stdout beyond execFile default maxBuffer", async () => {
+  const size = 1024 * 1024 + 64 * 1024;
+  const stdout = await runTimedExecFile(process.execPath, [
+    "-e",
+    `process.stdout.write("x".repeat(${size}))`,
+  ]);
+  assert.equal(stdout.length, size);
+});
+
 test("runTimedExecFile kills a hung helper instead of waiting forever", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-timed-exec-"));
   const pidPath = path.join(tmp, "child.pid");

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { resolveClaudeCodeExecutable } from "../src/acp/agent-command.js";
-import { resolveAgentSessionCwd } from "../src/acp/client-process.js";
+import { resolveAgentSessionCwd, runTimedExecFile } from "../src/acp/client-process.js";
 import { buildAgentSpawnOptions, buildSpawnCommandOptions } from "../src/acp/client.js";
 import { buildTerminalSpawnOptions } from "../src/acp/terminal-manager.js";
 import { buildQueueOwnerSpawnOptions } from "../src/cli/session/queue-owner-process.js";
@@ -479,6 +479,53 @@ test("resolveAgentSessionCwd rejects empty wslpath output", async () => {
     }),
     /wslpath returned an empty Windows path/,
   );
+});
+
+test("runTimedExecFile returns helper stdout", async () => {
+  const stdout = await runTimedExecFile(process.execPath, [
+    "-e",
+    "process.stdout.write('helper-ok')",
+  ]);
+  assert.equal(stdout, "helper-ok");
+});
+
+test("runTimedExecFile kills a hung helper instead of waiting forever", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-timed-exec-"));
+  const pidPath = path.join(tmp, "child.pid");
+  try {
+    await assert.rejects(
+      runTimedExecFile(
+        process.execPath,
+        [
+          "-e",
+          `require('node:fs').writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); setInterval(() => {}, 1000)`,
+        ],
+        { timeoutMs: 200 },
+      ),
+    );
+
+    const pid = Number(await fs.readFile(pidPath, "utf8"));
+    assert.ok(Number.isInteger(pid) && pid > 0);
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // best-effort cleanup
+    }
+    assert.fail(`hung helper process still alive: ${pid}`);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
 });
 
 test("buildTerminalSpawnOptions enables shell for PATH-resolved .cmd wrappers on Windows", async () => {

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -500,25 +500,35 @@ test("runTimedExecFile keeps stdout beyond execFile default maxBuffer", async ()
 
 test("runTimedExecFile kills a hung helper instead of waiting forever", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-timed-exec-"));
-  const pidPath = path.join(tmp, "child.pid");
+  const helperPidPath = path.join(tmp, "helper.pid");
+  const descendantPidPath = path.join(tmp, "descendant.pid");
   try {
     await assert.rejects(
       runTimedExecFile(
         process.execPath,
         [
           "-e",
-          `require('node:fs').writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); setInterval(() => {}, 1000)`,
+          [
+            `const fs = require("node:fs")`,
+            `const { spawn } = require("node:child_process")`,
+            `fs.writeFileSync(${JSON.stringify(helperPidPath)}, String(process.pid))`,
+            `const descendant = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 5000)"], { stdio: "inherit" })`,
+            `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid))`,
+            `setInterval(() => {}, 1000)`,
+          ].join(";"),
         ],
         { timeoutMs: 200 },
       ),
+      (error: unknown) =>
+        error instanceof Error && (error as NodeJS.ErrnoException).code === "ETIMEDOUT",
     );
 
-    const pid = Number(await fs.readFile(pidPath, "utf8"));
-    assert.ok(Number.isInteger(pid) && pid > 0);
+    const helperPid = Number(await fs.readFile(helperPidPath, "utf8"));
+    assert.ok(Number.isInteger(helperPid) && helperPid > 0);
     const deadline = Date.now() + 2_000;
     while (Date.now() < deadline) {
       try {
-        process.kill(pid, 0);
+        process.kill(helperPid, 0);
       } catch {
         return;
       }
@@ -527,12 +537,20 @@ test("runTimedExecFile kills a hung helper instead of waiting forever", async ()
       });
     }
     try {
-      process.kill(pid, "SIGKILL");
+      process.kill(helperPid, "SIGKILL");
     } catch {
       // best-effort cleanup
     }
-    assert.fail(`hung helper process still alive: ${pid}`);
+    assert.fail(`hung helper process still alive: ${helperPid}`);
   } finally {
+    try {
+      const descendantPid = Number(await fs.readFile(descendantPidPath, "utf8"));
+      if (Number.isInteger(descendantPid) && descendantPid > 0) {
+        process.kill(descendantPid, "SIGKILL");
+      }
+    } catch {
+      // best-effort cleanup of the helper's pipe-inheriting descendant
+    }
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -691,6 +691,61 @@ function isPidAlive(pid: number): boolean {
   }
 }
 
+async function rejectIfHung<T>(
+  operation: Promise<T>,
+  message: string,
+  timeoutMs = 1_500,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(message));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function withHangingProcessListCommand<T>(run: () => Promise<T>): Promise<T> {
+  const bin = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-hanging-ps-"));
+  const pidPath = path.join(bin, "ps.pids");
+  const previousPath = process.env.PATH ?? "";
+  await fs.writeFile(
+    path.join(bin, "ps"),
+    `#!/bin/sh\nprintf '%s\\n' "$$" >> ${JSON.stringify(pidPath)}\nexec sleep 3600\n`,
+    { mode: 0o755 },
+  );
+  process.env.PATH = `${bin}${path.delimiter}${previousPath}`;
+  try {
+    return await run();
+  } finally {
+    process.env.PATH = previousPath;
+    try {
+      const pids = (await fs.readFile(pidPath, "utf8"))
+        .split("\n")
+        .map((line) => Number(line))
+        .filter((pid) => Number.isInteger(pid) && pid > 0);
+      for (const pid of pids) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // best-effort cleanup of the hung helper
+        }
+      }
+    } catch {
+      // no helper pids recorded
+    }
+    await fs.rm(bin, { recursive: true, force: true });
+  }
+}
+
 test("terminal manager prompts in approve-reads mode and can deny", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
   try {
@@ -735,6 +790,89 @@ test("terminal manager fails when prompt is unavailable and policy is fail", asy
       }),
       PermissionPromptUnavailableError,
     );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager wait_for_exit and release finish when process listing hangs", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX process list hang assertion");
+    return;
+  }
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  try {
+    const manager = new TerminalManager({
+      cwd: tmp,
+      permissionMode: "approve-all",
+      processHelperTimeoutMs: 200,
+    });
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: "echo done",
+    });
+
+    await withHangingProcessListCommand(async () => {
+      const waitResult = await rejectIfHung(
+        manager.waitForTerminalExit({
+          sessionId: "session-1",
+          terminalId: created.terminalId,
+        }),
+        "terminal/wait_for_exit hung on process listing",
+      );
+      assert.equal(waitResult.exitCode, 0);
+
+      await rejectIfHung(
+        manager.releaseTerminal({
+          sessionId: "session-1",
+          terminalId: created.terminalId,
+        }),
+        "terminal/release hung on process listing",
+      );
+    });
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager kill finishes when process listing hangs", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX process list hang assertion");
+    return;
+  }
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  try {
+    const manager = new TerminalManager({
+      cwd: tmp,
+      permissionMode: "approve-all",
+      killGraceMs: 200,
+      processHelperTimeoutMs: 200,
+    });
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: "sleep 30",
+    });
+
+    await withHangingProcessListCommand(async () => {
+      await rejectIfHung(
+        manager.killTerminal({
+          sessionId: "session-1",
+          terminalId: created.terminalId,
+        }),
+        "terminal/kill hung on process listing",
+      );
+
+      const waitResult = await rejectIfHung(
+        manager.waitForTerminalExit({
+          sessionId: "session-1",
+          terminalId: created.terminalId,
+        }),
+        "terminal/wait_for_exit hung after kill while process listing hangs",
+      );
+      assert.ok(waitResult.exitCode !== null || waitResult.signal !== null);
+    });
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting on an ACP shell-backed terminal would hang forever in `terminal/wait_for_exit`, `terminal/kill`, or `terminal/release` after the command had already exited, when the follow-up `ps` or PowerShell process-list helper never returned.

The same unbounded helper class could also stall session close (matching a leftover owner via `ps` / PowerShell) and WSL cwd translation (`wslpath`).

## Why This Change Was Made

`exitPromise` waits on `rememberProcessGroupPids()`, which used to spawn `ps` / PowerShell with no timeout. A stuck helper kept wait, kill, and release parked even though the terminal process itself was gone.

This change runs those short helpers through a shared 8s `execFile` timeout (SIGKILL on expiry) and treats a timeout as "no process list" so release can continue. Session-close process matching and `wslpath` use the same helper. Agent `initialize` is not given a generic timeout; only Gemini remains timed by design.

## User Impact

A finished terminal can be waited on, killed, or released even when the host process listing tool is stuck. Session close and WSL cwd translation fail closed or skip the match instead of hanging the CLI.

## Evidence

Live `node` against production `TerminalManager` and `runTimedExecFile` from the patched worktree at `/tmp/oc-impl-acpx-ps-timeout`. A fake `ps` that only sleeps was placed first on `PATH`. Same script compared the old unbounded spawn with the patched wait/release path.

```console
$ node /tmp/acpx-ps-timeout-proof.mjs
{
  "beforeUnboundedPs": {
    "result": "hung",
    "elapsedMs": 1502
  },
  "timedHelper": {
    "result": "timed_out",
    "elapsedMs": 506,
    "killed": true,
    "signal": "SIGKILL"
  },
  "afterTerminalManager": {
    "waitMs": 506,
    "releaseMs": 1007,
    "exitCode": 0,
    "signal": null
  }
}
```

The unpatched `ps` spawn was still running at 1502ms and had to be killed by the proof script. After the patch, `terminal/wait_for_exit` returned `exitCode: 0` in 506ms and `terminal/release` finished in 1007ms while the same hanging `ps` stayed on `PATH`.

Introduced in [#313](https://github.com/openclaw/acpx/pull/313) (2026-05-15) when shell-backed terminals started snapshotting the process group after exit. Not [#498](https://github.com/openclaw/acpx/pull/498) (persist swallow).

## Real behavior proof

- **Behavior or issue addressed:** After a shell-backed ACP terminal exits, wait_for_exit, kill, and release hang if the `ps` / PowerShell process-list helper never returns.
- **Real environment tested:** macOS 26.6.1, Node v26.7.0, patched acpx checkout at `/tmp/oc-impl-acpx-ps-timeout`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-impl-acpx-ps-timeout
  node /tmp/acpx-ps-timeout-proof.mjs
  ```

- **Evidence after fix:** terminal output from the live node script above. Unbounded `ps` stayed hung at 1502ms. `runTimedExecFile` killed the helper at 506ms (`killed: true`, `SIGKILL`). Production `TerminalManager.waitForTerminalExit` then returned `exitCode: 0` in 506ms and `releaseTerminal` completed in 1007ms with the hanging `ps` still first on `PATH`.
- **Observed result after fix:** wait and release no longer wait on the stuck process-list helper. The terminal exit code is still reported. The hung helper is SIGKILL'd instead of left running.
- **What was not tested:** Windows PowerShell listing under a live hung `powershell.exe`, and a real WSL `wslpath` hang. Those call the same timed helper.
