### PR TITLE
refactor(session): drop unused RUNTIME_SESSION_ID_META_KEYS alias

### DIFF
--- a/src/session/runtime-session-id.ts
+++ b/src/session/runtime-session-id.ts
@@ -1,10 +1,4 @@
-import {
-  AGENT_SESSION_ID_META_KEYS,
-  extractAgentSessionId,
-  normalizeAgentSessionId,
-} from "../acp/agent-session-id.js";
-
-export const RUNTIME_SESSION_ID_META_KEYS = AGENT_SESSION_ID_META_KEYS;
+import { extractAgentSessionId, normalizeAgentSessionId } from "../acp/agent-session-id.js";
 
 export function normalizeRuntimeSessionId(value: unknown): string | undefined {
   return normalizeAgentSessionId(value);


### PR DESCRIPTION
## What Problem This Solves

`src/session/runtime-session-id.ts` exported `RUNTIME_SESSION_ID_META_KEYS`, a bare re-alias of `AGENT_SESSION_ID_META_KEYS` (`export const RUNTIME_SESSION_ID_META_KEYS = AGENT_SESSION_ID_META_KEYS;`). Nothing referenced it — a repo-wide search (`src`, `test`, `conformance`, `docs`, `scripts`) finds the symbol only at its own definition, and it is not part of the published API surface: the package builds `src/cli.ts`, `src/flows.ts`, and `src/runtime.ts`, and none of those graphs re-export it (no `export *` barrel carries it). It is dead code that also forced `runtime-session-id.ts` to import `AGENT_SESSION_ID_META_KEYS` solely to alias it.

## Why This Change Was Made

Debt cleanup (family: dead-code removal). Remove the unused exported alias and its now-unnecessary import binding. The live sibling helpers in the same file — `normalizeRuntimeSessionId` / `extractRuntimeSessionId` (the "runtime" wrappers actually consumed across `src/acp/client.ts`, `src/cli/output/render.ts`, `src/session/persistence/*`, etc.) — are untouched, as is the `AGENT_SESSION_ID_META_KEYS` export in `src/acp/agent-session-id.js` (still used internally at `agent-session-id.ts:25` and asserted by `test/agent-session-id.test.ts`). Behavior-preserving, single production file, net **−6** lines.

## User Impact

None. No runtime, CLI, config, or public-API behavior changes — the removed symbol was reachable from nothing (unexported from the public entry graphs, referenced nowhere). The `.d.ts` output is unaffected because the alias was never in the `cli`/`flows`/`runtime` entry surface.

## Evidence

Branched off current `main` (`2d735cf`), Linux, Node 22, `pnpm install --frozen-lockfile`.

- **Dead-symbol proof** — `git grep RUNTIME_SESSION_ID_META_KEYS` returns only `src/session/runtime-session-id.ts:7` (the definition) before the change, and **0 hits** after.
- **No dangling reference** — `pnpm run typecheck` (`tsc --noEmit`) → **exit 0**.
- `pnpm run lint` (`oxlint --type-aware --deny-warnings src …`) → **exit 0** (confirms the import cleanup leaves no unused binding).
- `oxfmt --check src/session/runtime-session-id.ts` → clean.
- `pnpm run build` (tsdown, `--dts`) → **exit 0**.
- **Full test suite** (`pnpm run build && build:test && node --test dist-test/test/*.test.js`) → **935 pass, 0 fail** on this branch. The removed symbol had no test, so the count matches `main`; behavior is preserved and `test/agent-session-id.test.ts` (which asserts on `AGENT_SESSION_ID_META_KEYS`) still passes.

Diff: **+1 / −7, 1 file**. Same shape as the merged dead-export cleanup #457.

_AI-assisted contribution._

---
_Generated by [Claude Code](https://claude.ai/code/session_01WE91LpE6SzwbA6F31i3uGy)_