### PR TITLE
fix(runtime): prompt for ACP elicitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Repo: https://github.com/openclaw/acpx
   `AcpRuntimeOptions` so embedded clients can reuse its rule matching and
   decisions. Thanks @xenaocx-dev.
 
+- Runtime/embedding: add turn-scoped ACP form and URL elicitation handlers with capability and cancellation fencing.
+
 ### Breaking
 
 - Runtime API: require `AcpRuntimeTurn.promptStarted`, which settles after `connection.prompt()` returns its request promise or fails beforehand.

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1,30 +1,44 @@
 import { spawn, type ChildProcess, type ChildProcessByStdio } from "node:child_process";
 import { Readable, Writable } from "node:stream";
 import {
-  ClientSideConnection,
   PROTOCOL_VERSION,
-  RequestError,
+  client,
+  methods,
   type AnyMessage,
   type AuthMethod,
+  type AuthenticateRequest,
   type ClientCapabilities,
+  type ClientConnection,
+  type CreateElicitationRequest,
+  type CreateElicitationResponse,
   type CreateTerminalRequest,
   type CreateTerminalResponse,
+  type InitializeRequest,
   type InitializeResponse,
+  type JsonRpcId,
+  type LoadSessionRequest,
   type ListSessionsRequest,
   type ListSessionsResponse,
   type KillTerminalRequest,
   type KillTerminalResponse,
   type LoadSessionResponse,
+  type NewSessionRequest,
+  type NewSessionResponse,
   type PromptResponse,
+  type PromptRequest,
   type ReadTextFileRequest,
   type ReadTextFileResponse,
   type ReleaseTerminalRequest,
   type ReleaseTerminalResponse,
   type ResumeSessionResponse,
+  type ResumeSessionRequest,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
   type SetSessionConfigOptionResponse,
+  type SetSessionConfigOptionRequest,
+  type SetSessionModeRequest,
+  type SetSessionModeResponse,
   type TerminalOutputRequest,
   type TerminalOutputResponse,
   type WaitForTerminalExitRequest,
@@ -58,6 +72,8 @@ import { extractRuntimeSessionId } from "../session/runtime-session-id.js";
 import { buildAgentSpawnCommand, buildSpawnCommandOptions } from "../spawn-command-options.js";
 import type {
   AcpClientOptions,
+  AcpElicitationHandler,
+  AcpElicitationMode,
   NonInteractivePermissionPolicy,
   PermissionMode,
   PermissionStats,
@@ -134,6 +150,14 @@ const DEVIN_COMPATIBILITY_CLIENT_CAPABILITIES_META = Object.freeze({
 const DEVIN_COMPATIBILITY_CLIENT_NAME = "windsurf";
 // This is the embedded Windsurf IDE version bundled with Devin Desktop 3.1.7, the first locally verified version that passes Devin's server-side ACP precondition.
 const DEFAULT_DEVIN_COMPATIBILITY_CLIENT_VERSION = "1.110.1";
+const ELICITATION_CANCEL_MESSAGES = {
+  inactive: "elicitation owner is no longer active",
+  unavailable: "elicitation handler is unavailable",
+  unsupported: "elicitation mode is not supported",
+  mismatchedSession: "elicitation session is not active",
+  cancelled: "elicitation request was cancelled",
+  requestScoped: "request-scoped elicitation has no owner",
+} as const;
 
 function resolveClientInfo(devinAcp: boolean): { name: string; version: string } {
   if (!devinAcp) {
@@ -149,10 +173,119 @@ function resolveClientInfo(devinAcp: boolean): { name: string; version: string }
   };
 }
 
+function normalizeElicitationModes(
+  modes: readonly AcpElicitationMode[] | undefined,
+): AcpElicitationMode[] {
+  return [...new Set((modes ?? []).filter((mode) => mode === "form" || mode === "url"))];
+}
+
+function cancelledElicitationResponse(message: string): CreateElicitationResponse {
+  return { action: "cancel", _meta: { message } };
+}
+
+function isKnownElicitationResponse(response: unknown): response is CreateElicitationResponse {
+  if (!response || typeof response !== "object") {
+    return false;
+  }
+  const action = (response as { action?: unknown }).action;
+  return action === "accept" || action === "decline" || action === "cancel";
+}
+
+function elicitationSessionId(request: CreateElicitationRequest): string | undefined {
+  const value = (request as { sessionId?: unknown }).sessionId;
+  return typeof value === "string" ? value : undefined;
+}
+
+function elicitationRequestScopeId(request: CreateElicitationRequest): JsonRpcId | undefined {
+  const value = (request as { requestId?: unknown }).requestId;
+  return value === null || typeof value === "string" || typeof value === "number"
+    ? value
+    : undefined;
+}
+
+function waitForAbort(signal: AbortSignal): Promise<{ kind: "aborted" }> {
+  if (signal.aborted) {
+    return Promise.resolve({ kind: "aborted" });
+  }
+  return new Promise((resolve) => {
+    signal.addEventListener("abort", () => resolve({ kind: "aborted" }), { once: true });
+  });
+}
+
+function isExtensionNotification(message: AnyMessage): boolean {
+  if (!("method" in message) || "id" in message || typeof message.method !== "string") {
+    return false;
+  }
+  return (
+    message.method !== methods.client.session.update &&
+    message.method !== methods.client.elicitation.complete &&
+    message.method !== methods.protocol.cancelRequest
+  );
+}
+
+function elicitationRequestId(message: AnyMessage): JsonRpcId | undefined {
+  if (
+    !("method" in message) ||
+    message.method !== methods.client.elicitation.create ||
+    !("id" in message)
+  ) {
+    return undefined;
+  }
+  return message.id;
+}
+
+function responseId(message: AnyMessage): JsonRpcId | undefined {
+  if (!("id" in message) || "method" in message) {
+    return undefined;
+  }
+  return message.id;
+}
+
+function promptRequestOwner(
+  message: AnyMessage,
+): { requestId: JsonRpcId; sessionId: string } | undefined {
+  if (
+    !("method" in message) ||
+    message.method !== methods.agent.session.prompt ||
+    !("id" in message)
+  ) {
+    return undefined;
+  }
+  const sessionId = (message.params as { sessionId?: unknown } | undefined)?.sessionId;
+  return typeof sessionId === "string" ? { requestId: message.id, sessionId } : undefined;
+}
+
+function createAgentConnectionFacade(connection: ClientConnection): AcpAgentConnection {
+  const agent = connection.agent;
+  return {
+    signal: connection.signal,
+    close: (error) => connection.close(error),
+    initialize: async (params) => await agent.request(methods.agent.initialize, params),
+    authenticate: async (params) => {
+      await agent.request(methods.agent.authenticate, params);
+    },
+    newSession: async (params) => await agent.request(methods.agent.session.new, params),
+    loadSession: async (params) => await agent.request(methods.agent.session.load, params),
+    resumeSession: async (params) => await agent.request(methods.agent.session.resume, params),
+    prompt: async (params) => await agent.request(methods.agent.session.prompt, params),
+    setSessionMode: async (params) => await agent.request(methods.agent.session.setMode, params),
+    setSessionConfigOption: async (params) =>
+      await agent.request(methods.agent.session.setConfigOption, params),
+    extMethod: async (method, params) =>
+      await agent.request<Record<string, unknown>, Record<string, unknown>>(method, params),
+    cancel: async (params) => await agent.notify(methods.agent.session.cancel, params),
+    closeSession: async (params) => {
+      await agent.request(methods.agent.session.close, params);
+    },
+    listSessions: async (params) => await agent.request(methods.agent.session.list, params),
+  };
+}
+
 function resolveClientCapabilities(params: {
   devinAcp: boolean;
   fs: boolean;
   terminal: boolean;
+  elicitationModes: readonly AcpElicitationMode[];
 }): ClientCapabilities {
   const baseCapabilities: ClientCapabilities = {
     fs: {
@@ -160,6 +293,14 @@ function resolveClientCapabilities(params: {
       writeTextFile: params.fs,
     },
     terminal: params.terminal,
+    ...(params.elicitationModes.length > 0
+      ? {
+          elicitation: {
+            ...(params.elicitationModes.includes("form") ? { form: {} } : {}),
+            ...(params.elicitationModes.includes("url") ? { url: {} } : {}),
+          },
+        }
+      : {}),
   };
 
   if (!params.devinAcp) {
@@ -170,10 +311,6 @@ function resolveClientCapabilities(params: {
     ...baseCapabilities,
     _meta: DEVIN_COMPATIBILITY_CLIENT_CAPABILITIES_META,
   };
-}
-
-function isDevinRequestDiagnosticsMethod(method: string): boolean {
-  return method === "_cognition.ai/request_diagnostics";
 }
 
 type LoadSessionOptions = {
@@ -234,6 +371,38 @@ type AgentDisconnectReason = "process_exit" | "process_close" | "pipe_close" | "
 type PendingConnectionRequest = {
   settled: boolean;
   reject: (error: unknown) => void;
+};
+
+type AcpAgentConnection = {
+  signal: AbortSignal;
+  close?: (error?: unknown) => void;
+  initialize: (params: InitializeRequest) => Promise<InitializeResponse>;
+  authenticate: (params: AuthenticateRequest) => Promise<void>;
+  newSession: (params: NewSessionRequest) => Promise<NewSessionResponse>;
+  loadSession: (params: LoadSessionRequest) => Promise<LoadSessionResponse>;
+  resumeSession: (params: ResumeSessionRequest) => Promise<ResumeSessionResponse>;
+  prompt: (params: PromptRequest) => Promise<PromptResponse>;
+  setSessionMode: (params: SetSessionModeRequest) => Promise<SetSessionModeResponse>;
+  setSessionConfigOption: (
+    params: SetSessionConfigOptionRequest,
+  ) => Promise<SetSessionConfigOptionResponse>;
+  extMethod: (method: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  cancel: (params: { sessionId: string }) => Promise<void>;
+  closeSession: (params: { sessionId: string }) => Promise<void>;
+  listSessions: (params: ListSessionsRequest) => Promise<ListSessionsResponse>;
+};
+
+type ActivePromptState = {
+  sessionId: string;
+  requestId?: JsonRpcId;
+  promise?: Promise<PromptResponse>;
+  elicitationHandler?: AcpElicitationHandler;
+  elicitationController: AbortController;
+};
+
+type ElicitationOwner = {
+  active: ActivePromptState;
+  handler: AcpElicitationHandler;
 };
 
 function snapshotPermissionPolicy(
@@ -422,7 +591,7 @@ function createNdJsonMessageStream(
 
 export class AcpClient {
   private options: AcpClientOptions;
-  private connection?: ClientSideConnection;
+  private connection?: AcpAgentConnection;
   private agent?: ChildProcessByStdio<Writable, Readable, Readable>;
   private initResult?: InitializeResponse;
   private loadedSessionId?: string;
@@ -447,10 +616,8 @@ export class AcpClient {
   private processedSessionUpdates = 0;
   private suppressSessionUpdates = false;
   private suppressReplaySessionUpdateMessages = false;
-  private activePrompt?: {
-    sessionId: string;
-    promise: Promise<PromptResponse>;
-  };
+  private activePrompt?: ActivePromptState;
+  private readonly pendingPromptOwners: ActivePromptState[] = [];
   private readonly cancellingSessionIds = new Set<string>();
   private readonly permissionAbortControllers = new Map<string, AbortController>();
   private closing = false;
@@ -468,6 +635,7 @@ export class AcpClient {
       cwd: asAbsoluteCwd(options.cwd),
       authPolicy: options.authPolicy ?? "skip",
       permissionPolicy: snapshotPermissionPolicy(options.permissionPolicy),
+      elicitationModes: normalizeElicitationModes(options.elicitationModes),
     };
     this.eventHandlers = {
       onAcpMessage: this.options.onAcpMessage,
@@ -623,6 +791,19 @@ export class AcpClient {
     return this.activePrompt.sessionId === sessionId;
   }
 
+  hasUnresolvedPrompt(): boolean {
+    return this.activePrompt !== undefined;
+  }
+
+  endPromptElicitation(sessionId: string): void {
+    const active = this.activePrompt;
+    if (!active || active.sessionId !== sessionId) {
+      return;
+    }
+    active.elicitationHandler = undefined;
+    active.elicitationController.abort();
+  }
+
   async start(): Promise<void> {
     if (this.connection && this.agent && isChildProcessRunning(this.agent)) {
       return;
@@ -761,61 +942,58 @@ export class AcpClient {
       writable: WritableStream<AnyMessage>;
     },
     launch: Pick<AgentLaunchPlan, "devinAcp">,
-  ): ClientSideConnection {
-    return new ClientSideConnection(
-      () => ({
-        sessionUpdate: async (params: SessionNotification) => {
-          await this.handleSessionUpdate(params);
+  ): AcpAgentConnection {
+    const app = client({ name: "acpx" })
+      .onNotification(methods.client.session.update, async ({ params }) => {
+        await this.handleSessionUpdate(params);
+      })
+      .onNotification(methods.client.elicitation.complete, async () => {})
+      .onRequest(methods.client.session.requestPermission, async ({ params }) => {
+        return await this.handlePermissionRequest(params);
+      })
+      .onRequest(methods.client.elicitation.create, async ({ params, requestId, signal }) => {
+        return await this.handleElicitationRequest(params, requestId, signal);
+      })
+      .onRequest(methods.client.fs.readTextFile, async ({ params }) => {
+        return await this.handleReadTextFile(params);
+      })
+      .onRequest(methods.client.fs.writeTextFile, async ({ params }) => {
+        return await this.handleWriteTextFile(params);
+      })
+      .onRequest(methods.client.terminal.create, async ({ params }) => {
+        return await this.handleCreateTerminal(params);
+      })
+      .onRequest(methods.client.terminal.output, async ({ params }) => {
+        return await this.handleTerminalOutput(params);
+      })
+      .onRequest(methods.client.terminal.waitForExit, async ({ params }) => {
+        return await this.handleWaitForTerminalExit(params);
+      })
+      .onRequest(methods.client.terminal.kill, async ({ params }) => {
+        return await this.handleKillTerminal(params);
+      })
+      .onRequest(methods.client.terminal.release, async ({ params }) => {
+        return await this.handleReleaseTerminal(params);
+      });
+
+    if (launch.devinAcp) {
+      app.onRequest(
+        "_cognition.ai/request_diagnostics",
+        (params): Record<string, unknown> => {
+          return params && typeof params === "object" && !Array.isArray(params)
+            ? (params as Record<string, unknown>)
+            : {};
         },
-        requestPermission: async (
-          params: RequestPermissionRequest,
-        ): Promise<RequestPermissionResponse> => {
-          return this.handlePermissionRequest(params);
-        },
-        extMethod: async (method: string): Promise<Record<string, unknown>> => {
-          if (launch.devinAcp && isDevinRequestDiagnosticsMethod(method)) {
-            return {};
-          }
-          const error = RequestError.methodNotFound(method);
-          if (!this.options.suppressSdkConsoleErrors) {
-            console.error(error.message);
-          }
-          throw error;
-        },
-        readTextFile: async (params: ReadTextFileRequest): Promise<ReadTextFileResponse> => {
-          return this.handleReadTextFile(params);
-        },
-        writeTextFile: async (params: WriteTextFileRequest): Promise<WriteTextFileResponse> => {
-          return this.handleWriteTextFile(params);
-        },
-        createTerminal: async (params: CreateTerminalRequest): Promise<CreateTerminalResponse> => {
-          return this.handleCreateTerminal(params);
-        },
-        terminalOutput: async (params: TerminalOutputRequest): Promise<TerminalOutputResponse> => {
-          return this.handleTerminalOutput(params);
-        },
-        waitForTerminalExit: async (
-          params: WaitForTerminalExitRequest,
-        ): Promise<WaitForTerminalExitResponse> => {
-          return this.handleWaitForTerminalExit(params);
-        },
-        killTerminal: async (params: KillTerminalRequest): Promise<KillTerminalResponse> => {
-          return this.handleKillTerminal(params);
-        },
-        releaseTerminal: async (
-          params: ReleaseTerminalRequest,
-        ): Promise<ReleaseTerminalResponse> => {
-          return this.handleReleaseTerminal(params);
-        },
-        extNotification: async (): Promise<void> => {},
-      }),
-      stream,
-    );
+        async () => ({}),
+      );
+    }
+
+    return createAgentConnectionFacade(app.connect(stream));
   }
 
   private async initializeAgentConnection(params: {
     child: ChildProcessByStdio<Writable, Readable, Readable>;
-    connection: ClientSideConnection;
+    connection: AcpAgentConnection;
     startupFailure: StartupFailureWatcher;
     startupStderr: string[];
     launch: AgentLaunchPlan;
@@ -831,12 +1009,13 @@ export class AcpClient {
       this.initResult = initResult;
       this.log(`initialized protocol version ${initResult.protocolVersion}`);
     } catch (error) {
+      params.connection.close?.(error);
       await this.handleInitializeFailure(params, error);
     }
   }
 
   private async initializeProtocolConnection(
-    connection: ClientSideConnection,
+    connection: AcpAgentConnection,
     launch: Pick<AgentLaunchPlan, "devinAcp" | "geminiAcp">,
   ): Promise<InitializeResponse> {
     const initializePromise = connection.initialize({
@@ -845,6 +1024,7 @@ export class AcpClient {
         devinAcp: launch.devinAcp,
         fs: this.options.fs !== false,
         terminal: this.options.terminal !== false,
+        elicitationModes: this.options.elicitationModes ?? [],
       }),
       clientInfo: resolveClientInfo(launch.devinAcp),
     });
@@ -896,9 +1076,24 @@ export class AcpClient {
   } {
     const onAcpMessage = () => this.eventHandlers.onAcpMessage;
     const onAcpOutputMessage = () => this.eventHandlers.onAcpOutputMessage;
+    const elicitationRequestIds = new Set<JsonRpcId>();
+    const bindPromptOwner = (owner: { requestId: JsonRpcId; sessionId: string }): void => {
+      this.bindPromptOwner(owner);
+    };
 
     const shouldSuppressInboundReplaySessionUpdate = (message: AnyMessage): boolean => {
       return this.suppressReplaySessionUpdateMessages && isSessionUpdateNotification(message);
+    };
+    const observeInbound = (message: AnyMessage): void => {
+      const requestId = elicitationRequestId(message);
+      if (requestId !== undefined) {
+        elicitationRequestIds.add(requestId);
+        return;
+      }
+      if (!shouldSuppressInboundReplaySessionUpdate(message)) {
+        onAcpOutputMessage()?.("inbound", message);
+        onAcpMessage()?.("inbound", message);
+      }
     };
 
     const readable = new ReadableStream<AnyMessage>({
@@ -913,9 +1108,9 @@ export class AcpClient {
             if (!value) {
               continue;
             }
-            if (!shouldSuppressInboundReplaySessionUpdate(value)) {
-              onAcpOutputMessage()?.("inbound", value);
-              onAcpMessage()?.("inbound", value);
+            observeInbound(value);
+            if (isExtensionNotification(value)) {
+              continue;
             }
             controller.enqueue(value);
           }
@@ -928,8 +1123,16 @@ export class AcpClient {
 
     const writable = new WritableStream<AnyMessage>({
       async write(message) {
-        onAcpOutputMessage()?.("outbound", message);
-        onAcpMessage()?.("outbound", message);
+        const promptOwner = promptRequestOwner(message);
+        if (promptOwner) {
+          bindPromptOwner(promptOwner);
+        }
+        const id = responseId(message);
+        const sensitive = id !== undefined && elicitationRequestIds.delete(id);
+        if (!sensitive) {
+          onAcpOutputMessage()?.("outbound", message);
+          onAcpMessage()?.("outbound", message);
+        }
         const writer = base.writable.getWriter();
         try {
           await writer.write(message);
@@ -951,7 +1154,7 @@ export class AcpClient {
     const claudeAcp = isClaudeAcpCommand(command, args);
     const sessionCwd = await resolveAgentSessionCwd(cwd, this.options.agentCommand);
 
-    let result: Awaited<ReturnType<typeof connection.newSession>>;
+    let result: NewSessionResponse;
     try {
       const createPromise = this.runConnectionRequest(() =>
         connection.newSession({
@@ -1066,12 +1269,15 @@ export class AcpClient {
     sessionId: string,
     prompt: PromptInput | string,
     onRequestStarted?: () => Promise<void> | void,
+    onElicitation?: AcpElicitationHandler,
   ): Promise<PromptResponse> {
     const connection = this.getConnection();
     const normalizedPrompt = this.normalizePromptForAgent(prompt);
     const restoreConsoleError = this.options.suppressSdkConsoleErrors
       ? installSdkConsoleErrorSuppression()
       : undefined;
+
+    const activePrompt = this.beginActivePrompt(sessionId, onElicitation);
 
     let promptPromise: Promise<PromptResponse>;
     try {
@@ -1085,14 +1291,12 @@ export class AcpClient {
         () => !connection.signal?.aborted,
       );
     } catch (error) {
+      this.clearActivePrompt(activePrompt);
       restoreConsoleError?.();
       throw error;
     }
 
-    this.activePrompt = {
-      sessionId,
-      promise: promptPromise,
-    };
+    activePrompt.promise = promptPromise;
 
     try {
       return this.returnPromptResponseOrPermissionFailure(sessionId, await promptPromise);
@@ -1101,13 +1305,48 @@ export class AcpClient {
       throw error;
     } finally {
       restoreConsoleError?.();
-      if (this.activePrompt?.promise === promptPromise) {
-        this.activePrompt = undefined;
-      }
+      this.clearActivePrompt(activePrompt);
       this.cancellingSessionIds.delete(sessionId);
       this.abortAndDropPermissionSignal(sessionId);
       this.promptPermissionFailures.delete(sessionId);
     }
+  }
+
+  private beginActivePrompt(
+    sessionId: string,
+    elicitationHandler: AcpElicitationHandler | undefined,
+  ): ActivePromptState {
+    const previous = this.activePrompt;
+    this.cancellingSessionIds.delete(sessionId);
+    const active: ActivePromptState = {
+      sessionId,
+      elicitationHandler,
+      elicitationController: new AbortController(),
+    };
+    this.activePrompt = active;
+    this.pendingPromptOwners.push(active);
+    previous?.elicitationController?.abort();
+    return active;
+  }
+
+  private bindPromptOwner(owner: { requestId: JsonRpcId; sessionId: string }): void {
+    const active = this.pendingPromptOwners.find((candidate) => {
+      return candidate.requestId === undefined && candidate.sessionId === owner.sessionId;
+    });
+    if (active) {
+      active.requestId = owner.requestId;
+    }
+  }
+
+  private clearActivePrompt(active: ActivePromptState): void {
+    if (this.activePrompt === active) {
+      this.activePrompt = undefined;
+    }
+    const pendingIndex = this.pendingPromptOwners.indexOf(active);
+    if (pendingIndex >= 0) {
+      this.pendingPromptOwners.splice(pendingIndex, 1);
+    }
+    active.elicitationController.abort();
   }
 
   private normalizePromptForAgent(prompt: PromptInput | string): PromptInput {
@@ -1294,7 +1533,13 @@ export class AcpClient {
 
   async cancel(sessionId: string): Promise<void> {
     const connection = this.getConnection();
-    this.cancellingSessionIds.add(sessionId);
+    const active = this.activePrompt;
+    if (active?.sessionId === sessionId) {
+      this.cancellingSessionIds.add(sessionId);
+      active.elicitationController?.abort();
+    } else {
+      this.cancellingSessionIds.delete(sessionId);
+    }
     this.abortAndDropPermissionSignal(sessionId);
     await this.runConnectionRequest(() =>
       connection.cancel({
@@ -1305,6 +1550,10 @@ export class AcpClient {
 
   async closeSession(sessionId: string): Promise<void> {
     const connection = this.getConnection();
+    this.cancellingSessionIds.add(sessionId);
+    if (this.activePrompt?.sessionId === sessionId) {
+      this.activePrompt.elicitationController?.abort();
+    }
     await this.runConnectionRequest(() =>
       connection.closeSession({
         sessionId,
@@ -1347,6 +1596,10 @@ export class AcpClient {
     if (waitMs <= 0) {
       return undefined;
     }
+    const activePromise = active.promise;
+    if (!activePromise) {
+      return undefined;
+    }
 
     let timer: NodeJS.Timeout | number | undefined;
     const timeoutPromise = new Promise<undefined>((resolve) => {
@@ -1355,7 +1608,7 @@ export class AcpClient {
 
     try {
       return await Promise.race([
-        active.promise.then(
+        activePromise.then(
           (response) => response,
           () => undefined,
         ),
@@ -1370,6 +1623,7 @@ export class AcpClient {
 
   async close(): Promise<void> {
     this.closing = true;
+    this.abortActiveElicitation();
 
     await this.terminalManager.shutdown();
 
@@ -1377,6 +1631,7 @@ export class AcpClient {
     if (agent) {
       await this.terminateAgentProcess(agent);
     }
+    this.closeConnection();
     if (this.pendingConnectionRequests.size > 0) {
       this.rejectPendingConnectionRequests(
         this.lastAgentExit
@@ -1400,6 +1655,7 @@ export class AcpClient {
     this.suppressSessionUpdates = false;
     this.suppressReplaySessionUpdateMessages = false;
     this.activePrompt = undefined;
+    this.pendingPromptOwners.length = 0;
     this.cancellingSessionIds.clear();
     for (const controller of this.permissionAbortControllers.values()) {
       controller.abort();
@@ -1412,6 +1668,14 @@ export class AcpClient {
     this.initResult = undefined;
     this.connection = undefined;
     this.agent = undefined;
+  }
+
+  private abortActiveElicitation(): void {
+    this.activePrompt?.elicitationController?.abort();
+  }
+
+  private closeConnection(): void {
+    this.connection?.close?.();
   }
 
   private async terminateAgentProcess(
@@ -1477,7 +1741,7 @@ export class AcpClient {
     }
   }
 
-  private getConnection(): ClientSideConnection {
+  private getConnection(): AcpAgentConnection {
     if (!this.connection) {
       throw new Error("ACP client not started");
     }
@@ -1678,23 +1942,23 @@ export class AcpClient {
   }
 
   private async authenticateIfRequired(
-    connection: ClientSideConnection,
-    methods: AuthMethod[],
+    connection: AcpAgentConnection,
+    authMethods: AuthMethod[],
   ): Promise<void> {
-    if (methods.length === 0) {
+    if (authMethods.length === 0) {
       return;
     }
 
-    const selected = this.selectAuthMethod(methods);
+    const selected = this.selectAuthMethod(authMethods);
     if (!selected) {
       if (this.options.authPolicy === "fail") {
         throw new AuthPolicyError(
-          `agent advertised auth methods [${methods.map((m) => m.id).join(", ")}] but no matching credentials found`,
+          `agent advertised auth methods [${authMethods.map((m) => m.id).join(", ")}] but no matching credentials found`,
         );
       }
 
       this.log(
-        `agent advertised auth methods [${methods.map((m) => m.id).join(", ")}] but no matching credentials found — skipping (agent may handle auth internally)`,
+        `agent advertised auth methods [${authMethods.map((m) => m.id).join(", ")}] but no matching credentials found — skipping (agent may handle auth internally)`,
       );
       return;
     }
@@ -1725,6 +1989,86 @@ export class AcpClient {
     }
 
     return response;
+  }
+
+  private async handleElicitationRequest(
+    request: CreateElicitationRequest,
+    requestId: JsonRpcId,
+    requestSignal: AbortSignal,
+  ): Promise<CreateElicitationResponse> {
+    const resolved = this.resolveElicitationOwner(request);
+    if ("response" in resolved) {
+      return resolved.response;
+    }
+    const { active, handler } = resolved.owner;
+
+    const signal = AbortSignal.any([requestSignal, active.elicitationController.signal]);
+    const handlerAttempt = Promise.resolve()
+      .then(async () => await handler(request, { requestId, signal }))
+      .then(
+        (response) => ({ kind: "response" as const, response }),
+        (error: unknown) => ({ kind: "error" as const, error }),
+      );
+    const outcome = await Promise.race([handlerAttempt, waitForAbort(signal)]);
+
+    if (this.activePrompt !== active) {
+      return cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.inactive);
+    }
+    if (outcome.kind === "aborted" || signal.aborted) {
+      return cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.cancelled);
+    }
+    if (outcome.kind === "error" || !isKnownElicitationResponse(outcome.response)) {
+      return cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.unavailable);
+    }
+    return outcome.response;
+  }
+
+  private resolveElicitationOwner(
+    request: CreateElicitationRequest,
+  ): { owner: ElicitationOwner } | { response: CreateElicitationResponse } {
+    if (!this.options.elicitationModes?.includes(request.mode as AcpElicitationMode)) {
+      return { response: cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.unsupported) };
+    }
+    const active = this.activePrompt;
+    if (!active) {
+      return { response: cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.inactive) };
+    }
+    const scope = this.resolveElicitationScope(request, active);
+    if ("response" in scope) {
+      return scope;
+    }
+    if (this.isElicitationSessionCancelling(scope.sessionId)) {
+      return { response: cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.cancelled) };
+    }
+    if (!active.elicitationHandler) {
+      return { response: cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.unavailable) };
+    }
+    return { owner: { active, handler: active.elicitationHandler } };
+  }
+
+  private resolveElicitationScope(
+    request: CreateElicitationRequest,
+    active: ActivePromptState,
+  ): { sessionId: string } | { response: CreateElicitationResponse } {
+    const sessionId = elicitationSessionId(request);
+    if (sessionId) {
+      return sessionId === active.sessionId
+        ? { sessionId }
+        : {
+            response: cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.mismatchedSession),
+          };
+    }
+    const requestScopeId = elicitationRequestScopeId(request);
+    if (requestScopeId === undefined || requestScopeId !== active.requestId) {
+      return {
+        response: cancelledElicitationResponse(ELICITATION_CANCEL_MESSAGES.requestScoped),
+      };
+    }
+    return { sessionId: active.sessionId };
+  }
+
+  private isElicitationSessionCancelling(sessionId: string): boolean {
+    return this.closing || this.cancellingSessionIds.has(sessionId);
   }
 
   private async tryHandlePermissionRequestWithHost(

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -45,6 +45,11 @@ export {
 } from "./runtime/public/handle-state.js";
 export type {
   AcpAgentRegistry,
+  AcpElicitationContext,
+  AcpElicitationHandler,
+  AcpElicitationMode,
+  AcpElicitationRequest,
+  AcpElicitationResponse,
   AcpFileSessionStoreOptions,
   AcpPermissionDecision,
   AcpPermissionRequest,
@@ -221,6 +226,7 @@ export class AcpxRuntime implements AcpxRuntimeLike {
         requestId: input.requestId,
         timeoutMs: input.timeoutMs,
         signal: input.signal,
+        onElicitation: input.onElicitation,
       }),
     );
     return {
@@ -258,6 +264,7 @@ export class AcpxRuntime implements AcpxRuntimeLike {
       requestId: input.requestId,
       timeoutMs: input.timeoutMs,
       signal: input.signal,
+      onElicitation: input.onElicitation,
     });
   }
 

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -7,6 +7,7 @@ import { absolutePath, isoNow } from "../../session/persistence.js";
 import type {
   AcpPermissionDecision,
   AcpPermissionRequest,
+  AcpElicitationMode,
   AuthPolicy,
   McpServer,
   NonInteractivePermissionPolicy,
@@ -53,6 +54,7 @@ export type WithConnectedSessionOptions<T> = {
   authPolicy?: AuthPolicy;
   fs?: boolean;
   terminal?: boolean;
+  elicitationModes?: readonly AcpElicitationMode[];
   resumePolicy?: SessionResumePolicy;
   timeoutMs?: number;
   verbose?: boolean;
@@ -112,6 +114,7 @@ export async function withConnectedSession<T>(
       authPolicy: options.authPolicy,
       fs: options.fs,
       terminal: options.terminal,
+      elicitationModes: options.elicitationModes,
       verbose: options.verbose,
       sessionOptions: sessionOptionsFromRecord(record),
     }) ??
@@ -128,6 +131,7 @@ export async function withConnectedSession<T>(
       authPolicy: options.authPolicy,
       fs: options.fs,
       terminal: options.terminal,
+      elicitationModes: options.elicitationModes,
       verbose: options.verbose,
       sessionOptions: sessionOptionsFromRecord(record),
     });

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -100,41 +100,24 @@ export async function withConnectedSession<T>(
   options: WithConnectedSessionOptions<T>,
 ): Promise<WithConnectedSessionResult<T>> {
   const record = await options.loadRecord(options.sessionRecordId);
-  const client =
-    options.createClient?.({
-      agentCommand: record.agentCommand,
-      agentArgv: record.agentArgv,
-      cwd: absolutePath(record.cwd),
-      mcpServers: options.mcpServers,
-      permissionMode: options.permissionMode ?? "approve-reads",
-      nonInteractivePermissions: options.nonInteractivePermissions,
-      permissionPolicy: options.permissionPolicy,
-      onPermissionRequest: options.onPermissionRequest,
-      authCredentials: options.authCredentials,
-      authPolicy: options.authPolicy,
-      fs: options.fs,
-      terminal: options.terminal,
-      elicitationModes: options.elicitationModes,
-      verbose: options.verbose,
-      sessionOptions: sessionOptionsFromRecord(record),
-    }) ??
-    new AcpClient({
-      agentCommand: record.agentCommand,
-      agentArgv: record.agentArgv,
-      cwd: absolutePath(record.cwd),
-      mcpServers: options.mcpServers,
-      permissionMode: options.permissionMode ?? "approve-reads",
-      nonInteractivePermissions: options.nonInteractivePermissions,
-      permissionPolicy: options.permissionPolicy,
-      onPermissionRequest: options.onPermissionRequest,
-      authCredentials: options.authCredentials,
-      authPolicy: options.authPolicy,
-      fs: options.fs,
-      terminal: options.terminal,
-      elicitationModes: options.elicitationModes,
-      verbose: options.verbose,
-      sessionOptions: sessionOptionsFromRecord(record),
-    });
+  const clientOptions: ConstructorParameters<typeof AcpClient>[0] = {
+    agentCommand: record.agentCommand,
+    agentArgv: record.agentArgv,
+    cwd: absolutePath(record.cwd),
+    mcpServers: options.mcpServers,
+    permissionMode: options.permissionMode ?? "approve-reads",
+    nonInteractivePermissions: options.nonInteractivePermissions,
+    permissionPolicy: options.permissionPolicy,
+    onPermissionRequest: options.onPermissionRequest,
+    authCredentials: options.authCredentials,
+    authPolicy: options.authPolicy,
+    fs: options.fs,
+    terminal: options.terminal,
+    elicitationModes: options.elicitationModes,
+    verbose: options.verbose,
+    sessionOptions: sessionOptionsFromRecord(record),
+  };
+  const client = options.createClient?.(clientOptions) ?? new AcpClient(clientOptions);
   let activeSessionIdForControl = record.acpSessionId;
   let notifiedClientAvailable = false;
   const activeController = createActiveSessionController({

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -44,6 +44,7 @@ import type {
   SessionTokenUsage,
 } from "../../types.js";
 import type {
+  AcpElicitationHandler,
   AcpRuntimeAvailableCommand,
   AcpRuntimeEvent,
   AcpRuntimeHandle,
@@ -499,6 +500,7 @@ type RuntimeTurnTask = {
     requestId: string;
     timeoutMs?: number;
     signal?: AbortSignal;
+    onElicitation?: AcpElicitationHandler;
   };
   promptInput: PromptInput | string;
   queue: AsyncEventQueue;
@@ -841,11 +843,7 @@ export class AcpRuntimeManager {
     acpxState: ReturnType<typeof cloneSessionAcpxState>;
   }): Promise<boolean> {
     const { record, owner, conversation, acpxState } = input;
-    if (
-      owner.mode !== "persistent" ||
-      record.closed ||
-      !owner.client.hasReusableSession(record.acpSessionId)
-    ) {
+    if (!this.canRetainPersistentSessionOwner(owner, record)) {
       owner.activeTurn = undefined;
       return false;
     }
@@ -857,6 +855,18 @@ export class AcpRuntimeManager {
       await this.stopSessionOwner(previousOwner);
     }
     return true;
+  }
+
+  private canRetainPersistentSessionOwner(
+    owner: RuntimeSessionOwner,
+    record: SessionRecord,
+  ): boolean {
+    return (
+      owner.mode === "persistent" &&
+      !record.closed &&
+      !(owner.client.hasUnresolvedPrompt?.() ?? false) &&
+      owner.client.hasReusableSession(record.acpSessionId)
+    );
   }
 
   private async withRuntimeControlSession<T>(
@@ -891,6 +901,7 @@ export class AcpRuntimeManager {
       nonInteractivePermissions: this.options.nonInteractivePermissions,
       permissionPolicy: this.options.permissionPolicy,
       onPermissionRequest: this.options.onPermissionRequest,
+      elicitationModes: this.options.elicitationModes,
       verbose: this.options.verbose,
       timeoutMs: this.options.timeoutMs,
       resumePolicy: resumePolicyForSessionMode(sessionMode),
@@ -1058,6 +1069,7 @@ export class AcpRuntimeManager {
       nonInteractivePermissions: this.options.nonInteractivePermissions,
       permissionPolicy: this.options.permissionPolicy,
       onPermissionRequest: this.options.onPermissionRequest,
+      elicitationModes: this.options.elicitationModes,
       verbose: this.options.verbose,
       sessionOptions: input.sessionOptions,
     });
@@ -1169,6 +1181,7 @@ export class AcpRuntimeManager {
     requestId: string;
     timeoutMs?: number;
     signal?: AbortSignal;
+    onElicitation?: AcpElicitationHandler;
   }): AcpRuntimeTurn {
     let promptInput: PromptInput | string;
     try {
@@ -1293,15 +1306,7 @@ export class AcpRuntimeManager {
         };
       } else {
         await this.applyPendingRuntimeTurnCancel(task, turn);
-        const response = await runPromptTurn({
-          client: turn.client,
-          sessionId,
-          prompt: task.promptInput,
-          timeoutMs: task.input.timeoutMs ?? this.options.timeoutMs,
-          conversation: turn.conversation,
-          promptMessageId: turn.promptMessageId,
-          onPromptRequestStarted: () => task.promptStarted.resolve(),
-        });
+        const response = await this.runRuntimePrompt(task, turn, sessionId);
         await this.saveCompletedRuntimeTurn(turn, response.stopReason);
         terminalResult = {
           status: response.stopReason === "cancelled" ? "cancelled" : "completed",
@@ -1317,6 +1322,27 @@ export class AcpRuntimeManager {
       terminalResult = this.failRuntimeTurn(task, error);
     }
     task.settleResult(terminalResult);
+  }
+
+  private async runRuntimePrompt(
+    task: RuntimeTurnTask,
+    turn: RunningRuntimeTurn,
+    sessionId: string,
+  ): ReturnType<typeof runPromptTurn> {
+    try {
+      return await runPromptTurn({
+        client: turn.client,
+        sessionId,
+        prompt: task.promptInput,
+        timeoutMs: task.input.timeoutMs ?? this.options.timeoutMs,
+        conversation: turn.conversation,
+        promptMessageId: turn.promptMessageId,
+        onPromptRequestStarted: () => task.promptStarted.resolve(),
+        onElicitation: task.input.onElicitation,
+      });
+    } finally {
+      turn.client.endPromptElicitation?.(sessionId);
+    }
   }
 
   private async prepareRuntimeTurn(task: RuntimeTurnTask): Promise<RunningRuntimeTurn> {
@@ -1466,6 +1492,7 @@ export class AcpRuntimeManager {
       nonInteractivePermissions: this.options.nonInteractivePermissions,
       permissionPolicy: this.options.permissionPolicy,
       onPermissionRequest: this.options.onPermissionRequest,
+      elicitationModes: this.options.elicitationModes,
       verbose: this.options.verbose,
       sessionOptions: sessionOptionsFromRecord(record),
     });
@@ -1811,6 +1838,7 @@ export class AcpRuntimeManager {
     requestId: string;
     timeoutMs?: number;
     signal?: AbortSignal;
+    onElicitation?: AcpElicitationHandler;
   }): AsyncIterable<AcpRuntimeEvent> {
     const turn = this.startTurn(input);
     yield* turn.events;
@@ -2014,6 +2042,7 @@ export class AcpRuntimeManager {
         nonInteractivePermissions: this.options.nonInteractivePermissions,
         permissionPolicy: this.options.permissionPolicy,
         onPermissionRequest: this.options.onPermissionRequest,
+        elicitationModes: this.options.elicitationModes,
         verbose: this.options.verbose,
       }),
     };

--- a/src/runtime/engine/prompt-turn.ts
+++ b/src/runtime/engine/prompt-turn.ts
@@ -3,7 +3,12 @@ import {
   hasAgentReplyAfterPrompt,
   recordPromptResponseUsage,
 } from "../../session/conversation-model.js";
-import type { PromptInput, RunPromptResult, SessionConversation } from "../../types.js";
+import type {
+  AcpElicitationHandler,
+  PromptInput,
+  RunPromptResult,
+  SessionConversation,
+} from "../../types.js";
 
 const SESSION_REPLY_IDLE_MS = 1_000;
 const SESSION_REPLY_DRAIN_TIMEOUT_MS = 5_000;
@@ -13,6 +18,7 @@ type PromptTurnClient = {
     sessionId: string,
     prompt: PromptInput | string,
     onRequestStarted?: () => Promise<void> | void,
+    onElicitation?: AcpElicitationHandler,
   ) => Promise<{ stopReason: RunPromptResult["stopReason"]; usage?: unknown }>;
   waitForSessionUpdatesIdle?: (options?: { idleMs?: number; timeoutMs?: number }) => Promise<void>;
 };
@@ -26,12 +32,14 @@ export async function runPromptTurn(params: {
   promptMessageId?: string;
   onPromptRequestStarted?: () => Promise<void> | void;
   onPromptStarted?: () => Promise<void> | void;
+  onElicitation?: AcpElicitationHandler;
 }): Promise<{ stopReason: RunPromptResult["stopReason"]; source: "rpc" | "session" }> {
   try {
     const promptPromise = params.client.prompt(
       params.sessionId,
       params.prompt,
       params.onPromptRequestStarted,
+      params.onElicitation,
     );
     await params.onPromptStarted?.();
     const response = await withTimeout(promptPromise, params.timeoutMs);

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -1,5 +1,7 @@
 import type { ToolCallContent, ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
 import type {
+  AcpElicitationHandler,
+  AcpElicitationMode,
   AcpPermissionDecision,
   AcpPermissionRequest,
   McpServer,
@@ -12,7 +14,16 @@ import type { SessionAgentOptions } from "../engine/session-options.js";
 
 export type { SessionAgentOptions, SystemPromptOption } from "../engine/session-options.js";
 
-export type { AcpPermissionDecision, AcpPermissionRequest, PermissionPolicy } from "../../types.js";
+export type {
+  AcpElicitationHandler,
+  AcpElicitationMode,
+  AcpElicitationContext,
+  AcpElicitationRequest,
+  AcpElicitationResponse,
+  AcpPermissionDecision,
+  AcpPermissionRequest,
+  PermissionPolicy,
+} from "../../types.js";
 
 export type AcpRuntimePromptMode = "prompt" | "steer";
 
@@ -77,6 +88,8 @@ export type AcpRuntimeTurnInput = {
   requestId: string;
   timeoutMs?: number;
   signal?: AbortSignal;
+  /** Handles ACP elicitation requests owned by this prompt turn. */
+  onElicitation?: AcpElicitationHandler;
 };
 
 export type AcpRuntimeCapabilities = {
@@ -339,6 +352,8 @@ export type AcpRuntimeOptions = {
   timeoutMs?: number;
   probeAgent?: string;
   verbose?: boolean;
+  /** ACP elicitation modes the embedding host can render for prompt turns. */
+  elicitationModes?: readonly AcpElicitationMode[];
   onPermissionRequest?: (
     req: AcpPermissionRequest,
     ctx: { signal: AbortSignal },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 import type {
   AgentCapabilities,
   AnyMessage,
+  CreateElicitationRequest,
+  ElicitationContentValue,
+  JsonRpcId,
   McpServer,
   RequestPermissionRequest,
   SessionNotification,
@@ -25,6 +28,34 @@ export type AcpPermissionDecision =
   | { outcome: "reject_once" }
   | { outcome: "reject_always" }
   | { outcome: "cancel" };
+
+export const ACP_ELICITATION_MODES = ["form", "url"] as const;
+export type AcpElicitationMode = (typeof ACP_ELICITATION_MODES)[number];
+export type AcpElicitationRequest = CreateElicitationRequest;
+
+export type AcpElicitationContext = {
+  /** Exact JSON-RPC id of the outer `elicitation/create` request. */
+  requestId: JsonRpcId;
+  /** Aborts with the request itself or its owning prompt turn/session. */
+  signal: AbortSignal;
+};
+
+type AcpElicitationResponseMeta = {
+  _meta?: Record<string, unknown> | null;
+};
+
+export type AcpElicitationResponse =
+  | ({
+      action: "accept";
+      content?: Record<string, ElicitationContentValue> | null;
+    } & AcpElicitationResponseMeta)
+  | ({ action: "decline" } & AcpElicitationResponseMeta)
+  | ({ action: "cancel" } & AcpElicitationResponseMeta);
+
+export type AcpElicitationHandler = (
+  request: AcpElicitationRequest,
+  context: AcpElicitationContext,
+) => Promise<AcpElicitationResponse>;
 
 export const EXIT_CODES = {
   SUCCESS: 0,
@@ -212,6 +243,7 @@ export type AcpClientOptions = {
   authPolicy?: AuthPolicy;
   fs?: boolean;
   terminal?: boolean;
+  elicitationModes?: readonly AcpElicitationMode[];
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   sessionOptions?: {

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import {
   AgentSideConnection,
+  type AnyMessage,
   type CloseSessionRequest,
   type CloseSessionResponse,
   PROTOCOL_VERSION,
@@ -14,7 +15,11 @@ import {
   type Agent,
   type AgentSideConnection as AgentConnection,
   type ContentBlock,
+  type CreateElicitationRequest,
+  type CreateElicitationResponse,
+  type InitializeRequest,
   type InitializeResponse,
+  type JsonRpcId,
   type ListSessionsRequest,
   type ListSessionsResponse,
   type LoadSessionRequest,
@@ -31,12 +36,15 @@ import {
   type SetSessionModeRequest,
   type SetSessionModeResponse,
   type SessionInfo,
+  methods,
 } from "@agentclientprotocol/sdk";
 
 type ParsedCommand = {
   command: string;
   args: string[];
 };
+
+let activePromptRequestId: JsonRpcId | undefined;
 
 type MockAgentOptions = {
   hangOnNewSession: boolean;
@@ -69,6 +77,7 @@ type MockAgentOptions = {
   loadReplayText: string;
   ignoreSigterm: boolean;
   cancelDelayMs: number;
+  elicitOnNewSession: boolean;
   /** If set, the agent writes its PID to this path at startup (before ACP handshake). */
   pidFile?: string;
 };
@@ -80,6 +89,7 @@ type SessionState = {
   configValues: Record<string, string | boolean>;
   transientPromptAttempts: Record<string, number>;
   modelId: string;
+  lastElicitationResponse?: CreateElicitationResponse;
 };
 
 class CancelledError extends Error {
@@ -129,6 +139,16 @@ function getPromptText(prompt: ContentBlock[]): string {
   }
 
   return parts.join("").trim();
+}
+
+function formSchema() {
+  return {
+    type: "object" as const,
+    properties: {
+      answer: { type: "string" as const },
+    },
+    required: ["answer"],
+  };
 }
 
 function describePromptBlocks(prompt: ContentBlock[]): string {
@@ -381,6 +401,7 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let ignoreSigterm = false;
   let cancelDelayMs = 0;
   let hangOnNewSession = false;
+  let elicitOnNewSession = false;
   let pidFile: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -531,6 +552,11 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
       continue;
     }
 
+    if (token === "--elicit-on-new-session") {
+      elicitOnNewSession = true;
+      continue;
+    }
+
     if (token === "--pid-file") {
       pidFile = parseOptionValue(argv, index + 1, token);
       index += 1;
@@ -604,6 +630,7 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     loadReplayText,
     ignoreSigterm,
     cancelDelayMs,
+    elicitOnNewSession,
     pidFile,
   };
 }
@@ -749,13 +776,15 @@ class MockAgent implements Agent {
   private readonly connection: AgentConnection;
   private readonly sessions = new Map<SessionId, SessionState>();
   private readonly options: MockAgentOptions;
+  private clientCapabilities?: InitializeRequest["clientCapabilities"];
 
   constructor(connection: AgentConnection, options: MockAgentOptions) {
     this.connection = connection;
     this.options = options;
   }
 
-  async initialize(): Promise<InitializeResponse> {
+  async initialize(params: InitializeRequest): Promise<InitializeResponse> {
+    this.clientCapabilities = structuredClone(params.clientCapabilities);
     const sessionCapabilities = {
       ...(this.options.supportsCloseSession ? { close: {} } : {}),
       ...(this.options.supportsListSessions ? { list: {} } : {}),
@@ -787,6 +816,16 @@ class MockAgent implements Agent {
 
     const sessionId = randomUUID();
     this.sessions.set(sessionId, createSessionState(false));
+
+    if (this.options.elicitOnNewSession) {
+      const response = await this.connection.request(methods.client.elicitation.create, {
+        mode: "form",
+        requestId: "session-new",
+        message: "Configure the session",
+        requestedSchema: formSchema(),
+      });
+      this.ensureSession(sessionId).lastElicitationResponse = response;
+    }
 
     const response: NewSessionResponse = { sessionId };
 
@@ -1204,6 +1243,14 @@ class MockAgent implements Agent {
       return "recovered after retry";
     }
 
+    if (text === "client-capabilities") {
+      return JSON.stringify(this.clientCapabilities);
+    }
+
+    if (text.startsWith("elicitation ")) {
+      return await this.handleElicitation(sessionId, text.slice("elicitation ".length), signal);
+    }
+
     if (text.startsWith("extension-notification ")) {
       const rest = text.slice("extension-notification ".length).trim();
       const firstSpace = rest.search(/\s/);
@@ -1436,6 +1483,94 @@ class MockAgent implements Agent {
     return `unrecognized prompt: ${text}`;
   }
 
+  private async handleElicitation(
+    sessionId: SessionId,
+    command: string,
+    signal: AbortSignal,
+  ): Promise<string> {
+    if (command === "complete") {
+      await this.connection.unstable_completeElicitation({
+        elicitationId: "elicitation-123",
+      });
+      return "elicitation complete accepted";
+    }
+
+    if (command === "last-response") {
+      return JSON.stringify(this.ensureSession(sessionId).lastElicitationResponse ?? null);
+    }
+
+    const request: CreateElicitationRequest =
+      command === "request-scoped"
+        ? {
+            mode: "form",
+            requestId: activePromptRequestId ?? "missing-prompt-request",
+            message: "Choose a value",
+            requestedSchema: formSchema(),
+          }
+        : command === "mismatched-session"
+          ? {
+              mode: "form",
+              sessionId: "wrong-session",
+              toolCallId: "tool-123",
+              message: "Choose a value",
+              requestedSchema: formSchema(),
+            }
+          : command === "custom-mode"
+            ? {
+                mode: "future-mode",
+                sessionId,
+                message: "Choose a value",
+              }
+            : {
+                mode: command === "url" ? "url" : "form",
+                sessionId,
+                toolCallId: "tool-123",
+                message: "Choose a value",
+                ...(command === "url"
+                  ? { elicitationId: "elicitation-123", url: "https://example.invalid/input" }
+                  : { requestedSchema: formSchema() }),
+              };
+
+    if (command === "late") {
+      void this.connection.request(methods.client.elicitation.create, request).then((response) => {
+        this.ensureSession(sessionId).lastElicitationResponse = response;
+      });
+      return "elicitation dispatched";
+    }
+
+    if (command === "timeout-late") {
+      void this.connection.request(methods.client.elicitation.create, request).then((response) => {
+        this.ensureSession(sessionId).lastElicitationResponse = response;
+      });
+      await sleepWithCancel(5_000, signal);
+      return "elicitation timeout completed";
+    }
+
+    if (command === "request-cancel") {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 30);
+      try {
+        const response = await this.connection.request(methods.client.elicitation.create, request, {
+          cancellationSignal: controller.signal,
+        });
+        return `elicitation request completed:${JSON.stringify(response)}:aborted:${controller.signal.aborted}`;
+      } catch {
+        return `elicitation request cancelled:${controller.signal.aborted}`;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    const response = await this.connection.request(methods.client.elicitation.create, request, {
+      cancellationSignal: signal,
+    });
+    this.ensureSession(sessionId).lastElicitationResponse = response;
+    if (command === "form-no-echo") {
+      return `elicitation ${response.action}`;
+    }
+    return JSON.stringify(response);
+  }
+
   private async runTerminalCommand(
     sessionId: SessionId,
     rawCommand: string,
@@ -1507,7 +1642,30 @@ class MockAgent implements Agent {
 
 const output = Writable.toWeb(process.stdout);
 const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
-const stream = ndJsonStream(output, input);
+const baseStream = ndJsonStream(output, input);
+const stream = {
+  readable: new ReadableStream<AnyMessage>({
+    async start(controller) {
+      const reader = baseStream.readable.getReader();
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            break;
+          }
+          if ("method" in value && value.method === methods.agent.session.prompt && "id" in value) {
+            activePromptRequestId = value.id;
+          }
+          controller.enqueue(value);
+        }
+      } finally {
+        reader.releaseLock();
+        controller.close();
+      }
+    },
+  }),
+  writable: baseStream.writable,
+};
 const mockAgentOptions = parseMockAgentOptions(process.argv.slice(2));
 
 // Write PID to a file before doing anything else so that the parent can track

--- a/test/runtime-elicitation.test.ts
+++ b/test/runtime-elicitation.test.ts
@@ -1,0 +1,388 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import type { AnyMessage, JsonRpcId } from "@agentclientprotocol/sdk";
+import { AcpClient } from "../src/acp/client.js";
+import {
+  createAcpRuntime,
+  createAgentRegistry,
+  createFileSessionStore,
+  type AcpElicitationHandler,
+  type AcpElicitationResponse,
+  type AcpRuntimeOptions,
+  type AcpRuntimeTurnInput,
+  type AcpRuntimeEvent,
+} from "../src/runtime.js";
+
+const MOCK_AGENT_PATH = fileURLToPath(new URL("./mock-agent.js", import.meta.url));
+
+type ExpectedElicitationHandler = AcpElicitationHandler;
+
+type RuntimeOptionsWithElicitation = AcpRuntimeOptions & {
+  elicitationModes?: readonly ("form" | "url")[];
+};
+
+type TurnInputWithElicitation = AcpRuntimeTurnInput & {
+  onElicitation?: ExpectedElicitationHandler;
+};
+
+async function withRuntime(
+  modes: readonly ("form" | "url")[] | undefined,
+  run: (context: {
+    runtime: ReturnType<typeof createAcpRuntime>;
+    handle: Awaited<ReturnType<ReturnType<typeof createAcpRuntime>["ensureSession"]>>;
+  }) => Promise<void>,
+  mockAgentArgs: string[] = [],
+): Promise<void> {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-runtime-elicitation-"));
+  const options: RuntimeOptionsWithElicitation = {
+    cwd: rootDir,
+    sessionStore: createFileSessionStore({ stateDir: path.join(rootDir, "state") }),
+    agentRegistry: createAgentRegistry({
+      overrides: {
+        fixture: [process.execPath, MOCK_AGENT_PATH, "--supports-close-session", ...mockAgentArgs],
+      },
+    }),
+    permissionMode: "approve-reads",
+    ...(modes ? { elicitationModes: modes } : {}),
+  };
+  const runtime = createAcpRuntime(options);
+  const handle = await runtime.ensureSession({
+    sessionKey: "elicitation-test",
+    agent: "fixture",
+    mode: "persistent",
+  });
+  try {
+    await run({ runtime, handle });
+  } finally {
+    await runtime.close({ handle, reason: "test complete", discardPersistentState: true });
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+async function runTurn(
+  runtime: ReturnType<typeof createAcpRuntime>,
+  input: TurnInputWithElicitation,
+): Promise<{ text: string; status: string }> {
+  const turn = runtime.startTurn(input);
+  const events: AcpRuntimeEvent[] = [];
+  for await (const event of turn.events) {
+    events.push(event);
+  }
+  const result = await turn.result;
+  const text = events
+    .filter((event): event is Extract<AcpRuntimeEvent, { type: "text_delta" }> => {
+      return event.type === "text_delta";
+    })
+    .map((event) => event.text)
+    .join("");
+  return { text, status: result.status };
+}
+
+function turnInput(
+  handle: TurnInputWithElicitation["handle"],
+  text: string,
+  onElicitation?: ExpectedElicitationHandler,
+): TurnInputWithElicitation {
+  return {
+    handle,
+    text,
+    mode: "prompt",
+    requestId: `request-${text}`,
+    ...(onElicitation ? { onElicitation } : {}),
+  };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
+test("runtime advertises only configured elicitation modes", async () => {
+  await withRuntime(undefined, async ({ runtime, handle }) => {
+    const result = await runTurn(runtime, turnInput(handle, "client-capabilities"));
+    const capabilities = JSON.parse(result.text) as { elicitation?: unknown };
+    assert.equal(capabilities.elicitation, undefined);
+  });
+
+  await withRuntime(["form", "url"], async ({ runtime, handle }) => {
+    const result = await runTurn(runtime, turnInput(handle, "client-capabilities"));
+    const capabilities = JSON.parse(result.text) as { elicitation?: unknown };
+    assert.deepEqual(capabilities.elicitation, { form: {}, url: {} });
+  });
+});
+
+test("runtime routes form elicitation context and known responses", async (t) => {
+  await withRuntime(["form"], async ({ runtime, handle }) => {
+    for (const response of [
+      { action: "accept", content: { answer: "yes" } },
+      { action: "decline" },
+      { action: "cancel" },
+    ] satisfies AcpElicitationResponse[]) {
+      await t.test(response.action, async () => {
+        let seenRequestId: JsonRpcId | undefined;
+        const result = await runTurn(
+          runtime,
+          turnInput(handle, "elicitation form", async (request, context) => {
+            seenRequestId = context.requestId;
+            assert.equal(context.signal.aborted, false);
+            assert.equal(request.mode, "form");
+            assert.equal(
+              "sessionId" in request ? request.sessionId : undefined,
+              handle.backendSessionId,
+            );
+            assert.equal("toolCallId" in request ? request.toolCallId : undefined, "tool-123");
+            return response;
+          }),
+        );
+        assert.equal(result.status, "completed");
+        assert.deepEqual(JSON.parse(result.text), response);
+        assert.notEqual(seenRequestId, undefined);
+      });
+    }
+  });
+});
+
+test("runtime routes request-scoped elicitation owned by the active prompt", async () => {
+  await withRuntime(["form"], async ({ runtime, handle }) => {
+    let promptRequestId: JsonRpcId | undefined;
+    let elicitationRequestId: JsonRpcId | undefined;
+    const result = await runTurn(
+      runtime,
+      turnInput(handle, "elicitation request-scoped", async (request, context) => {
+        const scopedId = "requestId" in request ? request.requestId : undefined;
+        if (scopedId === null || typeof scopedId === "string" || typeof scopedId === "number") {
+          promptRequestId = scopedId;
+        }
+        elicitationRequestId = context.requestId;
+        return { action: "decline" };
+      }),
+    );
+    assert.deepEqual(JSON.parse(result.text), { action: "decline" });
+    assert.notEqual(promptRequestId, undefined);
+    assert.notEqual(elicitationRequestId, undefined);
+    assert.notEqual(promptRequestId, elicitationRequestId);
+  });
+});
+
+test("runtime combines exact request and session cancellation signals", async () => {
+  await withRuntime(["form"], async ({ runtime, handle }) => {
+    let exactSignalAborted = false;
+    const requestCancelled = await runTurn(
+      runtime,
+      turnInput(handle, "elicitation request-cancel", async (_request, context) => {
+        await new Promise<void>((resolve) => {
+          context.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        exactSignalAborted = context.signal.aborted;
+        return { action: "accept", content: { ignored: true } };
+      }),
+    );
+    assert.equal(await waitFor(() => exactSignalAborted), true);
+    assert.match(requestCancelled.text, /"action":"cancel"/);
+    assert.match(requestCancelled.text, /aborted:true/);
+
+    let turnSignalAborted = false;
+    const turn = runtime.startTurn(
+      turnInput(handle, "elicitation form", async (_request, context) => {
+        await new Promise<void>((resolve) => {
+          context.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        turnSignalAborted = context.signal.aborted;
+        return { action: "accept", content: { ignored: true } };
+      }),
+    );
+    await turn.promptStarted;
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+    await turn.cancel();
+    for await (const event of turn.events) {
+      void event;
+    }
+    await turn.result;
+    assert.equal(await waitFor(() => turnSignalAborted), true);
+  });
+});
+
+test("runtime suppresses stale handler resolutions after prompt completion", async () => {
+  await withRuntime(["form"], async ({ runtime, handle }) => {
+    let resolveHandler!: (response: AcpElicitationResponse) => void;
+    let handlerStarted = false;
+    const handlerResponse = new Promise<AcpElicitationResponse>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const dispatched = await runTurn(
+      runtime,
+      turnInput(handle, "elicitation late", async () => {
+        handlerStarted = true;
+        return await handlerResponse;
+      }),
+    );
+    assert.equal(dispatched.status, "completed");
+    assert.equal(await waitFor(() => handlerStarted), true);
+    resolveHandler({ action: "accept", content: { stale: true } });
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+    const observed = await runTurn(runtime, turnInput(handle, "elicitation last-response"));
+    assert.deepEqual(JSON.parse(observed.text), {
+      action: "cancel",
+      _meta: { message: "elicitation owner is no longer active" },
+    });
+  });
+});
+
+test("runtime aborts the elicitation owner when a turn times out", async () => {
+  await withRuntime(
+    ["form"],
+    async ({ runtime, handle }) => {
+      let resolveHandler!: (response: AcpElicitationResponse) => void;
+      let handlerStarted = false;
+      let handlerAborted = false;
+      const handlerResponse = new Promise<AcpElicitationResponse>((resolve) => {
+        resolveHandler = resolve;
+      });
+      const timedOut = await runTurn(runtime, {
+        ...turnInput(handle, "elicitation timeout-late", async (_request, context) => {
+          handlerStarted = true;
+          context.signal.addEventListener(
+            "abort",
+            () => {
+              handlerAborted = true;
+            },
+            { once: true },
+          );
+          return await handlerResponse;
+        }),
+        timeoutMs: 50,
+      });
+      assert.equal(timedOut.status, "failed");
+      assert.equal(handlerStarted, true);
+      assert.equal(await waitFor(() => handlerAborted), true);
+
+      resolveHandler({ action: "accept", content: { stale: true } });
+      const nextTurn = await runTurn(runtime, turnInput(handle, "echo after timeout"));
+      assert.deepEqual(nextTurn, { status: "completed", text: "after timeout" });
+    },
+    ["--supports-load-session"],
+  );
+});
+
+test("runtime explicitly cancels unsupported or unauthorised elicitations", async () => {
+  await withRuntime(["form"], async ({ runtime, handle }) => {
+    const cases = [
+      ["elicitation form", "elicitation handler is unavailable", false],
+      ["elicitation mismatched-session", "elicitation session is not active", true],
+      ["elicitation custom-mode", "elicitation mode is not supported", true],
+    ] as const;
+    for (const [prompt, message, passHandler] of cases) {
+      const result = await runTurn(
+        runtime,
+        turnInput(
+          handle,
+          prompt,
+          passHandler
+            ? async () => {
+                assert.fail("handler must not run");
+              }
+            : undefined,
+        ),
+      );
+      assert.deepEqual(JSON.parse(result.text), {
+        action: "cancel",
+        _meta: { message },
+      });
+    }
+
+    const failed = await runTurn(
+      runtime,
+      turnInput(handle, "elicitation form", async () => {
+        throw new Error("host UI failed with private form data");
+      }),
+    );
+    assert.deepEqual(JSON.parse(failed.text), {
+      action: "cancel",
+      _meta: { message: "elicitation handler is unavailable" },
+    });
+  });
+});
+
+test("runtime cancels request-scoped elicitation without an active owner", async () => {
+  await withRuntime(
+    ["form"],
+    async ({ runtime, handle }) => {
+      const observed = await runTurn(runtime, turnInput(handle, "elicitation last-response"));
+      assert.deepEqual(JSON.parse(observed.text), {
+        action: "cancel",
+        _meta: { message: "elicitation owner is no longer active" },
+      });
+    },
+    ["--elicit-on-new-session"],
+  );
+});
+
+test("runtime accepts elicitation complete notifications", async () => {
+  await withRuntime(["url"], async ({ runtime, handle }) => {
+    const result = await runTurn(runtime, turnInput(handle, "elicitation complete"));
+    assert.equal(result.status, "completed");
+    assert.equal(result.text, "elicitation complete accepted");
+  });
+});
+
+test("client taps omit elicitation forms and answers", async () => {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-elicitation-tap-"));
+  const tapped: AnyMessage[] = [];
+  const client = new AcpClient({
+    agentCommand: process.execPath,
+    agentArgv: [process.execPath, MOCK_AGENT_PATH],
+    cwd: rootDir,
+    permissionMode: "approve-reads",
+    elicitationModes: ["form"],
+    onAcpMessage: (_direction, message) => tapped.push(message),
+  });
+  try {
+    await client.start();
+    const session = await client.createSession();
+    await client.prompt(session.sessionId, "elicitation form-no-echo", undefined, async () => ({
+      action: "accept",
+      content: { answer: "sensitive-answer" },
+    }));
+    await client.cancel(session.sessionId);
+    let postCancelHandled = false;
+    await client.prompt(session.sessionId, "elicitation form-no-echo", undefined, async () => {
+      postCancelHandled = true;
+      return { action: "accept", content: { answer: "after-idle-cancel" } };
+    });
+    assert.equal(postCancelHandled, true);
+    await client.prompt(
+      session.sessionId,
+      "elicitation request-cancel",
+      undefined,
+      async (_request, context) => {
+        await new Promise<void>((resolve) => {
+          context.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return { action: "cancel" };
+      },
+    );
+  } finally {
+    await client.close();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+
+  const serialized = JSON.stringify(tapped);
+  assert.doesNotMatch(serialized, /Choose a value/);
+  assert.doesNotMatch(serialized, /sensitive-answer/);
+  assert.doesNotMatch(serialized, /after-idle-cancel/);
+  assert.equal(
+    tapped.some((message) => "method" in message && message.method === "$/cancel_request"),
+    true,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where embedding clients could not handle current ACP form or URL elicitation requests. Agents such as Codex would see no advertised elicitation capability, so `request_user_input` returned empty answers and dependency prompts could silently skip instead of reaching the operator.

## Why This Change Was Made

The runtime now exposes an optional turn-scoped elicitation handler and advertises only the modes the embedding host declares it can render. The ACP connection uses the SDK's modern client handler API so exact JSON-RPC request cancellation, session ownership, prompt replacement, timeout, and late-response fencing stay bound to the active turn. Unsupported, stale, mismatched, and unavailable requests return explicit bounded cancellation outcomes rather than fabricated success.

The connection remains one canonical path; this does not add an adapter-specific Codex layer to acpx.

## User Impact

Embedding hosts can now support structured form and URL prompts from ACP agents without losing correlation or silently returning empty input. Existing clients that do not configure elicitation modes continue to advertise no elicitation capability and retain their previous behavior.

## Evidence

Pre-fix regression:

- `runtime advertises only configured elicitation modes` expected `{ form: {}, url: {} }` but received no elicitation capability.

Validation:

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run format:check`
- `pnpm run build:test && node --test dist-test/test/runtime-elicitation.test.js` — 13/13 passed
- Focused elicitation/runtime-manager boundary suite — 73 passed
- Existing client suite — 51 passed
- Relevant real CLI integration suite — 10 passed
- Autoreview: clean, no accepted/actionable findings

A broad `pnpm run test` attempt reached 837/845 passing tests; eight unrelated fixed child-process timeout cases failed under concurrent host saturation. Their affected focused suites passed when rerun.

AI-assisted implementation; the code and lifecycle boundaries were reviewed directly against `@agentclientprotocol/sdk@1.3.0` and current Codex ACP behavior.