### PR TITLE
fix: reconcile accepted session controls after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Repo: https://github.com/openclaw/acpx
 ### Fixes
 
 - Docs/JSON: fix raw ACP tool-call pipelines and message examples so automation reads nested session updates and handles partial tool updates. Fixes #520. Thanks @prateek.
+- Session controls: restore saved model/config selections after reconnect, keep reasoning effort aligned with accepted model changes, and return accepted configuration to embedded clients without pinning unselected defaults. Thanks @programmerlapar.
 
 ## 2026.8.18 (v0.13.1)
 

--- a/agents/Claude.md
+++ b/agents/Claude.md
@@ -4,6 +4,8 @@
 - Default command: `npx -y @agentclientprotocol/claude-agent-acp`
 - Upstream: https://github.com/agentclientprotocol/claude-agent-acp
 - ACPX pins the built-in package range so fresh installs pick up Claude model and ACP adapter fixes without depending on a global adapter binary.
+- Model switches can change the available effort controls. ACPX updates existing saved effort selections from the accepted response and removes selections whose controls disappear.
+- Saved model and config selections are restored after reconnect, without replacing the conversation.
 
 ## Settings isolation
 

--- a/agents/Codex.md
+++ b/agents/Codex.md
@@ -6,4 +6,6 @@
 - ACPX owns the built-in package range so fresh launches use the repository-selected stable adapter line without requiring a global install.
 - Runtime controls exposed by current codex-acp releases include ACP modes plus separate `model` and `reasoning_effort` session config options.
 - Use the advertised base model id with `acpx --model <id> codex ...` or `acpx codex set model <id>`, then set reasoning effort separately with `acpx codex set reasoning_effort <value>`.
+- Switching models can adjust reasoning effort. ACPX saves the accepted effort for an existing selection, or removes that selection if the new model has no effort control.
+- Reconnecting restores the saved model and effort before prompting, even when the adapter resumes the conversation with different defaults.
 - Legacy `models` metadata may encode both values in a combined id such as `gpt-5.6-sol[max]`; ACPX uses that form only when the adapter does not advertise the newer model config option.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -322,6 +322,8 @@ Behavior:
 - Routes through queue-owner IPC when an owner is active.
 - Falls back to a direct client reconnect when no owner is running.
 - **`set model <id>`**: Uses the advertised model config option through `session/set_config_option`; adapters that explicitly advertise legacy `models` metadata use `session/set_model`.
+- Saves accepted values for existing non-mode selections, including reasoning effort adjusted or removed by a model switch; does not pin unselected defaults.
+- Restores saved model and config selections after reconnect, before the next prompt; already loaded sessions are reused without replay.
 
 ## `sessions` subcommand
 

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -48,7 +48,11 @@ acpx claude set verbosity terse
 acpx set model gpt-5.4         # defaults to codex
 ```
 
-Calls ACP `session/set_config_option` with the literal `<key>` and `<value>`. Non-mode `set_config_option` values are persisted by `acpx` and replayed onto fresh adapter sessions when the adapter supports those config keys.
+Calls ACP `session/set_config_option` with the literal `<key>` and `<value>`. Non-mode selections are saved using the adapter's accepted values and restored after reconnect, before the next prompt. If a control changes another saved selection, such as reasoning effort after a model switch, ACPX saves the adjusted value or removes the selection when its control disappears. Unselected defaults are not pinned.
+
+After a genuine resume or load, ACPX restores the saved model first when the adapter advertises model controls, then replays saved configuration. An already loaded, reusable session needs no replay. A failed replay stops the operation with an error instead of silently continuing with defaults.
+
+For applications using `acpx/runtime`, `AcpxRuntime.setConfigOption(...)` returns the ACP response's complete `configOptions` after saving the accepted state. Use that response to update displayed controls, including changed or removed sibling options.
 
 ### `set model <id>`
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -189,6 +189,8 @@ Behavior:
 - Current codex-acp releases expose `model` and `reasoning_effort` as separate config options.
 - `--model <id>`: Claude-compatible adapters may consume session creation metadata; other agents must advertise a model config option or legacy `models` metadata.
 - `set model <id>`: uses `session/set_config_option` for advertised model config options and preserves `session/set_model` for explicitly advertised legacy models.
+- Model switches can change or remove reasoning-effort controls. ACPX reconciles saved non-mode selections with the accepted response; select a supported effort again if needed.
+- After reconnect, ACPX restores the saved model when advertised and replays saved config selections before prompting. A replay failure is reported instead of silently using defaults.
 - `set-mode`/`set` route through queue-owner IPC when active, otherwise reconnect directly.
 
 ### Sessions

--- a/src/cli/session/prompt-runner.ts
+++ b/src/cli/session/prompt-runner.ts
@@ -1,4 +1,3 @@
-import type { AcpClient } from "../../acp/client.js";
 import { withTimeout } from "../../async-control.js";
 import {
   withConnectedSession,
@@ -6,25 +5,14 @@ import {
   type WithConnectedSessionOptions,
   type WithConnectedSessionResult,
 } from "../../runtime/engine/connected-session.js";
-import { sessionOptionsFromRecord } from "../../runtime/engine/session-options.js";
-import { applyConfigOptionsToRecord } from "../../session/config-options.js";
-import {
-  setCurrentModelId,
-  setDesiredConfigOption,
-  setDesiredModeId,
-  setDesiredModelId,
-} from "../../session/mode-preference.js";
-import {
-  applyRequestedModelIfAdvertised,
-  currentModelIdFromSetModelResponse,
-} from "../../session/model-application.js";
+import { applyConfigOptionSelection, applyModelSelection } from "../../session/config-options.js";
+import { setDesiredModeId } from "../../session/mode-preference.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import { resolveSessionRecord, writeSessionRecord } from "../../session/persistence.js";
 import type {
   AuthPolicy,
   McpServer,
   NonInteractivePermissionPolicy,
-  SessionRecord,
   SessionSetConfigOptionResult,
   SessionSetModelResult,
   SessionSetModeResult,
@@ -81,6 +69,7 @@ export type RunSessionSetModelDirectOptions = {
 
 type DirectConnectedSessionOptions = {
   sessionRecordId: string;
+  replacingConfigOption?: WithConnectedSessionOptions<unknown>["replacingConfigOption"];
   mcpServers?: McpServer[];
   nonInteractivePermissions?: NonInteractivePermissionPolicy;
   authCredentials?: Record<string, string>;
@@ -99,6 +88,7 @@ function buildDirectConnectedSessionOptions<T>(
 ): WithConnectedSessionOptions<T> {
   return {
     sessionRecordId: options.sessionRecordId,
+    replacingConfigOption: options.replacingConfigOption,
     loadRecord: resolveSessionRecord,
     saveRecord: writeSessionRecord,
     mcpServers: options.mcpServers,
@@ -127,64 +117,11 @@ function toSessionMutationResult(
   };
 }
 
-/**
- * Re-apply the session-pinned model after reconnect, matching the prompt path.
- *
- * Some agents (e.g. opencode) restore to their default model on session load and
- * advertise model-dependent config options for that default. Without replaying
- * `session_options.model` first, `set` fails because the option set belongs to
- * the wrong model, and the record is overwritten with default-model options.
- */
-async function reapplyPinnedModelAfterConnect(params: {
-  client: AcpClient;
-  sessionId: string;
-  record: SessionRecord;
-  timeoutMs?: number;
-}): Promise<void> {
-  const pinnedModel = sessionOptionsFromRecord(params.record)?.model;
-  if (!pinnedModel) {
-    return;
-  }
-
-  const models = advertisedModelState(params.record.acpx);
-  if (models?.currentModelId === pinnedModel) {
-    // Keep the pin sticky when the agent already reports it after load.
-    setDesiredModelId(params.record, pinnedModel, models.configId);
-    setCurrentModelId(params.record, pinnedModel);
-    return;
-  }
-
-  const result = await applyRequestedModelIfAdvertised({
-    client: params.client,
-    sessionId: params.sessionId,
-    requestedModel: pinnedModel,
-    models,
-    agentCommand: params.record.agentCommand,
-    timeoutMs: params.timeoutMs,
-  });
-  if (result.response) {
-    applyConfigOptionsToRecord(params.record, result.response);
-  }
-  if (result.applied) {
-    setDesiredModelId(params.record, pinnedModel, models?.configId);
-    setCurrentModelId(
-      params.record,
-      currentModelIdFromSetModelResponse(result.response, pinnedModel),
-    );
-  }
-}
-
 export async function runSessionSetModeDirect(
   options: RunSessionSetModeDirectOptions,
 ): Promise<SessionSetModeResult> {
   const result = await withConnectedSession(
     buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
-      await reapplyPinnedModelAfterConnect({
-        client,
-        sessionId,
-        record,
-        timeoutMs: options.timeoutMs,
-      });
       await withTimeout(client.setSessionMode(sessionId, options.modeId), options.timeoutMs);
       setDesiredModeId(record, options.modeId);
     }),
@@ -197,19 +134,18 @@ export async function runSessionSetModelDirect(
   options: RunSessionSetModelDirectOptions,
 ): Promise<SessionSetModelResult> {
   const result = await withConnectedSession(
-    buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
-      // Explicit model switch replaces the saved pin. Do not re-apply the old
-      // pin first: an unadvertised saved model would reject and block the switch.
-      const models = advertisedModelState(record.acpx);
-      const response = await withTimeout(
-        client.setSessionModel(sessionId, options.modelId, models),
-        options.timeoutMs,
-      );
-      applyConfigOptionsToRecord(record, response);
-      setDesiredModelId(record, options.modelId, models?.configId);
-      setCurrentModelId(record, currentModelIdFromSetModelResponse(response, options.modelId));
-      return response;
-    }),
+    buildDirectConnectedSessionOptions(
+      { ...options, replacingConfigOption: { key: "model" } },
+      async ({ client, sessionId, record }) => {
+        const models = advertisedModelState(record.acpx);
+        const response = await withTimeout(
+          client.setSessionModel(sessionId, options.modelId, models),
+          options.timeoutMs,
+        );
+        record.acpx = applyModelSelection(record.acpx, options.modelId, response);
+        return response;
+      },
+    ),
   );
 
   return { ...toSessionMutationResult(result), response: result.value };
@@ -219,34 +155,22 @@ export async function runSessionSetConfigOptionDirect(
   options: RunSessionSetConfigOptionDirectOptions,
 ): Promise<SessionSetConfigOptionResult> {
   const result = await withConnectedSession(
-    buildDirectConnectedSessionOptions(options, async ({ client, sessionId, record }) => {
-      const modelConfigId = advertisedModelState(record.acpx)?.configId;
-      // Model-valued config updates replace the pin; skip pin replay so an
-      // obsolete saved model cannot block the replacement. Other config keys
-      // still re-apply the pin so model-dependent options see the right set.
-      if (options.configId !== modelConfigId) {
-        await reapplyPinnedModelAfterConnect({
-          client,
-          sessionId,
-          record,
-          timeoutMs: options.timeoutMs,
-        });
-      }
-      const response = await withTimeout(
-        client.setSessionConfigOption(sessionId, options.configId, options.value),
-        options.timeoutMs,
-      );
-      applyConfigOptionsToRecord(record, response);
-      if (options.configId === modelConfigId) {
-        setDesiredModelId(record, options.value, options.configId);
-        setCurrentModelId(record, currentModelIdFromSetModelResponse(response, options.value));
-      } else if (options.configId === "mode") {
-        setDesiredModeId(record, options.value);
-      } else {
-        setDesiredConfigOption(record, options.configId, options.value);
-      }
-      return response;
-    }),
+    buildDirectConnectedSessionOptions(
+      { ...options, replacingConfigOption: { key: options.configId } },
+      async ({ client, sessionId, record }) => {
+        const response = await withTimeout(
+          client.setSessionConfigOption(sessionId, options.configId, options.value),
+          options.timeoutMs,
+        );
+        record.acpx = applyConfigOptionSelection(
+          record.acpx,
+          options.configId,
+          options.value,
+          response,
+        );
+        return response;
+      },
+    ),
   );
 
   return {

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -5,10 +5,6 @@ import {
   isRetryablePromptError,
   normalizeOutputError,
 } from "../../acp/error-normalization.js";
-import {
-  assertRequestedModelSupported,
-  modelStateFromConfigOptions,
-} from "../../acp/model-support.js";
 import { InterruptedError, withInterrupt, withTimeout } from "../../async-control.js";
 export { InterruptedError, TimeoutError } from "../../async-control.js";
 import { formatPerfMetric, measurePerf, startPerfTimer } from "../../perf-metrics.js";
@@ -24,10 +20,7 @@ import {
   sessionOptionsFromRecord,
   type SessionAgentOptions,
 } from "../../runtime/engine/session-options.js";
-import {
-  applyConfigOptionsToRecord,
-  applyConfigOptionsToState,
-} from "../../session/config-options.js";
+import { applyConfigOptionSelection, applyModelSelection } from "../../session/config-options.js";
 import {
   cloneSessionAcpxState,
   cloneSessionConversation,
@@ -38,15 +31,7 @@ import {
 } from "../../session/conversation-model.js";
 import { SessionEventWriter } from "../../session/events.js";
 import { LiveSessionCheckpoint } from "../../session/live-checkpoint.js";
-import {
-  clearDesiredConfigOption,
-  setCurrentModelId,
-  setDesiredModelId,
-} from "../../session/mode-preference.js";
-import {
-  applyRequestedModelIfAdvertised,
-  currentModelIdFromSetModelResponse,
-} from "../../session/model-application.js";
+import { applyRequestedModelIfAdvertised } from "../../session/model-application.js";
 import { advertisedModelState } from "../../session/model-state.js";
 import {
   absolutePath,
@@ -246,18 +231,6 @@ function requestedModelId(value: string | undefined): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function applyConfigOptionResponseToState(
-  state: SessionAcpxState | undefined,
-  response:
-    | Awaited<ReturnType<AcpClient["setSessionConfigOption"]>>
-    | Awaited<ReturnType<AcpClient["setSessionModel"]>>,
-): SessionAcpxState | undefined {
-  if (!response?.configOptions) {
-    return state;
-  }
-  return applyConfigOptionsToState(state, response.configOptions);
-}
-
 export function mergeConnectedModelState(
   state: SessionAcpxState | undefined,
   connectedState: SessionAcpxState | undefined,
@@ -309,6 +282,8 @@ function mergeConnectedModelPreferences(
   }
   if (connectedState.desired_config_options) {
     nextState.desired_config_options = { ...connectedState.desired_config_options };
+  } else {
+    delete nextState.desired_config_options;
   }
 }
 
@@ -325,34 +300,19 @@ async function applyPromptModelIfAdvertised(params: {
     return;
   }
 
-  const models = advertisedModelState(params.record.acpx);
-  const warning = assertRequestedModelSupported({
+  const result = await applyRequestedModelIfAdvertised({
+    client: params.client,
+    sessionId: params.sessionId,
     requestedModel,
-    models,
+    models: advertisedModelState(params.record.acpx),
     agentCommand: params.record.agentCommand,
-    context: "apply",
+    timeoutMs: params.timeoutMs,
+    onWarning: params.suppressWarnings
+      ? undefined
+      : (message) => process.stderr.write(`[acpx] warning: ${message}\n`),
   });
-  emitModelSupportWarning(warning, params.suppressWarnings);
-  if (!models) {
-    return;
-  }
-  if (params.record.acpx?.current_model_id === requestedModel) {
-    setDesiredModelId(params.record, requestedModel, models.configId);
-    return;
-  }
-
-  const response = await withTimeout(
-    params.client.setSessionModel(params.sessionId, requestedModel, models),
-    params.timeoutMs,
-  );
-  applyConfigOptionsToRecord(params.record, response);
-  setDesiredModelId(params.record, requestedModel, models.configId);
-  setCurrentModelId(params.record, currentModelIdFromSetModelResponse(response, requestedModel));
-}
-
-function emitModelSupportWarning(warning: string | undefined, suppressWarnings?: boolean): void {
-  if (warning && !suppressWarnings) {
-    process.stderr.write(`[acpx] warning: ${warning}\n`);
+  if (result.applied) {
+    params.record.acpx = applyModelSelection(params.record.acpx, requestedModel, result.response);
   }
 }
 
@@ -754,7 +714,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     },
   });
 
-  const ownClient = options.client == null;
+  let closeClientOnExit = options.client == null;
   const client =
     options.client ??
     new AcpClient({
@@ -828,36 +788,18 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     setSessionModel: async (modelId: string) => {
       const models = advertisedModelState(acpxState);
       const response = await client.setSessionModel(activeSessionIdForControl, modelId, models);
-      acpxState = applyConfigOptionResponseToState(acpxState, response);
-      const nextState = cloneSessionAcpxState(acpxState) ?? {};
-      nextState.session_options = { ...nextState.session_options, model: modelId };
-      nextState.current_model_id = currentModelIdFromSetModelResponse(response, modelId);
-      clearDesiredConfigOption(nextState, models?.configId);
-      acpxState = nextState;
+      acpxState = applyModelSelection(acpxState, modelId, response);
       return response;
     },
     setSessionConfigOption: async (configId: string, value: string) => {
+      // Preserve the selected control's identity across pre-ack notifications.
+      const modelConfigId = advertisedModelState(acpxState)?.configId;
       const response = await client.setSessionConfigOption(
         activeSessionIdForControl,
         configId,
         value,
       );
-      acpxState = applyConfigOptionResponseToState(acpxState, response);
-      const nextState = cloneSessionAcpxState(acpxState) ?? {};
-      const modelConfigId = modelStateFromConfigOptions(nextState.config_options)?.configId;
-      if (configId === modelConfigId) {
-        nextState.session_options = { ...nextState.session_options, model: value };
-        nextState.current_model_id = currentModelIdFromSetModelResponse(response, value);
-        clearDesiredConfigOption(nextState, configId);
-      } else if (configId === "mode") {
-        nextState.desired_mode_id = value;
-      } else {
-        nextState.desired_config_options = {
-          ...nextState.desired_config_options,
-          [configId]: value,
-        };
-      }
-      acpxState = nextState;
+      acpxState = applyConfigOptionSelection(acpxState, configId, value, response, modelConfigId);
       return response;
     },
   };
@@ -879,6 +821,9 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
           client,
           record,
           resumePolicy: options.resumePolicy,
+          replacingConfigOption: requestedModelId(options.sessionOptions?.model)
+            ? { key: "model" }
+            : undefined,
           timeoutMs: options.timeoutMs,
           verbose: options.verbose,
           suppressWarnings: options.suppressSdkConsoleErrors,
@@ -900,6 +845,8 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       emitConnectPerfMetric(connectStartedAt, options.verbose);
       return connected;
     } catch (error) {
+      // A shared queue client must reconnect after an incomplete preference replay.
+      closeClientOnExit = true;
       flushConnectOutput();
       throw error;
     }
@@ -1020,7 +967,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     await applyPromptModelIfAdvertised({
       client,
       sessionId: activeSessionId,
-      requestedModel: sessionOptions?.model,
+      requestedModel: options.sessionOptions?.model,
       record,
       timeoutMs: options.timeoutMs,
       suppressWarnings: options.suppressSdkConsoleErrors,
@@ -1052,7 +999,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
     await flushPendingMessages(false).catch(() => {
       // best effort while process is being interrupted
     });
-    if (ownClient) {
+    if (closeClientOnExit) {
       await client.close();
     }
   };
@@ -1078,7 +1025,7 @@ async function runSessionPrompt(options: RunSessionPromptOptions): Promise<Sessi
       options.onClientClosed?.();
     }
     client.clearEventHandlers();
-    if (ownClient) {
+    if (closeClientOnExit) {
       await client.close();
     }
     applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());

--- a/src/cli/session/session-control.ts
+++ b/src/cli/session/session-control.ts
@@ -1,15 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runTimedExecFile, splitCommandLine } from "../../acp/client-process.js";
-import { applyConfigOptionsToRecord } from "../../session/config-options.js";
-import {
-  setCurrentModelId,
-  setDesiredConfigOption,
-  setDesiredModeId,
-  setDesiredModelId,
-} from "../../session/mode-preference.js";
-import { currentModelIdFromSetModelResponse } from "../../session/model-application.js";
-import { advertisedModelState } from "../../session/model-state.js";
+import { applyConfigOptionSelection, applyModelSelection } from "../../session/config-options.js";
+import { setDesiredModeId } from "../../session/mode-preference.js";
 import { resolveSessionRecord, writeSessionRecord, isoNow } from "../../session/persistence.js";
 import type {
   SessionRecord,
@@ -94,12 +87,7 @@ export async function setSessionModel(
   );
   if (submittedToOwner) {
     const record = await resolveSessionRecord(options.sessionId);
-    applyConfigOptionsToRecord(record, submittedToOwner.response);
-    setDesiredModelId(record, options.modelId, advertisedModelState(record.acpx)?.configId);
-    setCurrentModelId(
-      record,
-      currentModelIdFromSetModelResponse(submittedToOwner.response, options.modelId),
-    );
+    record.acpx = applyModelSelection(record.acpx, options.modelId, submittedToOwner.response);
     await writeSessionRecord(record);
     return {
       record,
@@ -134,16 +122,12 @@ export async function setSessionConfigOption(
   );
   if (ownerResponse) {
     const record = await resolveSessionRecord(options.sessionId);
-    const modelConfigId = advertisedModelState(record.acpx)?.configId;
-    applyConfigOptionsToRecord(record, ownerResponse);
-    if (options.configId === modelConfigId) {
-      setDesiredModelId(record, options.value, options.configId);
-      setCurrentModelId(record, currentModelIdFromSetModelResponse(ownerResponse, options.value));
-    } else if (options.configId === "mode") {
-      setDesiredModeId(record, options.value);
-    } else {
-      setDesiredConfigOption(record, options.configId, options.value);
-    }
+    record.acpx = applyConfigOptionSelection(
+      record.acpx,
+      options.configId,
+      options.value,
+      ownerResponse,
+    );
     await writeSessionRecord(record);
     return {
       record,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,3 +1,4 @@
+import type { SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import {
   DEFAULT_AGENT_NAME,
   listBuiltInAgents,
@@ -312,10 +313,10 @@ export class AcpxRuntime implements AcpxRuntimeLike {
     handle: AcpRuntimeHandle;
     key: string;
     value: string;
-  }): Promise<void> {
+  }): Promise<SetSessionConfigOptionResponse> {
     const { handle, state } = this.resolveManagerHandle(input.handle);
     const manager = await this.getManager();
-    await manager.setConfigOption(handle, input.key, input.value, state.mode);
+    return await manager.setConfigOption(handle, input.key, input.value, state.mode);
   }
 
   async cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void> {

--- a/src/runtime/engine/connected-session.ts
+++ b/src/runtime/engine/connected-session.ts
@@ -17,7 +17,11 @@ import type {
   SessionResumePolicy,
 } from "../../types.js";
 import { applyLifecycleSnapshotToRecord } from "./lifecycle.js";
-import { connectAndLoadSession, type ConnectedSessionController } from "./reconnect.js";
+import {
+  connectAndLoadSession,
+  type ConnectAndLoadSessionOptions,
+  type ConnectedSessionController,
+} from "./reconnect.js";
 import { sessionOptionsFromRecord } from "./session-options.js";
 
 export type FullConnectedSessionController = ConnectedSessionController & {
@@ -56,6 +60,7 @@ export type WithConnectedSessionOptions<T> = {
   terminal?: boolean;
   elicitationModes?: readonly AcpElicitationMode[];
   resumePolicy?: SessionResumePolicy;
+  replacingConfigOption?: ConnectAndLoadSessionOptions["replacingConfigOption"];
   timeoutMs?: number;
   verbose?: boolean;
   onClientAvailable?: (controller: FullConnectedSessionController) => void;
@@ -133,6 +138,7 @@ export async function withConnectedSession<T>(
           client,
           record,
           resumePolicy: options.resumePolicy,
+          replacingConfigOption: options.replacingConfigOption,
           timeoutMs: options.timeoutMs,
           verbose: options.verbose,
           activeController,

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
-import type { SessionNotification } from "@agentclientprotocol/sdk";
+import type { SessionNotification, SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import { normalizeAgentCommandInput } from "../../acp/client-process.js";
 import { AcpClient } from "../../acp/client.js";
 import { normalizeOutputError } from "../../acp/error-normalization.js";
@@ -11,7 +11,8 @@ import { withTimeout } from "../../async-control.js";
 import { textPrompt, type PromptInput } from "../../prompt-content.js";
 import {
   applyConfigOptionsToRecord,
-  applyConfigOptionsToState,
+  applyConfigOptionSelection,
+  applyModelSelection,
 } from "../../session/config-options.js";
 import {
   cloneSessionAcpxState,
@@ -25,10 +26,7 @@ import {
 import { defaultSessionEventLog } from "../../session/event-log.js";
 import { LiveSessionCheckpoint } from "../../session/live-checkpoint.js";
 import {
-  clearDesiredConfigOption,
   setCurrentModelId,
-  setDesiredConfigOption,
-  setDesiredModelId,
   setDesiredModeId,
   syncAdvertisedModelState,
 } from "../../session/mode-preference.js";
@@ -67,7 +65,11 @@ import {
   reconcileAgentSessionId,
 } from "./lifecycle.js";
 import { runPromptTurn } from "./prompt-turn.js";
-import { connectAndLoadSession, type ConnectAndLoadSessionResult } from "./reconnect.js";
+import {
+  connectAndLoadSession,
+  type ConnectAndLoadSessionOptions,
+  type ConnectAndLoadSessionResult,
+} from "./reconnect.js";
 import { shouldReuseExistingRecord } from "./reuse-policy.js";
 import {
   persistSessionOptions,
@@ -518,8 +520,7 @@ type RunningRuntimeTurn = {
   liveCheckpoint: LiveSessionCheckpoint;
   client: AcpClient;
   owner: RuntimeSessionOwner;
-  pendingClient: AcpClient | undefined;
-  connectionUpdates: SessionNotification[] | undefined;
+  connected: boolean;
   promptMessageId: string | undefined;
   activeSessionId: string;
 };
@@ -527,7 +528,6 @@ type RunningRuntimeTurn = {
 type RuntimeSessionProjection = {
   record: SessionRecord;
   conversation: ReturnType<typeof cloneSessionConversation>;
-  acpxState: ReturnType<typeof cloneSessionAcpxState>;
   checkpoint: LiveSessionCheckpoint;
 };
 
@@ -552,54 +552,6 @@ type PreparedRuntimeTurnState = {
   acpxState: ReturnType<typeof cloneSessionAcpxState>;
   promptMessageId: string | undefined;
 };
-
-function applyConfigOptionResponseToTurn(
-  turn: RunningRuntimeTurn,
-  response:
-    | Awaited<ReturnType<AcpClient["setSessionConfigOption"]>>
-    | Awaited<ReturnType<AcpClient["setSessionModel"]>>,
-): void {
-  if (!response?.configOptions) {
-    return;
-  }
-  turn.acpxState = applyConfigOptionsToState(turn.acpxState, response.configOptions);
-}
-
-function applyDesiredConfigOptionToTurn(
-  turn: RunningRuntimeTurn,
-  configId: string,
-  value: string,
-): void {
-  const nextState = cloneSessionAcpxState(turn.acpxState) ?? {};
-  const modelConfigId = modelStateFromConfigOptions(nextState.config_options)?.configId;
-  if (configId === modelConfigId) {
-    nextState.session_options = { ...nextState.session_options, model: value };
-    clearDesiredConfigOption(nextState, configId);
-  } else if (configId === "mode") {
-    nextState.desired_mode_id = value;
-  } else {
-    nextState.desired_config_options = {
-      ...nextState.desired_config_options,
-      [configId]: value,
-    };
-  }
-  turn.acpxState = nextState;
-}
-
-function applyDesiredConfigOptionToRecord(
-  record: SessionRecord,
-  configId: string,
-  value: string,
-): void {
-  const modelConfigId = modelStateFromConfigOptions(record.acpx?.config_options)?.configId;
-  if (configId === modelConfigId) {
-    setDesiredModelId(record, value, configId);
-  } else if (configId === "mode") {
-    setDesiredModeId(record, value);
-  } else {
-    setDesiredConfigOption(record, configId, value);
-  }
-}
 
 async function createOrLoadRuntimeSession(
   client: AcpClient,
@@ -677,18 +629,15 @@ export class AcpRuntimeManager {
     const active = owner.activeTurn;
     if (active) {
       const { task, turn } = active;
-      if (turn.connectionUpdates) {
-        turn.connectionUpdates.push(notification);
-        this.emitRuntimeTurnEvent(task, {
-          jsonrpc: "2.0",
-          method: "session/update",
-          params: notification,
-        });
-        return;
+      if (turn.connected) {
+        turn.acpxState = recordSessionUpdate(turn.conversation, turn.acpxState, notification);
+        turn.liveCheckpoint.request();
+      } else {
+        // Reconnect setters and their notifications share the record so an older
+        // notification cannot overwrite a later acknowledgement after replay.
+        turn.record.acpx = recordSessionUpdate(turn.conversation, turn.record.acpx, notification);
       }
-      turn.acpxState = recordSessionUpdate(turn.conversation, turn.acpxState, notification);
       trimConversationForRuntime(turn.conversation);
-      turn.liveCheckpoint.request();
       this.emitRuntimeTurnEvent(task, {
         jsonrpc: "2.0",
         method: "session/update",
@@ -707,9 +656,9 @@ export class AcpRuntimeManager {
       owner.pendingSessionUpdates.push(notification);
       return;
     }
-    projection.acpxState = recordSessionUpdate(
+    projection.record.acpx = recordSessionUpdate(
       projection.conversation,
-      projection.acpxState,
+      projection.record.acpx,
       notification,
     );
     trimConversationForRuntime(projection.conversation);
@@ -722,9 +671,13 @@ export class AcpRuntimeManager {
       return;
     }
     const { task, turn } = active;
-    turn.acpxState = recordClientOperation(turn.conversation, turn.acpxState, operation);
+    if (turn.connected) {
+      turn.acpxState = recordClientOperation(turn.conversation, turn.acpxState, operation);
+      turn.liveCheckpoint.request();
+    } else {
+      turn.record.acpx = recordClientOperation(turn.conversation, turn.record.acpx, operation);
+    }
     trimConversationForRuntime(turn.conversation);
-    turn.liveCheckpoint.request();
     this.emitRuntimeTurnEvent(task, {
       type: "client_operation",
       ...operation,
@@ -735,21 +688,24 @@ export class AcpRuntimeManager {
     owner: RuntimeSessionOwner,
     record: SessionRecord,
     conversation = cloneSessionConversation(record),
-    acpxState = cloneSessionAcpxState(record.acpx),
+    acpxState = record.acpx,
   ): void {
-    let projection: RuntimeSessionProjection;
+    record.acpx = acpxState;
     const checkpoint = new LiveSessionCheckpoint({
       save: async () => {
+        // Initialization owns publication; notifications before its model
+        // selection succeeds must not create an incomplete session record.
+        if (!owner.recordId) {
+          return;
+        }
         record.lastUsedAt = isoNow();
-        record.acpx = projection.acpxState;
-        applyConversation(record, projection.conversation);
+        applyConversation(record, conversation);
         applyLifecycleSnapshotToRecord(record, owner.client.getAgentLifecycleSnapshot());
         await this.refreshClosedState(record);
         await this.options.sessionStore.save(record);
       },
     });
-    projection = { record, conversation, acpxState, checkpoint };
-    owner.projection = projection;
+    owner.projection = { record, conversation, checkpoint };
     owner.activeTurn = undefined;
     this.drainPendingSessionUpdates(owner);
   }
@@ -873,11 +829,11 @@ export class AcpRuntimeManager {
     record: SessionRecord,
     sessionMode: "persistent" | "oneshot",
     run: (context: { client: AcpClient; sessionId: string; record: SessionRecord }) => Promise<T>,
+    replacingConfigOption?: ConnectAndLoadSessionOptions["replacingConfigOption"],
   ): Promise<{ value: T; record: SessionRecord }> {
     const owner = await this.readRetainedSessionOwner(record, { consume: false });
     if (owner) {
       const ownedRecord = owner.projection?.record ?? record;
-      owner.bufferSessionUpdates = true;
       try {
         const value = await run({
           client: owner.client,
@@ -887,7 +843,7 @@ export class AcpRuntimeManager {
         this.refreshOwnedRecordLifecycle(owner, ownedRecord);
         return { value, record: ownedRecord };
       } finally {
-        await this.finishBufferedOwnerControl(owner, ownedRecord);
+        await this.flushSessionOwner(owner);
       }
     }
 
@@ -905,6 +861,7 @@ export class AcpRuntimeManager {
       verbose: this.options.verbose,
       timeoutMs: this.options.timeoutMs,
       resumePolicy: resumePolicyForSessionMode(sessionMode),
+      replacingConfigOption,
       run,
     });
     return {
@@ -922,22 +879,6 @@ export class AcpRuntimeManager {
     applyLifecycleSnapshotToRecord(record, owner.client.getAgentLifecycleSnapshot());
   }
 
-  private async finishBufferedOwnerControl(
-    owner: RuntimeSessionOwner,
-    record: SessionRecord,
-  ): Promise<void> {
-    const projection = owner.projection;
-    if (projection) {
-      projection.acpxState = cloneSessionAcpxState(record.acpx);
-    }
-    owner.bufferSessionUpdates = false;
-    this.drainPendingSessionUpdates(owner);
-    if (projection) {
-      record.acpx = projection.acpxState;
-      applyConversation(record, projection.conversation);
-      await projection.checkpoint.flush();
-    }
-  }
   async ensureSession(input: RuntimeEnsureInput): Promise<SessionRecord> {
     return await this.withEnsureSessionLock(input, async () =>
       this.ensureSessionWithOwnership(input),
@@ -1083,39 +1024,41 @@ export class AcpRuntimeManager {
     try {
       await client.start();
       const session = await createOrLoadRuntimeSession(client, input.resumeSessionId, cwd);
-      const record = await this.createAndSaveRuntimeRecord({
+      const record = await this.prepareInitialRuntimeRecord({
         input,
         client,
+        owner,
         agentCommand,
         agentArgv,
         cwd,
         session,
       });
-      this.attachIdleProjection(owner, record);
       await this.retainInitializedSessionOwner(owner, record);
       retained = true;
       return record;
     } finally {
       if (!retained) {
+        owner.recordId = undefined;
         client.clearEventHandlers();
         await client.close();
       }
     }
   }
 
-  private async createAndSaveRuntimeRecord(params: {
+  private async prepareInitialRuntimeRecord(params: {
     input: {
       sessionKey: string;
       mode: "persistent" | "oneshot";
       sessionOptions?: SessionAgentOptions;
     };
     client: AcpClient;
+    owner: RuntimeSessionOwner;
     agentCommand: string;
     agentArgv?: string[];
     cwd: string;
     session: CreatedRuntimeSession;
   }): Promise<SessionRecord> {
-    const { input, client, agentCommand, agentArgv, cwd, session } = params;
+    const { input, client, owner, agentCommand, agentArgv, cwd, session } = params;
     const record = createInitialRecord({
       recordId: createRecordId(input.sessionKey, input.mode),
       sessionName: input.sessionKey,
@@ -1128,6 +1071,9 @@ export class AcpRuntimeManager {
     this.closingActiveRecords.delete(record.acpxRecordId);
     record.protocolVersion = client.initializeResult?.protocolVersion;
     record.agentCapabilities = client.initializeResult?.agentCapabilities;
+    // Fold pre-response notifications first; later controls and their updates
+    // then share this record and retain wire order through acknowledgement.
+    this.attachIdleProjection(owner, record);
     applyConfigOptionsToRecord(record, session.sessionResult);
     const modelApplication = await applyRequestedModelIfAdvertised({
       client,
@@ -1152,7 +1098,6 @@ export class AcpRuntimeManager {
     }
     applyLifecycleSnapshotToRecord(record, client.getAgentLifecycleSnapshot());
     persistSessionOptions(record, input.sessionOptions);
-    await this.options.sessionStore.save(record);
     return record;
   }
 
@@ -1161,6 +1106,9 @@ export class AcpRuntimeManager {
     record: SessionRecord,
   ): Promise<void> {
     owner.recordId = record.acpxRecordId;
+    // The checkpoint loop also persists notifications arriving during the
+    // initial async save before this owner becomes available for reuse.
+    await owner.projection?.checkpoint.checkpoint();
     const previousOwner = this.retainedSessionOwners.get(record.acpxRecordId);
     this.retainedSessionOwners.set(record.acpxRecordId, owner);
     if (owner.mode === "oneshot") {
@@ -1366,7 +1314,7 @@ export class AcpRuntimeManager {
         acpxState,
         client,
         owner,
-        pendingClient: retainedOwner?.client,
+        connected: retainedOwner !== undefined,
         promptMessageId,
       });
       this.activateRuntimeTurn(task, turn);
@@ -1450,11 +1398,10 @@ export class AcpRuntimeManager {
     acpxState: ReturnType<typeof cloneSessionAcpxState>;
     client: AcpClient;
     owner: RuntimeSessionOwner;
-    pendingClient: AcpClient | undefined;
+    connected: boolean;
     promptMessageId: string | undefined;
   }): RunningRuntimeTurn {
-    const { record, conversation, acpxState, client, owner, pendingClient, promptMessageId } =
-      input;
+    const { record, conversation, acpxState, client, owner, connected, promptMessageId } = input;
     const turn: RunningRuntimeTurn = {
       record,
       conversation,
@@ -1462,8 +1409,7 @@ export class AcpRuntimeManager {
       liveCheckpoint: this.createRuntimeTurnCheckpoint(record, conversation, () => turn.acpxState),
       client,
       owner,
-      pendingClient,
-      connectionUpdates: pendingClient ? undefined : [],
+      connected,
       promptMessageId,
       activeSessionId: record.acpSessionId,
     };
@@ -1532,12 +1478,7 @@ export class AcpRuntimeManager {
         await this.waitForRuntimeControlSession(task, turn);
         const models = advertisedModelState(turn.acpxState);
         const response = await turn.client.setSessionModel(turn.activeSessionId, modelId, models);
-        applyConfigOptionResponseToTurn(turn, response);
-        const nextState = cloneSessionAcpxState(turn.acpxState) ?? {};
-        nextState.session_options = { ...nextState.session_options, model: modelId };
-        nextState.current_model_id = currentModelIdFromSetModelResponse(response, modelId);
-        clearDesiredConfigOption(nextState, models?.configId);
-        turn.acpxState = nextState;
+        turn.acpxState = applyModelSelection(turn.acpxState, modelId, response);
         return response;
       },
       setSessionConfigOption: async (configId: string, value: string) => {
@@ -1593,23 +1534,21 @@ export class AcpRuntimeManager {
       },
       configId,
     );
+    // Notifications can remove the model control before the setter resolves.
+    const modelConfigId = advertisedModelState(turn.acpxState)?.configId;
     const response = await turn.client.setSessionConfigOption(
       turn.activeSessionId,
       resolvedConfigId,
       value,
     );
-    this.applyRuntimeConfigOptionState(turn, resolvedConfigId, value, response);
+    turn.acpxState = applyConfigOptionSelection(
+      turn.acpxState,
+      resolvedConfigId,
+      value,
+      response,
+      modelConfigId,
+    );
     return { configId: resolvedConfigId, response };
-  }
-
-  private applyRuntimeConfigOptionState(
-    turn: RunningRuntimeTurn,
-    configId: string,
-    value: string,
-    response: Awaited<ReturnType<AcpClient["setSessionConfigOption"]>>,
-  ): void {
-    applyConfigOptionResponseToTurn(turn, response);
-    applyDesiredConfigOptionToTurn(turn, configId, value);
   }
 
   private emitRuntimeTurnEvent(task: RuntimeTurnTask, payload: Record<string, unknown>): void {
@@ -1624,24 +1563,13 @@ export class AcpRuntimeManager {
     task: RuntimeTurnTask,
     turn: RunningRuntimeTurn,
   ): Promise<ConnectAndLoadSessionResult> {
-    const loaded = turn.pendingClient
-      ? { sessionId: turn.record.acpSessionId, resumed: false, loadError: undefined }
-      : await this.connectRuntimeTurnClient(task, turn);
-    this.drainRuntimeConnectionUpdates(turn);
-    return loaded;
-  }
-
-  private drainRuntimeConnectionUpdates(turn: RunningRuntimeTurn): void {
-    if (!turn.connectionUpdates) {
-      return;
+    if (turn.connected) {
+      return { sessionId: turn.record.acpSessionId, resumed: false, loadError: undefined };
     }
+    const loaded = await this.connectRuntimeTurnClient(task, turn);
     turn.acpxState = cloneSessionAcpxState(turn.record.acpx);
-    for (const notification of turn.connectionUpdates) {
-      turn.acpxState = recordSessionUpdate(turn.conversation, turn.acpxState, notification);
-    }
-    turn.connectionUpdates = undefined;
-    trimConversationForRuntime(turn.conversation);
-    turn.liveCheckpoint.request();
+    turn.connected = true;
+    return loaded;
   }
 
   private async connectRuntimeTurnClient(
@@ -1810,7 +1738,9 @@ export class AcpRuntimeManager {
   }
 
   private async finalizeRuntimeTurnRecord(turn: RunningRuntimeTurn): Promise<boolean> {
-    this.drainRuntimeConnectionUpdates(turn);
+    if (!turn.connected) {
+      turn.acpxState = cloneSessionAcpxState(turn.record.acpx);
+    }
     applyLifecycleSnapshotToRecord(turn.record, turn.client.getAgentLifecycleSnapshot());
     turn.record.acpx = turn.acpxState;
     applyConversation(turn.record, turn.conversation);
@@ -1818,7 +1748,8 @@ export class AcpRuntimeManager {
     await turn.liveCheckpoint.flush();
     const closed = await this.refreshClosedState(turn.record);
     await this.options.sessionStore.save(turn.record);
-    if (closed) {
+    // A loaded transport is not reusable until preference reconciliation succeeds.
+    if (closed || !turn.connected) {
       return false;
     }
     return await this.retainPersistentSessionOwnerAfterTurn({
@@ -1911,9 +1842,9 @@ export class AcpRuntimeManager {
     key: string,
     value: string,
     sessionMode: "persistent" | "oneshot" = "persistent",
-  ): Promise<void> {
+  ): Promise<SetSessionConfigOptionResponse> {
     const recordId = handle.acpxRecordId ?? handle.sessionKey;
-    await this.withManagerLock(this.runtimeOperationLocks, recordId, async () =>
+    return await this.withManagerLock(this.runtimeOperationLocks, recordId, async () =>
       this.setConfigOptionWithOwnership(handle, key, value, sessionMode),
     );
   }
@@ -1923,15 +1854,14 @@ export class AcpRuntimeManager {
     key: string,
     value: string,
     sessionMode: "persistent" | "oneshot",
-  ): Promise<void> {
+  ): Promise<SetSessionConfigOptionResponse> {
     const record = await this.requireRecord(handle.acpxRecordId ?? handle.sessionKey);
     const controller = this.activeControllers.get(record.acpxRecordId);
     if (controller) {
       const { configId, response } = await controller.setResolvedSessionConfigOption(key, value);
-      applyConfigOptionsToRecord(record, response);
-      applyDesiredConfigOptionToRecord(record, configId, value);
+      record.acpx = applyConfigOptionSelection(record.acpx, configId, value, response);
       await this.options.sessionStore.save(record);
-      return;
+      return response;
     }
 
     const result = await this.withRuntimeControlSession(
@@ -1939,12 +1869,21 @@ export class AcpRuntimeManager {
       sessionMode,
       async ({ client, sessionId, record: connectedRecord }) => {
         const configId = resolveSupportedConfigOptionId(connectedRecord, key);
+        const modelConfigId = advertisedModelState(connectedRecord.acpx)?.configId;
         const response = await client.setSessionConfigOption(sessionId, configId, value);
-        applyConfigOptionsToRecord(connectedRecord, response);
-        applyDesiredConfigOptionToRecord(connectedRecord, configId, value);
+        connectedRecord.acpx = applyConfigOptionSelection(
+          connectedRecord.acpx,
+          configId,
+          value,
+          response,
+          modelConfigId,
+        );
+        return response;
       },
+      { key, resolve: (connectedRecord) => resolveSupportedConfigOptionId(connectedRecord, key) },
     );
     await this.options.sessionStore.save(result.record);
+    return result.value;
   }
 
   async cancel(handle: AcpRuntimeHandle): Promise<void> {

--- a/src/runtime/engine/reconnect.ts
+++ b/src/runtime/engine/reconnect.ts
@@ -1,3 +1,4 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import type { AcpClient } from "../../acp/client.js";
 import {
   extractAcpError,
@@ -18,7 +19,11 @@ import {
   SessionResumeRequiredError,
 } from "../../errors.js";
 import { incrementPerfCounter } from "../../perf-metrics.js";
-import { applyConfigOptionsToRecord } from "../../session/config-options.js";
+import {
+  applyConfigOptionsToRecord,
+  applyConfigOptionSelection,
+  applyModelSelection,
+} from "../../session/config-options.js";
 import { cloneSessionAcpxState } from "../../session/conversation-model.js";
 import {
   getDesiredConfigOptions,
@@ -26,7 +31,11 @@ import {
   getDesiredModelId,
   syncAdvertisedModelState,
 } from "../../session/mode-preference.js";
-import { clearAdvertisedModelState, removeModelConfigOptions } from "../../session/model-state.js";
+import {
+  advertisedModelState,
+  clearAdvertisedModelState,
+  removeModelConfigOptions,
+} from "../../session/model-state.js";
 import type { SessionRecord, SessionResumePolicy } from "../../types.js";
 import {
   applyLifecycleSnapshotToRecord,
@@ -62,6 +71,10 @@ export type ConnectAndLoadSessionOptions = {
   client: AcpClient;
   record: SessionRecord;
   resumePolicy?: SessionResumePolicy;
+  replacingConfigOption?: {
+    key: string;
+    resolve?: (record: SessionRecord) => string;
+  };
   timeoutMs?: number;
   verbose?: boolean;
   suppressWarnings?: boolean;
@@ -157,6 +170,15 @@ async function replayDesiredMode(params: {
   }
 }
 
+function canReplayModel(
+  desiredModelId: string | undefined,
+  models: SessionModelState | undefined,
+  createdFreshSession: boolean,
+): desiredModelId is string {
+  // Resume metadata is optional; omission alone does not revoke saved model support.
+  return Boolean(desiredModelId) && (createdFreshSession || models !== undefined);
+}
+
 async function replayDesiredModel(params: {
   client: AcpClient;
   sessionId: string;
@@ -164,11 +186,12 @@ async function replayDesiredModel(params: {
   previousSessionId: string;
   record: SessionRecord;
   models: import("../../acp/client.js").SessionLoadResult["models"] | undefined;
+  createdFreshSession: boolean;
   timeoutMs?: number;
   verbose?: boolean;
   suppressWarnings?: boolean;
 }): Promise<ModelReplayResult> {
-  if (!params.desiredModelId) {
+  if (!canReplayModel(params.desiredModelId, params.models, params.createdFreshSession)) {
     return { replayed: false };
   }
 
@@ -180,30 +203,32 @@ async function replayDesiredModel(params: {
       context: "replay",
     });
     emitModelSupportWarning(warning, params.suppressWarnings);
-    if (!params.models || params.models.currentModelId === params.desiredModelId) {
+    if (!params.models) {
       return { replayed: false };
     }
+    // Reassert even an unchanged model: its acknowledgement reconciles saved
+    // sibling selections left invalid by earlier model switches.
     const response = await withTimeout(
       params.client.setSessionModel(params.sessionId, params.desiredModelId, params.models),
       params.timeoutMs,
     );
-    applyConfigOptionsToRecord(params.record, response);
+    params.record.acpx = applyModelSelection(params.record.acpx, params.desiredModelId, response);
     const models = response
       ? modelStateFromConfigOptions(response.configOptions)
       : { ...params.models, currentModelId: params.desiredModelId };
     if (params.verbose) {
       process.stderr.write(
-        `[acpx] replayed desired model ${params.desiredModelId} on fresh ACP session ${params.sessionId} (previous ${params.previousSessionId})\n`,
+        `[acpx] replayed desired model ${params.desiredModelId} on ACP session ${params.sessionId} (previous ${params.previousSessionId})\n`,
       );
     }
     return {
       replayed: true,
       models,
-      configOptionsPresent: response !== undefined,
+      configOptions: response?.configOptions,
     };
   } catch (error) {
     throw new SessionModelReplayError(
-      `Failed to replay saved session model ${params.desiredModelId} on fresh ACP session ${params.sessionId}: ${formatErrorMessage(error)}`,
+      `Failed to replay saved session model ${params.desiredModelId} on ACP session ${params.sessionId}: ${formatErrorMessage(error)}`,
       {
         cause: error instanceof Error ? error : undefined,
         retryable: true,
@@ -219,11 +244,11 @@ function emitModelSupportWarning(warning: string | undefined, suppressWarnings?:
 }
 
 type ModelReplayResult =
-  | { replayed: false }
+  | { replayed: false; configOptions?: undefined }
   | {
       replayed: true;
       models: SessionModelState | undefined;
-      configOptionsPresent: boolean;
+      configOptions: SessionConfigOption[] | undefined;
     };
 
 type ConfigReplayResult =
@@ -233,7 +258,7 @@ type ConfigReplayResult =
       models: SessionModelState | undefined;
     };
 
-type FreshPreferenceReplayResult = {
+type PreferenceReplayResult = {
   modelReplay: ModelReplayResult;
   configReplay: ConfigReplayResult;
 };
@@ -243,30 +268,52 @@ async function replayDesiredConfigOptions(params: {
   record: SessionRecord;
   sessionId: string;
   desiredConfigOptions: Record<string, string>;
+  acceptedConfigOptions?: SessionConfigOption[];
+  replacingConfigOption?: ConnectAndLoadSessionOptions["replacingConfigOption"];
   previousSessionId: string;
   timeoutMs?: number;
   verbose?: boolean;
 }): Promise<ConfigReplayResult> {
   let result: ConfigReplayResult = { replayed: false };
+  let acceptedConfigOptions = params.acceptedConfigOptions;
+  const replacingKey = resolveReplacingConfigOptionId(params.replacingConfigOption, params.record);
   for (const [configId, value] of Object.entries(params.desiredConfigOptions)) {
+    // Each acknowledgement can retire later selections. Startup snapshots alone
+    // must not replace saved preferences with the adapter's defaults.
+    if (
+      configId === replacingKey ||
+      (acceptedConfigOptions &&
+        !acceptsSavedConfigValue(
+          acceptedConfigOptions.find((option) => option.id === configId),
+          value,
+        ))
+    ) {
+      continue;
+    }
     try {
       const response = await withTimeout(
         params.client.setSessionConfigOption(params.sessionId, configId, value),
         params.timeoutMs,
       );
-      applyConfigOptionsToRecord(params.record, response);
+      params.record.acpx = applyConfigOptionSelection(
+        params.record.acpx,
+        configId,
+        value,
+        response,
+      );
+      acceptedConfigOptions = response.configOptions;
       result = {
         replayed: true,
         models: modelStateFromConfigOptions(response.configOptions),
       };
       if (params.verbose) {
         process.stderr.write(
-          `[acpx] replayed desired config option ${configId} on fresh ACP session ${params.sessionId} (previous ${params.previousSessionId})\n`,
+          `[acpx] replayed desired config option ${configId} on ACP session ${params.sessionId} (previous ${params.previousSessionId})\n`,
         );
       }
     } catch (error) {
       throw new SessionConfigOptionReplayError(
-        `Failed to replay saved session config option ${configId} on fresh ACP session ${params.sessionId}: ${formatErrorMessage(error)}`,
+        `Failed to replay saved session config option ${configId} on ACP session ${params.sessionId}: ${formatErrorMessage(error)}`,
         {
           cause: error instanceof Error ? error : undefined,
           retryable: true,
@@ -336,10 +383,12 @@ export async function connectAndLoadSession(
   pendingAgentSessionId = loadState.pendingAgentSessionId;
   sessionModels = loadState.sessionModels;
 
-  const preferenceReplay = await replayFreshSessionPreferences({
+  const preferenceReplay = await replaySessionPreferences({
     client,
     record,
     createdFreshSession,
+    reusingLoadedSession,
+    replacingConfigOption: options.replacingConfigOption,
     sessionId,
     pendingAgentSessionId,
     originalSessionId,
@@ -373,7 +422,7 @@ export async function connectAndLoadSession(
 }
 
 function resolveModelsAfterReplay(
-  replay: FreshPreferenceReplayResult,
+  replay: PreferenceReplayResult,
   initialModels: SessionModelState | undefined,
 ): SessionModelState | undefined {
   if (replay.configReplay.replayed) {
@@ -392,13 +441,13 @@ function preserveLegacyModels(
 }
 
 function resolveConfigOptionsPresenceAfterReplay(
-  replay: FreshPreferenceReplayResult,
+  replay: PreferenceReplayResult,
   initiallyPresent: boolean,
 ): boolean {
   return (
     initiallyPresent ||
     replay.configReplay.replayed ||
-    (replay.modelReplay.replayed && replay.modelReplay.configOptionsPresent)
+    replay.modelReplay.configOptions !== undefined
   );
 }
 
@@ -458,10 +507,49 @@ function logReconnectAttempt(
   }
 }
 
-async function replayFreshSessionPreferences(params: {
+function replacesModel(
+  replacingConfigOption: ConnectAndLoadSessionOptions["replacingConfigOption"],
+  models: SessionModelState | undefined,
+  originalAcpx: SessionRecord["acpx"],
+): boolean {
+  // Metadata may be omitted on resume; either advertisement identifies the
+  // model replacement that must bypass obsolete model and config preferences.
+  const key = replacingConfigOption?.key;
+  return (
+    key !== undefined &&
+    (key === "model" ||
+      key === models?.configId ||
+      key === advertisedModelState(originalAcpx)?.configId)
+  );
+}
+
+function acceptsSavedConfigValue(option: SessionConfigOption | undefined, value: string): boolean {
+  if (!option || option.type !== "select") {
+    return false;
+  }
+  return (
+    option.currentValue === value ||
+    option.options.some((entry) =>
+      "options" in entry
+        ? entry.options.some((choice) => choice.value === value)
+        : entry.value === value,
+    )
+  );
+}
+
+function resolveReplacingConfigOptionId(
+  replacement: ConnectAndLoadSessionOptions["replacingConfigOption"],
+  record: SessionRecord,
+): string | undefined {
+  return replacement?.resolve?.(record) ?? replacement?.key;
+}
+
+async function replaySessionPreferences(params: {
   client: AcpClient;
   record: SessionRecord;
   createdFreshSession: boolean;
+  reusingLoadedSession: boolean;
+  replacingConfigOption?: ConnectAndLoadSessionOptions["replacingConfigOption"];
   sessionId: string;
   pendingAgentSessionId: string | undefined;
   originalSessionId: string;
@@ -474,8 +562,8 @@ async function replayFreshSessionPreferences(params: {
   timeoutMs?: number;
   verbose?: boolean;
   suppressWarnings?: boolean;
-}): Promise<FreshPreferenceReplayResult> {
-  if (!params.createdFreshSession) {
+}): Promise<PreferenceReplayResult> {
+  if (params.reusingLoadedSession) {
     return {
       modelReplay: { replayed: false },
       configReplay: { replayed: false },
@@ -484,11 +572,16 @@ async function replayFreshSessionPreferences(params: {
 
   let modelReplay: ModelReplayResult = { replayed: false };
   let configReplay: ConfigReplayResult = { replayed: false };
+  const replacingModel = replacesModel(
+    params.replacingConfigOption,
+    params.sessionModels,
+    params.originalAcpx,
+  );
   try {
     await replayDesiredMode({
       client: params.client,
       sessionId: params.sessionId,
-      desiredModeId: params.desiredModeId,
+      desiredModeId: params.createdFreshSession ? params.desiredModeId : undefined,
       previousSessionId: params.originalSessionId,
       timeoutMs: params.timeoutMs,
       verbose: params.verbose,
@@ -496,10 +589,11 @@ async function replayFreshSessionPreferences(params: {
     modelReplay = await replayDesiredModel({
       client: params.client,
       sessionId: params.sessionId,
-      desiredModelId: params.desiredModelId,
+      desiredModelId: replacingModel ? undefined : params.desiredModelId,
       previousSessionId: params.originalSessionId,
       record: params.record,
       models: params.sessionModels,
+      createdFreshSession: params.createdFreshSession,
       timeoutMs: params.timeoutMs,
       verbose: params.verbose,
       suppressWarnings: params.suppressWarnings,
@@ -508,7 +602,9 @@ async function replayFreshSessionPreferences(params: {
       client: params.client,
       record: params.record,
       sessionId: params.sessionId,
-      desiredConfigOptions: params.desiredConfigOptions,
+      desiredConfigOptions: replacingModel ? {} : params.desiredConfigOptions,
+      acceptedConfigOptions: modelReplay.configOptions,
+      replacingConfigOption: replacingModel ? undefined : params.replacingConfigOption,
       previousSessionId: params.originalSessionId,
       timeoutMs: params.timeoutMs,
       verbose: params.verbose,

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -1,4 +1,9 @@
-import type { ToolCallContent, ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
+import type {
+  SetSessionConfigOptionResponse,
+  ToolCallContent,
+  ToolCallLocation,
+  ToolKind,
+} from "@agentclientprotocol/sdk";
 import type {
   AcpElicitationHandler,
   AcpElicitationMode,
@@ -319,7 +324,11 @@ export interface AcpRuntime {
   }): Promise<AcpRuntimeCapabilities> | AcpRuntimeCapabilities;
   getStatus?(input: { handle: AcpRuntimeHandle; signal?: AbortSignal }): Promise<AcpRuntimeStatus>;
   setMode?(input: { handle: AcpRuntimeHandle; mode: string }): Promise<void>;
-  setConfigOption?(input: { handle: AcpRuntimeHandle; key: string; value: string }): Promise<void>;
+  setConfigOption?(input: {
+    handle: AcpRuntimeHandle;
+    key: string;
+    value: string;
+  }): Promise<SetSessionConfigOptionResponse | void>;
   doctor?(): Promise<AcpRuntimeDoctorReport>;
   cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void>;
   close(input: {

--- a/src/session/config-options.ts
+++ b/src/session/config-options.ts
@@ -1,8 +1,11 @@
-import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { SessionConfigOption, SetSessionConfigOptionResponse } from "@agentclientprotocol/sdk";
 import type { SessionCreateResult, SessionLoadResult } from "../acp/client.js";
+import { modelStateFromConfigOptions } from "../acp/model-support.js";
 import type { SessionAcpxState, SessionRecord } from "../types.js";
 import { cloneSessionAcpxState } from "./conversation-model.js";
-import { applyConfigOptionsModelState } from "./model-state.js";
+import { clearDesiredConfigOption } from "./mode-preference.js";
+import { currentModelIdFromSetModelResponse } from "./model-application.js";
+import { advertisedModelState, applyConfigOptionsModelState } from "./model-state.js";
 
 type ConfigOptionsResult = Pick<SessionCreateResult | SessionLoadResult, "configOptions">;
 
@@ -25,4 +28,70 @@ export function applyConfigOptionsToRecord(
   }
 
   record.acpx = applyConfigOptionsToState(record.acpx, configOptions);
+}
+
+function applyAcceptedConfigOptions(
+  state: SessionAcpxState | undefined,
+  response: SetSessionConfigOptionResponse | undefined,
+): SessionAcpxState {
+  const next = cloneSessionAcpxState(state) ?? {};
+  if (!response) {
+    return next;
+  }
+  applyConfigOptionsModelState(next, response.configOptions);
+  if (!next.desired_config_options) {
+    return next;
+  }
+  // A control response can change sibling options. Reconcile only saved
+  // selections; new/load snapshots must not replace preferences with defaults.
+  const desired: Record<string, string> = {};
+  for (const option of response.configOptions) {
+    if (
+      typeof option.currentValue === "string" &&
+      Object.hasOwn(next.desired_config_options, option.id)
+    ) {
+      desired[option.id] = option.currentValue;
+    }
+  }
+  if (Object.keys(desired).length > 0) {
+    next.desired_config_options = desired;
+  } else {
+    delete next.desired_config_options;
+  }
+  return next;
+}
+
+export function applyModelSelection(
+  state: SessionAcpxState | undefined,
+  modelId: string,
+  response: SetSessionConfigOptionResponse | undefined,
+): SessionAcpxState {
+  const modelConfigId = advertisedModelState(state)?.configId;
+  const next = applyAcceptedConfigOptions(state, response);
+  next.session_options = { ...next.session_options, model: modelId };
+  next.current_model_id = currentModelIdFromSetModelResponse(response, modelId);
+  clearDesiredConfigOption(next, modelConfigId ?? advertisedModelState(next)?.configId);
+  return next;
+}
+
+export function applyConfigOptionSelection(
+  state: SessionAcpxState | undefined,
+  configId: string,
+  value: string,
+  response: SetSessionConfigOptionResponse,
+  modelConfigId = advertisedModelState(state)?.configId,
+): SessionAcpxState {
+  if (
+    configId === modelConfigId ||
+    configId === modelStateFromConfigOptions(response.configOptions)?.configId
+  ) {
+    return applyModelSelection(state, value, response);
+  }
+  const next = cloneSessionAcpxState(state) ?? {};
+  if (configId === "mode") {
+    next.desired_mode_id = value;
+  } else {
+    next.desired_config_options = { ...next.desired_config_options, [configId]: value };
+  }
+  return applyAcceptedConfigOptions(next, response);
 }

--- a/src/session/mode-preference.ts
+++ b/src/session/mode-preference.ts
@@ -55,34 +55,6 @@ export function setDesiredModeId(record: SessionRecord, modeId: string | undefin
   record.acpx = acpx;
 }
 
-export function setDesiredConfigOption(
-  record: SessionRecord,
-  configId: string,
-  value: string | undefined,
-): void {
-  const normalizedConfigId = normalizeModeId(configId);
-  if (!normalizedConfigId || normalizedConfigId === "mode" || normalizedConfigId === "model") {
-    return;
-  }
-
-  const acpx = ensureAcpxState(record.acpx);
-  const desired = { ...acpx.desired_config_options };
-
-  if (typeof value === "string") {
-    desired[normalizedConfigId] = value;
-  } else {
-    delete desired[normalizedConfigId];
-  }
-
-  if (Object.keys(desired).length > 0) {
-    acpx.desired_config_options = desired;
-  } else {
-    delete acpx.desired_config_options;
-  }
-
-  record.acpx = acpx;
-}
-
 export function clearDesiredConfigOption(
   state: SessionAcpxState,
   configId: string | undefined,

--- a/test/connect-load.test.ts
+++ b/test/connect-load.test.ts
@@ -1083,93 +1083,226 @@ test("connectAndLoadSession restores the original session when desired model rep
   });
 });
 
-test("connectAndLoadSession replays desired config options on a fresh session", async () => {
-  await withTempHome(async (homeDir) => {
-    const cwd = path.join(homeDir, "workspace");
-    await fs.mkdir(cwd, { recursive: true });
+for (const [connection, modelMetadata, replacingConfig, savedEffort, siblingChange] of [
+  ["fresh", "different"],
+  ["load", "different"],
+  ["resume", "different"],
+  ["load", "same"],
+  ["resume", "same"],
+  ["load", "omitted"],
+  ["resume", "omitted"],
+  ["load", "removes-option"],
+  ["resume", "removes-option"],
+  ["load", "different", "thinking"],
+  ["resume", "different", "thinking"],
+  ["load", "different", undefined, "ultra"],
+  ["resume", "same", undefined, "ultra"],
+  ["load", "different", undefined, "low"],
+  ["fresh", "different", undefined, undefined, "removed"],
+  ["load", "omitted", undefined, undefined, "removed"],
+  ["resume", "omitted", undefined, undefined, "adjusted"],
+  ["resume", "same", undefined, undefined, "adjusted"],
+] as const) {
+  test(`connectAndLoadSession replays saved selections after ${connection} with ${modelMetadata} model metadata${replacingConfig ? " while replacing effort" : ""}${savedEffort ? ` with ${savedEffort === "ultra" ? "stale" : "unlisted current"} saved effort` : ""}${siblingChange ? ` with later ${siblingChange} control` : ""}`, async () => {
+    await withTempHome(async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
 
-    const record = makeSessionRecord({
-      acpxRecordId: "config-replay-record",
-      acpSessionId: "stale-session",
-      agentCommand: "agent",
-      cwd,
-      acpx: {
-        desired_config_options: {
-          reasoning_effort: "high",
-        },
-      },
-    });
-
-    const configCalls: Array<{ sessionId: string; configId: string; value: string }> = [];
-    const client: FakeClient = {
-      hasReusableSession: () => false,
-      start: async () => {},
-      getAgentLifecycleSnapshot: () => ({
-        running: true,
-      }),
-      supportsLoadSession: () => true,
-      supportsResumeSession: () => false,
-      loadSessionWithOptions: async () => {
-        throw {
-          error: {
-            code: -32002,
-            message: "session not found",
+      const record = makeSessionRecord({
+        acpxRecordId: "config-replay-record",
+        acpSessionId: "stale-session",
+        agentCommand: "agent",
+        cwd,
+        acpx: {
+          desired_mode_id: "plan",
+          session_options: { model: "gpt-5.4" },
+          desired_config_options: {
+            reasoning_effort: savedEffort ?? "high",
+            approval: "manual",
           },
-        };
-      },
-      createSession: async () => ({
-        sessionId: "fresh-session",
-        agentSessionId: "fresh-runtime",
-      }),
-      setSessionMode: async () => {},
-      setSessionModel: async () => {},
-      setSessionConfigOption: async (sessionId, configId, value) => {
-        configCalls.push({ sessionId, configId, value });
-        return {
-          configOptions: [
+        },
+      });
+
+      const configCalls: Array<{ sessionId: string; configId: string; value: string }> = [];
+      const expectedSessionId = connection === "fresh" ? "fresh-session" : "stale-session";
+      const shouldSetModel = modelMetadata !== "omitted";
+      const removesApproval = modelMetadata === "removes-option";
+      const configOptions = (
+        effort: string,
+        approval: string,
+        modelId = "gpt-5.4",
+      ): SetSessionConfigOptionResponse["configOptions"] => [
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: modelId,
+          options: buildModelsState(modelId).availableModels.map((model) => ({
+            value: model.modelId,
+            name: model.name,
+          })),
+        },
+        {
+          id: "reasoning_effort",
+          name: "Effort",
+          type: "select",
+          currentValue: effort,
+          options: [
             {
-              id: "llm",
-              name: "Model",
-              category: "model",
-              type: "select",
-              currentValue: "replayed-model",
-              options: [{ value: "replayed-model", name: "Replayed Model" }],
-            },
-            {
-              id: "reasoning_effort",
-              name: "Reasoning Effort",
-              type: "select",
-              currentValue: "high",
-              options: [{ value: "high", name: "High" }],
+              group: "supported",
+              name: "Supported",
+              options: (savedEffort === "low" ? ["high"] : ["low", "medium", "high"]).map(
+                (value) => ({ value, name: value }),
+              ),
             },
           ],
-        };
-      },
-    };
+        },
+        {
+          id: "approval",
+          name: "Approval",
+          type: "select",
+          currentValue: approval,
+          options: ["ask", "manual"].map((value) => ({ value, name: value })),
+        },
+      ];
+      const restoredOptions =
+        modelMetadata === "omitted"
+          ? {}
+          : {
+              configOptions: configOptions(
+                "low",
+                "ask",
+                modelMetadata === "same" ? "gpt-5.4" : "default-model",
+              ),
+              models: buildModelsState(modelMetadata === "same" ? "gpt-5.4" : "default-model"),
+            };
+      const acceptedOptions = (effort: string, approval: string) =>
+        configOptions(effort, approval).filter(
+          (option) => !removesApproval || option.id !== "approval",
+        );
+      const client: FakeClient = {
+        hasReusableSession: () => false,
+        start: async () => {},
+        getAgentLifecycleSnapshot: () => ({
+          running: true,
+        }),
+        supportsLoadSession: () => true,
+        supportsResumeSession: () => connection === "resume",
+        resumeSession: async () => ({
+          agentSessionId: "restored-runtime",
+          ...restoredOptions,
+        }),
+        loadSessionWithOptions: async () => {
+          if (connection === "load") {
+            return {
+              agentSessionId: "restored-runtime",
+              ...restoredOptions,
+            };
+          }
+          throw {
+            error: {
+              code: -32002,
+              message: "session not found",
+            },
+          };
+        },
+        createSession: async () => ({
+          sessionId: "fresh-session",
+          agentSessionId: "fresh-runtime",
+          configOptions: configOptions("low", "ask", "default-model"),
+          models: buildModelsState("default-model"),
+        }),
+        setSessionMode: async (sessionId, value) => {
+          assert.equal(connection, "fresh", "legacy mode must remain fresh-only");
+          configCalls.push({ sessionId, configId: "mode", value });
+        },
+        setSessionModel: async (sessionId, value) => {
+          configCalls.push({ sessionId, configId: "model", value });
+          return { configOptions: acceptedOptions("low", "ask") };
+        },
+        setSessionConfigOption: async (sessionId, configId, value) => {
+          configCalls.push({ sessionId, configId, value });
+          if (configId === "approval") {
+            assert.equal(
+              siblingChange,
+              undefined,
+              "the previous acknowledgement retired manual approval",
+            );
+          }
+          assert.notEqual(
+            value,
+            "ultra",
+            "a model acknowledgement must retire the old unsupported effort",
+          );
+          return {
+            configOptions: acceptedOptions("medium", configId === "approval" ? value : "ask")
+              .filter((option) => siblingChange !== "removed" || option.id !== "approval")
+              .map((option) =>
+                siblingChange === "adjusted" && option.id === "approval" && "options" in option
+                  ? Object.assign(option, { options: [{ value: "ask", name: "Ask" }] })
+                  : option,
+              ),
+          };
+        },
+      };
 
-    const result = await connectAndLoadSession({
-      client: client as never,
-      record,
-      activeController: ACTIVE_CONTROLLER,
+      const result = await connectAndLoadSession({
+        client: client as never,
+        record,
+        activeController: ACTIVE_CONTROLLER,
+        replacingConfigOption: replacingConfig
+          ? {
+              key: replacingConfig,
+              resolve: (connectedRecord) => {
+                assert.equal(connectedRecord.acpx?.current_model_id, "gpt-5.4");
+                return "reasoning_effort";
+              },
+            }
+          : undefined,
+      });
+
+      assert.equal(result.sessionId, expectedSessionId);
+      assert.equal(result.resumed, connection !== "fresh");
+      assert.deepEqual(configCalls, [
+        ...(connection === "fresh"
+          ? [{ sessionId: expectedSessionId, configId: "mode", value: "plan" }]
+          : []),
+        ...(shouldSetModel
+          ? [{ sessionId: expectedSessionId, configId: "model", value: "gpt-5.4" }]
+          : []),
+        ...(replacingConfig || savedEffort === "ultra"
+          ? []
+          : [
+              {
+                sessionId: expectedSessionId,
+                configId: "reasoning_effort",
+                value: savedEffort ?? "high",
+              },
+            ]),
+        ...(removesApproval || siblingChange
+          ? []
+          : [{ sessionId: expectedSessionId, configId: "approval", value: "manual" }]),
+      ]);
+      assert.deepEqual(record.acpx?.desired_config_options, {
+        reasoning_effort: "medium",
+        ...(removesApproval || siblingChange === "removed"
+          ? {}
+          : { approval: siblingChange === "adjusted" ? "ask" : "manual" }),
+      });
+      assert.equal(record.acpx?.current_model_id, "gpt-5.4");
+      assert.equal(record.acpx?.model_control, "config_option");
+      assert.deepEqual(
+        record.acpx?.config_options?.map((option) => option.id),
+        [
+          "model",
+          "reasoning_effort",
+          ...(removesApproval || siblingChange === "removed" ? [] : ["approval"]),
+        ],
+      );
     });
-
-    assert.equal(result.sessionId, "fresh-session");
-    assert.equal(result.resumed, false);
-    assert.deepEqual(configCalls, [
-      {
-        sessionId: "fresh-session",
-        configId: "reasoning_effort",
-        value: "high",
-      },
-    ]);
-    assert.equal(record.acpx?.current_model_id, "replayed-model");
-    assert.equal(record.acpx?.model_control, "config_option");
-    assert.deepEqual(
-      record.acpx?.config_options?.map((option) => option.id),
-      ["llm", "reasoning_effort"],
-    );
   });
-});
+}
 
 test("connectAndLoadSession preserves legacy models after config option replay", async () => {
   await withTempHome(async (homeDir) => {
@@ -1245,77 +1378,84 @@ test("connectAndLoadSession preserves legacy models after config option replay",
   });
 });
 
-test("connectAndLoadSession restores the original session when desired config replay fails", async () => {
-  await withTempHome(async (homeDir) => {
-    const cwd = path.join(homeDir, "workspace");
-    await fs.mkdir(cwd, { recursive: true });
+for (const connection of ["fresh", "load", "resume"] as const) {
+  test(`connectAndLoadSession restores the original session when desired config replay fails after ${connection}`, async () => {
+    await withTempHome(async (homeDir) => {
+      const cwd = path.join(homeDir, "workspace");
+      await fs.mkdir(cwd, { recursive: true });
 
-    const record = makeSessionRecord({
-      acpxRecordId: "config-replay-failure-record",
-      acpSessionId: "stale-session",
-      agentSessionId: "stale-runtime",
-      agentCommand: "agent",
-      cwd,
-      acpx: {
-        desired_config_options: {
-          reasoning_effort: "xhigh",
-        },
-      },
-    });
-
-    const client: FakeClient = {
-      hasReusableSession: () => false,
-      start: async () => {},
-      getAgentLifecycleSnapshot: () => ({
-        running: true,
-      }),
-      supportsLoadSession: () => true,
-      supportsResumeSession: () => false,
-      loadSessionWithOptions: async () => {
-        throw {
-          error: {
-            code: -32002,
-            message: "session not found",
+      const record = makeSessionRecord({
+        acpxRecordId: "config-replay-failure-record",
+        acpSessionId: "stale-session",
+        agentSessionId: "stale-runtime",
+        agentCommand: "agent",
+        cwd,
+        acpx: {
+          desired_config_options: {
+            reasoning_effort: "xhigh",
           },
-        };
-      },
-      createSession: async () => ({
-        sessionId: "fresh-session",
-        agentSessionId: "fresh-runtime",
-      }),
-      setSessionMode: async () => {},
-      setSessionModel: async () => {},
-      setSessionConfigOption: async (sessionId, configId, value) => {
-        assert.equal(sessionId, "fresh-session");
-        assert.equal(configId, "reasoning_effort");
-        assert.equal(value, "xhigh");
-        throw new Error("config restore rejected");
-      },
-    };
+        },
+      });
 
-    await assert.rejects(
-      async () =>
-        await connectAndLoadSession({
-          client: client as never,
-          record,
-          activeController: ACTIVE_CONTROLLER,
+      const client: FakeClient = {
+        hasReusableSession: () => false,
+        start: async () => {},
+        getAgentLifecycleSnapshot: () => ({
+          running: true,
         }),
-      (error: unknown) => {
-        assert(error instanceof Error);
-        assert.equal(error.name, "SessionConfigOptionReplayError");
-        assert.equal((error as Error & { retryable?: boolean }).retryable, true);
-        assert.match(
-          error.message,
-          /Failed to replay saved session config option reasoning_effort/,
-        );
-        return true;
-      },
-    );
+        supportsLoadSession: () => true,
+        supportsResumeSession: () => connection === "resume",
+        resumeSession: async () => ({ agentSessionId: "resumed-runtime" }),
+        loadSessionWithOptions: async () => {
+          if (connection === "load") {
+            return { agentSessionId: "resumed-runtime" };
+          }
+          throw {
+            error: {
+              code: -32002,
+              message: "session not found",
+            },
+          };
+        },
+        createSession: async () => ({
+          sessionId: "fresh-session",
+          agentSessionId: "fresh-runtime",
+        }),
+        setSessionMode: async () => {},
+        setSessionModel: async () => {},
+        setSessionConfigOption: async (sessionId, configId, value) => {
+          assert.equal(sessionId, connection === "fresh" ? "fresh-session" : "stale-session");
+          assert.equal(configId, "reasoning_effort");
+          assert.equal(value, "xhigh");
+          throw new Error("config restore rejected");
+        },
+      };
 
-    assert.equal(record.acpSessionId, "stale-session");
-    assert.equal(record.agentSessionId, "stale-runtime");
+      await assert.rejects(
+        async () =>
+          await connectAndLoadSession({
+            client: client as never,
+            record,
+            activeController: ACTIVE_CONTROLLER,
+          }),
+        (error: unknown) => {
+          assert(error instanceof Error);
+          assert.equal(error.name, "SessionConfigOptionReplayError");
+          assert.equal((error as Error & { retryable?: boolean }).retryable, true);
+          assert.match(
+            error.message,
+            /Failed to replay saved session config option reasoning_effort/,
+          );
+          return true;
+        },
+      );
+
+      assert.equal(record.acpSessionId, "stale-session");
+      assert.equal(record.agentSessionId, "stale-runtime");
+      assert.deepEqual(record.acpx?.desired_config_options, { reasoning_effort: "xhigh" });
+    });
   });
-});
+}
 
 test("connectAndLoadSession reuses an already loaded client session", async () => {
   await withTempHome(async (homeDir) => {
@@ -1327,6 +1467,11 @@ test("connectAndLoadSession reuses an already loaded client session", async () =
       acpSessionId: "reused-session",
       agentCommand: "agent",
       cwd,
+      acpx: {
+        session_options: { model: "gpt-5.4" },
+        desired_mode_id: "plan",
+        desired_config_options: { reasoning_effort: "high" },
+      },
     });
 
     let started = false;
@@ -1350,8 +1495,15 @@ test("connectAndLoadSession reuses an already loaded client session", async () =
       createSession: async () => {
         throw new Error("createSession should not be called");
       },
-      setSessionMode: async () => {},
-      setSessionModel: async () => {},
+      setSessionMode: async () => {
+        throw new Error("a reused session must not replay mode");
+      },
+      setSessionModel: async () => {
+        throw new Error("a reused session must not replay model");
+      },
+      setSessionConfigOption: async () => {
+        throw new Error("a reused session must not replay config");
+      },
     };
 
     const result = await connectAndLoadSession({

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1608,10 +1608,35 @@ test("integration: prompt --model updates existing session model before prompt",
 
     try {
       const created = await runCli(
-        ["--agent", modelAgentCommand, "--approve-all", "--cwd", cwd, "sessions", "new"],
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "sessions",
+          "new",
+        ],
         homeDir,
       );
       assert.equal(created.code, 0, created.stderr);
+      const { acpxRecordId } = JSON.parse(created.stdout.trim()) as { acpxRecordId: string };
+      const effort = await runCli(
+        [
+          "--agent",
+          modelAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "set",
+          "reasoning_effort",
+          "high",
+        ],
+        homeDir,
+      );
+      assert.equal(effort.code, 0, effort.stderr);
 
       const result = await runCli(
         [
@@ -1647,6 +1672,15 @@ test("integration: prompt --model updates existing session model before prompt",
       );
       assert.equal(status.code, 0, status.stderr);
       assert.equal((JSON.parse(status.stdout.trim()) as { model?: string }).model, "fast-model");
+      const stored = JSON.parse(
+        await fs.readFile(
+          path.join(homeDir, ".acpx", "sessions", `${encodeURIComponent(acpxRecordId)}.json`),
+          "utf8",
+        ),
+      ) as {
+        acpx?: { desired_config_options?: Record<string, string> };
+      };
+      assert.equal(stored.acpx?.desired_config_options?.reasoning_effort, "medium");
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }

--- a/test/prompt-runner.test.ts
+++ b/test/prompt-runner.test.ts
@@ -3,11 +3,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { AcpClient } from "../src/acp/client.js";
+import { createOutputFormatter } from "../src/cli/output/output.js";
 import {
   runSessionSetConfigOptionDirect,
   runSessionSetModelDirect,
   runSessionSetModeDirect,
 } from "../src/cli/session/prompt-runner.js";
+import { sendSessionDirect } from "../src/cli/session/runtime.js";
 import { resolveSessionRecord } from "../src/session/persistence/repository.js";
 import {
   makeSessionRecord as makeSessionRecordFixture,
@@ -16,6 +19,42 @@ import {
 } from "./runtime-test-helpers.js";
 
 const MOCK_AGENT_PATH = fileURLToPath(new URL("./mock-agent.js", import.meta.url));
+
+test("sendSessionDirect closes a shared client after reconnect preference failure", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = path.join(homeDir, "workspace");
+    await fs.mkdir(cwd, { recursive: true });
+    const record = makeSessionRecord({
+      acpxRecordId: "failed-shared-reconnect",
+      acpSessionId: "failed-shared-reconnect-backend",
+      agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --supports-load-session --advertise-models`,
+      cwd,
+      acpx: { session_options: { model: "unavailable-saved-model" } },
+    });
+    await writeSessionRecord(homeDir, record);
+    const client = new AcpClient({
+      agentCommand: record.agentCommand,
+      cwd,
+      permissionMode: "approve-all",
+    });
+    try {
+      await assert.rejects(
+        sendSessionDirect({
+          sessionId: record.acpxRecordId,
+          prompt: [{ type: "text", text: "hello" }],
+          permissionMode: "approve-all",
+          outputFormatter: createOutputFormatter("quiet"),
+          client,
+          timeoutMs: 5_000,
+        }),
+        /Failed to replay saved session model unavailable-saved-model/,
+      );
+      assert.equal(client.hasReusableSession(record.acpSessionId), false);
+    } finally {
+      await client.close();
+    }
+  });
+});
 
 test("runSessionSetModeDirect resumes a load-capable session and closes the client once", async () => {
   await withTempHome(async (homeDir) => {
@@ -190,7 +229,7 @@ test("runSessionSetConfigOptionDirect falls back to createSession and returns up
   });
 });
 
-test("runSessionSetConfigOptionDirect promotes a custom model config preference", async () => {
+test("runSessionSetConfigOptionDirect replaces an unavailable pinned model through its custom config key", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
@@ -201,6 +240,7 @@ test("runSessionSetConfigOptionDirect promotes a custom model config preference"
       agentCommand: `node ${JSON.stringify(MOCK_AGENT_PATH)} --supports-load-session --advertise-models --model-config-id llm`,
       cwd,
       acpx: {
+        session_options: { model: "unavailable-saved-model" },
         desired_config_options: {
           llm: "stale-model",
           reasoning_effort: "high",
@@ -219,7 +259,7 @@ test("runSessionSetConfigOptionDirect promotes a custom model config preference"
     assert.equal(result.record.acpx?.current_model_id, "smart-model");
     assert.equal(result.record.acpx?.session_options?.model, "smart-model");
     assert.deepEqual(result.record.acpx?.desired_config_options, {
-      reasoning_effort: "high",
+      reasoning_effort: "medium",
     });
     assert.equal(
       result.record.acpx?.config_options?.find((option) => option.id === "llm")?.currentValue,
@@ -276,7 +316,7 @@ test("runSessionSetConfigOptionDirect re-applies pinned model after reconnect", 
   });
 });
 
-test("runSessionSetModelDirect updates current and desired model", async () => {
+test("runSessionSetModelDirect replaces an unavailable pinned model", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = path.join(homeDir, "workspace");
     await fs.mkdir(cwd, { recursive: true });
@@ -289,6 +329,7 @@ test("runSessionSetModelDirect updates current and desired model", async () => {
       closed: true,
       closedAt: "2026-01-01T00:05:00.000Z",
       acpx: {
+        session_options: { model: "unavailable-saved-model" },
         desired_config_options: {
           llm: "stale-model",
           reasoning_effort: "high",
@@ -307,7 +348,7 @@ test("runSessionSetModelDirect updates current and desired model", async () => {
     assert.equal(result.record.acpx?.current_model_id, "gpt-5.4");
     assert.equal(result.record.acpx?.session_options?.model, "gpt-5.4");
     assert.deepEqual(result.record.acpx?.desired_config_options, {
-      reasoning_effort: "high",
+      reasoning_effort: "medium",
     });
     assert.equal(
       result.record.acpx?.config_options?.find((option) => option.category === "model")
@@ -319,7 +360,7 @@ test("runSessionSetModelDirect updates current and desired model", async () => {
     assert.equal(persisted.acpx?.current_model_id, "gpt-5.4");
     assert.equal(persisted.acpx?.session_options?.model, "gpt-5.4");
     assert.deepEqual(persisted.acpx?.desired_config_options, {
-      reasoning_effort: "high",
+      reasoning_effort: "medium",
     });
     assert.equal(
       persisted.acpx?.config_options?.find((option) => option.category === "model")?.currentValue,

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -1266,6 +1266,288 @@ test("AcpRuntimeManager retains a reusable persistent client across turns", asyn
   assert.equal(closeCalls, 1);
 });
 
+test("AcpRuntimeManager retries failed reconnect preferences with a new client", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "replay-failure-session",
+    acpSessionId: "replay-failure-backend",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+    acpx: { desired_config_options: { reasoning_effort: "high" } },
+  });
+  const store = new InMemorySessionStore([record]);
+  let clients = 0;
+  let closes = 0;
+  let replayCalls = 0;
+  const promptEfforts: string[] = [];
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => {
+        clients += 1;
+        let loaded = false;
+        let effort = "low";
+        return {
+          start: async () => {},
+          close: async () => {
+            closes += 1;
+            loaded = false;
+          },
+          hasReusableSession: () => loaded,
+          supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
+          loadSessionWithOptions: async () => {
+            loaded = true;
+            return {};
+          },
+          getAgentLifecycleSnapshot: () => ({ running: loaded }),
+          prompt: async () => {
+            promptEfforts.push(effort);
+            return { stopReason: "end_turn" };
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionConfigOption: async (_sessionId: string, _key: string, value: string) => {
+            replayCalls += 1;
+            if (replayCalls === 1) {
+              throw new Error("temporary preference rejection");
+            }
+            effort = value;
+            return {
+              configOptions: [
+                {
+                  id: "reasoning_effort",
+                  name: "Effort",
+                  type: "select",
+                  currentValue: effort,
+                  options: [{ value: "high", name: "High" }],
+                },
+              ],
+            };
+          },
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        } as never;
+      },
+    },
+  );
+  const handle = createHandle(record.acpxRecordId);
+  for (const [requestId, expectedStatus] of [
+    ["first", "failed"],
+    ["retry", "completed"],
+  ] as const) {
+    const { result } = await collectTurn(
+      manager.startTurn({
+        handle,
+        text: "hello",
+        mode: "prompt",
+        sessionMode: "persistent",
+        requestId,
+      }),
+    );
+    assert.equal(result.status, expectedStatus);
+  }
+  assert.deepEqual(promptEfforts, ["high"]);
+  assert.equal(replayCalls, 2);
+  assert.equal(clients, 2);
+  assert.equal(closes, 1);
+  await manager.close(handle);
+});
+
+for (const phase of [
+  "reconnect",
+  "idle",
+  "initialize",
+  "initialize-save",
+  "initialize-failure",
+] as const) {
+  test(`AcpRuntimeManager keeps config acknowledgements after earlier ${phase} notifications`, async () => {
+    const record = makeSessionRecord({
+      acpxRecordId: "ordered-config-session",
+      acpSessionId: "ordered-config-backend",
+      agentCommand: "codex --acp",
+      cwd: "/workspace",
+      acpx: {
+        session_options: { model: "target-model" },
+        desired_config_options: { reasoning_effort: "high" },
+      },
+    });
+    let afterSave: (() => void) | undefined;
+    class NotificationDuringSaveStore extends InMemorySessionStore {
+      override async save(nextRecord: AcpSessionRecord): Promise<void> {
+        await super.save(nextRecord);
+        const notify = afterSave;
+        afterSave = undefined;
+        notify?.();
+      }
+    }
+    const store = new NotificationDuringSaveStore(phase === "reconnect" ? [record] : []);
+    const initializing = phase.startsWith("initialize");
+    let handlers: FakeClientHandlers = {};
+    let loaded = false;
+    const configOptions = (
+      model: string,
+      effort: string,
+    ): SetSessionConfigOptionResponse["configOptions"] => [
+      {
+        id: "model",
+        name: "Model",
+        category: "model",
+        type: "select",
+        currentValue: model,
+        options: [
+          { value: "default-model", name: "Default" },
+          { value: "target-model", name: "Target" },
+        ],
+      },
+      {
+        id: "reasoning_effort",
+        name: "Effort",
+        type: "select",
+        currentValue: effort,
+        options: [
+          { value: "low", name: "Low" },
+          { value: "high", name: "High" },
+        ],
+      },
+    ];
+    const emitEarlierUpdates = () => {
+      handlers.onSessionUpdate?.({
+        sessionId: record.acpSessionId,
+        update: {
+          sessionUpdate: "config_option_update",
+          configOptions: configOptions("target-model", "low"),
+        },
+      });
+      handlers.onSessionUpdate?.({
+        sessionId: record.acpSessionId,
+        update: {
+          sessionUpdate: "available_commands_update",
+          availableCommands: [{ name: "reconnected", description: "Restored command" }],
+        },
+      });
+    };
+    if (phase === "initialize-save") {
+      afterSave = emitEarlierUpdates;
+    }
+    const manager = new AcpRuntimeManager(
+      createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+      {
+        clientFactory: () =>
+          ({
+            start: async () => {},
+            close: async () => {
+              loaded = false;
+            },
+            createSession: async () => {
+              loaded = true;
+              return {
+                sessionId: record.acpSessionId,
+                configOptions: configOptions("default-model", "low"),
+                models: {
+                  configId: "model",
+                  currentModelId: "default-model",
+                  availableModels: [{ modelId: "target-model", name: "Target" }],
+                },
+              };
+            },
+            hasReusableSession: () => loaded,
+            supportsLoadSession: () => true,
+            supportsResumeSession: () => false,
+            loadSessionWithOptions: async () => {
+              loaded = true;
+              return {
+                configOptions: configOptions("default-model", "low"),
+                models: {
+                  configId: "model",
+                  currentModelId: "default-model",
+                  availableModels: [
+                    { modelId: "default-model", name: "Default" },
+                    { modelId: "target-model", name: "Target" },
+                  ],
+                },
+              };
+            },
+            getAgentLifecycleSnapshot: () => ({ running: loaded }),
+            prompt: async () => ({ stopReason: "end_turn" }),
+            requestCancelActivePrompt: async () => false,
+            hasActivePrompt: () => false,
+            setSessionModel: async () => {
+              emitEarlierUpdates();
+              if (phase === "initialize-failure") {
+                // Cross the live checkpoint interval while initialization is
+                // unresolved: no partial session may become externally visible.
+                await new Promise((resolve) => setTimeout(resolve, 650));
+                assert.equal(store.records.has(record.acpxRecordId), false);
+                throw new Error("initial model selection rejected");
+              }
+              return {
+                configOptions: configOptions("target-model", initializing ? "high" : "low"),
+              };
+            },
+            setSessionConfigOption: async () => {
+              if (phase === "idle") {
+                emitEarlierUpdates();
+              }
+              return { configOptions: configOptions("target-model", "high") };
+            },
+            clearEventHandlers: () => {
+              handlers = {};
+            },
+            setEventHandlers: (next: FakeClientHandlers) => {
+              handlers = next;
+            },
+          }) as never,
+      },
+    );
+    const handle = createHandle(record.acpxRecordId);
+    if (phase !== "reconnect") {
+      const initialized = manager.ensureSession({
+        sessionKey: record.acpxRecordId,
+        agent: "codex",
+        mode: "persistent",
+        sessionOptions: initializing ? { model: "target-model" } : undefined,
+      });
+      if (phase === "initialize-failure") {
+        await assert.rejects(initialized, /initial model selection rejected/);
+        assert.equal(store.records.has(record.acpxRecordId), false);
+        assert.equal(loaded, false);
+        return;
+      }
+      await initialized;
+      if (phase === "idle") {
+        await manager.setConfigOption(handle, "reasoning_effort", "high");
+      }
+    } else {
+      const { result } = await collectTurn(
+        manager.startTurn({
+          handle,
+          text: "hello",
+          mode: "prompt",
+          sessionMode: "persistent",
+          requestId: "ordered-reconnect",
+        }),
+      );
+      assert.equal(result.status, "completed");
+    }
+    const reloadedManager = new AcpRuntimeManager(
+      createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    );
+    const status = await reloadedManager.getStatus(handle);
+    assert.deepEqual(
+      status.details?.configOptions,
+      configOptions("target-model", phase === "initialize-save" ? "low" : "high"),
+    );
+    assert.deepEqual(status.availableCommands, [
+      { name: "reconnected", description: "Restored command", hasInput: false },
+    ]);
+    assert.deepEqual(
+      store.records.get(record.acpxRecordId)?.acpx?.desired_config_options,
+      initializing ? undefined : { reasoning_effort: "high" },
+    );
+    await manager.close(handle);
+  });
+}
+
 test("AcpRuntimeManager projects session updates before, during, and after turns", async () => {
   const store = new InMemorySessionStore();
   let handlers: FakeClientHandlers = {};
@@ -2052,73 +2334,130 @@ test("AcpRuntimeManager maps generic thinking config to refreshed advertised eff
   assert.deepEqual(stored?.acpx?.desired_config_options, { effort: "high" });
 });
 
-test("AcpRuntimeManager persists advertised model config as desired model", async () => {
-  const record = makeSessionRecord({
-    acpxRecordId: "model-config-session",
-    acpSessionId: "model-config-backend-session",
-    agentCommand: "agent",
-    cwd: "/workspace",
-    acpx: {
-      desired_config_options: {
-        effort: "high",
-        llm: "stale-model",
-      },
-      config_options: [
-        {
-          id: "llm",
-          name: "Model",
-          category: "model",
-          type: "select",
-          currentValue: "default-model",
-          options: [{ value: "smart-model", name: "Smart Model" }],
+for (const scenario of [
+  {
+    name: "normalizes saved effort",
+    desiredEffort: "high",
+    acceptedEffort: "medium",
+    advertiseModel: true,
+  },
+  {
+    name: "removes unavailable effort",
+    desiredEffort: "high",
+    acceptedEffort: undefined,
+    advertiseModel: true,
+  },
+  {
+    name: "does not pin default effort",
+    desiredEffort: undefined,
+    acceptedEffort: "medium",
+    advertiseModel: true,
+  },
+  {
+    name: "learns the model control from the response",
+    desiredEffort: "high",
+    acceptedEffort: "medium",
+    advertiseModel: false,
+  },
+]) {
+  test(`AcpRuntimeManager persists accepted model preferences: ${scenario.name}`, async () => {
+    const record = makeSessionRecord({
+      acpxRecordId: "model-config-session",
+      acpSessionId: "model-config-backend-session",
+      agentCommand: "agent",
+      cwd: "/workspace",
+      acpx: {
+        desired_config_options: {
+          ...(scenario.desiredEffort ? { effort: scenario.desiredEffort } : {}),
+          llm: "stale-model",
         },
-      ],
-    },
-  });
-  const store = new InMemorySessionStore([record]);
-  const manager = new AcpRuntimeManager(
-    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
-    {
-      clientFactory: () =>
-        ({
-          start: async () => {},
-          close: async () => {},
-          hasReusableSession: () => false,
-          supportsLoadSession: () => true,
-          supportsResumeSession: () => false,
-          loadSessionWithOptions: async () => ({
-            configOptions: record.acpx?.config_options,
-          }),
-          getAgentLifecycleSnapshot: () => ({ running: true }),
-          requestCancelActivePrompt: async () => false,
-          hasActivePrompt: () => false,
-          setSessionMode: async () => {},
-          setSessionConfigOption: async () => ({
-            configOptions: [
+        config_options: scenario.advertiseModel
+          ? [
               {
                 id: "llm",
                 name: "Model",
                 category: "model",
                 type: "select",
-                currentValue: "smart-model",
+                currentValue: "default-model",
                 options: [{ value: "smart-model", name: "Smart Model" }],
               },
-            ],
-          }),
-          clearEventHandlers: () => {},
-          setEventHandlers: () => {},
-        }) as never,
-    },
-  );
+            ]
+          : undefined,
+      },
+    });
+    const store = new InMemorySessionStore([record]);
+    const manager = new AcpRuntimeManager(
+      createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+      {
+        clientFactory: () =>
+          ({
+            start: async () => {},
+            close: async () => {},
+            hasReusableSession: () => false,
+            supportsLoadSession: () => true,
+            supportsResumeSession: () => false,
+            loadSessionWithOptions: async () => ({
+              configOptions: record.acpx?.config_options,
+            }),
+            getAgentLifecycleSnapshot: () => ({ running: true }),
+            requestCancelActivePrompt: async () => false,
+            hasActivePrompt: () => false,
+            setSessionMode: async () => {},
+            setSessionConfigOption: async () => ({
+              configOptions: [
+                {
+                  id: "llm",
+                  name: "Model",
+                  category: "model",
+                  type: "select",
+                  currentValue: "smart-model",
+                  options: [{ value: "smart-model", name: "Smart Model" }],
+                },
+                ...(scenario.acceptedEffort
+                  ? [
+                      {
+                        id: "effort",
+                        name: "Effort",
+                        type: "select",
+                        currentValue: scenario.acceptedEffort,
+                        options: [{ value: scenario.acceptedEffort, name: "Medium" }],
+                      },
+                    ]
+                  : []),
+              ],
+            }),
+            clearEventHandlers: () => {},
+            setEventHandlers: () => {},
+          }) as never,
+      },
+    );
 
-  await manager.setConfigOption(createHandle("model-config-session"), "llm", "smart-model");
+    const response = await manager.setConfigOption(
+      createHandle("model-config-session"),
+      "llm",
+      "smart-model",
+    );
+    assert.equal(
+      response.configOptions.find((option) => option.id === "llm")?.currentValue,
+      "smart-model",
+    );
+    assert.equal(
+      response.configOptions.find((option) => option.id === "effort")?.currentValue,
+      scenario.acceptedEffort,
+    );
 
-  const stored = await store.load("model-config-session");
-  assert.equal(stored?.acpx?.session_options?.model, "smart-model");
-  assert.deepEqual(stored?.acpx?.desired_config_options, { effort: "high" });
-});
+    const stored = await store.load("model-config-session");
+    assert.equal(stored?.acpx?.session_options?.model, "smart-model");
+    assert.deepEqual(
+      stored?.acpx?.desired_config_options,
+      scenario.desiredEffort && scenario.acceptedEffort
+        ? { effort: scenario.acceptedEffort }
+        : undefined,
+    );
+  });
+}
 
-test("AcpRuntimeManager maps active generic thinking config against live advertised effort key", async () => {
+test("AcpRuntimeManager maps active thinking controls and persists the accepted value", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "active-thinking-alias-session",
     acpSessionId: "active-thinking-alias-backend-session",
@@ -2186,8 +2525,8 @@ test("AcpRuntimeManager maps active generic thinking config against live adverti
                   id: "effort",
                   name: "Effort",
                   type: "select",
-                  currentValue: value,
-                  options: [{ value, name: "High" }],
+                  currentValue: "medium",
+                  options: [{ value: "medium", name: "Medium" }],
                 },
               ],
             };
@@ -2222,6 +2561,95 @@ test("AcpRuntimeManager maps active generic thinking config against live adverti
   ]);
   assert.deepEqual(result, { status: "completed", stopReason: "end_turn" });
   assert.deepEqual(events, []);
+  assert.deepEqual((await store.load(record.acpxRecordId))?.acpx?.desired_config_options, {
+    effort: "medium",
+  });
+});
+
+test("AcpRuntimeManager retains a model selection when its control disappears before acknowledgement", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "active-model-removal",
+    acpSessionId: "active-model-session",
+    agentCommand: "agent",
+    cwd: "/workspace",
+    acpx: {
+      session_options: { model: "old-model" },
+      desired_config_options: { effort: "high" },
+      config_options: [
+        {
+          id: "llm",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: "old-model",
+          options: [{ value: "next-model", name: "Next Model" }],
+        },
+      ],
+    },
+  });
+  const store = new InMemorySessionStore([record]);
+  let resolveStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    resolveStarted = resolve;
+  });
+  let resolvePrompt!: (value: { stopReason: string }) => void;
+  const prompt = new Promise<{ stopReason: string }>((resolve) => {
+    resolvePrompt = resolve;
+  });
+  let handlers: FakeClientHandlers = {};
+  const client = createModelsClientFactory({})();
+  client.hasActivePrompt = () => true;
+  client.setEventHandlers = (next) => {
+    handlers = next;
+  };
+  client.prompt = async () => {
+    resolveStarted();
+    return await prompt;
+  };
+  client.setSessionConfigOption = async (_sessionId, key, value) => {
+    if (key !== "llm") {
+      return {
+        configOptions: [
+          ...record.acpx!.config_options!,
+          {
+            id: key,
+            name: key,
+            type: "select",
+            currentValue: value,
+            options: [{ value, name: value }],
+          },
+        ],
+      };
+    }
+    handlers.onSessionUpdate?.({
+      sessionId: record.acpSessionId,
+      update: { sessionUpdate: "config_option_update", configOptions: [] },
+    });
+    return { configOptions: [] };
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    { clientFactory: () => client as never },
+  );
+  const handle = createHandle(record.acpxRecordId);
+  const turn = manager.startTurn({
+    handle,
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "active-model-removal-turn",
+  });
+  const events = collectEvents(turn.events);
+  await started;
+  try {
+    await manager.setConfigOption(handle, "llm", "next-model");
+  } finally {
+    resolvePrompt({ stopReason: "end_turn" });
+  }
+  await Promise.all([turn.result, events]);
+  const stored = await store.load(record.acpxRecordId);
+  assert.equal(stored?.acpx?.session_options?.model, "next-model");
+  assert.equal(stored?.acpx?.desired_config_options, undefined);
 });
 
 test("AcpRuntimeManager waits for active load refresh before resolving generic config keys", async () => {
@@ -2531,6 +2959,7 @@ test("AcpRuntimeManager handles offline oneshot controls, status, close, and mis
           },
           setSessionConfigOption: async (sessionId: string) => {
             setConfigSessions.push(sessionId);
+            return { configOptions: [] };
           },
           clearEventHandlers: () => {},
           setEventHandlers: () => {},

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -136,7 +136,7 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
       acpxRecordId: record.acpxRecordId,
     }),
     setMode: async () => {},
-    setConfigOption: async () => {},
+    setConfigOption: async () => ({ configOptions: [] }),
     cancel: async () => {
       managerCancelCalls += 1;
     },
@@ -214,7 +214,9 @@ test("AcpxRuntime delegates session lifecycle to the runtime manager", async () 
 
   await runtime.getStatus({ handle });
   await runtime.setMode({ handle, mode: "architect" });
-  await runtime.setConfigOption({ handle, key: "approval", value: "manual" });
+  assert.deepEqual(await runtime.setConfigOption({ handle, key: "approval", value: "manual" }), {
+    configOptions: [],
+  });
   await runtime.cancel({ handle, reason: "legacy cancel" });
   await turn.closeStream({ reason: "observer closed stream" });
   await turn.cancel();

--- a/test/session-conversation-model.test.ts
+++ b/test/session-conversation-model.test.ts
@@ -337,6 +337,7 @@ test("model config parsing ignores malformed raw and persisted snapshots", () =>
 test("connected model state propagates authoritative removals", () => {
   const merged = mergeConnectedModelState(
     {
+      desired_config_options: { reasoning_effort: "high" },
       current_model_id: "stale-model",
       available_models: ["stale-model"],
       model_control: "config_option",
@@ -357,6 +358,7 @@ test("connected model state propagates authoritative removals", () => {
   assert.equal(merged?.available_models, undefined);
   assert.equal(merged?.model_control, undefined);
   assert.equal(merged?.config_options, undefined);
+  assert.equal(merged?.desired_config_options, undefined);
 });
 
 test("recordPromptSubmission preserves audio prompt content", () => {

--- a/test/session-mode-preference.test.ts
+++ b/test/session-mode-preference.test.ts
@@ -1,10 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  getDesiredConfigOptions,
   getDesiredModeId,
   normalizeModeId,
-  setDesiredConfigOption,
   setDesiredModeId,
   setDesiredModelId,
 } from "../src/session/mode-preference.js";
@@ -35,26 +33,6 @@ test("setDesiredModeId creates and clears acpx mode preference state", () => {
   assert.deepEqual(record.acpx, {});
 
   setDesiredModeId(record, undefined);
-  assert.deepEqual(record.acpx, {});
-});
-
-test("setDesiredConfigOption persists non-mode config option preferences", () => {
-  const record = makeSessionRecord();
-
-  setDesiredConfigOption(record, " reasoning_effort ", "high");
-  setDesiredConfigOption(record, "mode", "plan");
-  setDesiredConfigOption(record, "model", "gpt-5.4");
-
-  assert.deepEqual(record.acpx, {
-    desired_config_options: {
-      reasoning_effort: "high",
-    },
-  });
-  assert.deepEqual(getDesiredConfigOptions(record.acpx), {
-    reasoning_effort: "high",
-  });
-
-  setDesiredConfigOption(record, "reasoning_effort", undefined);
   assert.deepEqual(record.acpx, {});
 });
 


### PR DESCRIPTION
## What Problem This Solves

Switching models can change or remove reasoning-effort controls. ACPX saved the requested value instead of the adapter's accepted value, so a successful switch could leave a stale preference behind. A new ACP client also skipped saved model/config replay after `session/load` or `session/resume`, even when the adapter resumed the same conversation with different defaults.

This consolidates the reconnect repair from @programmerlapar with the accepted-selection repair, preserving contributor credit. Real Codex and Claude sessions reproduced the stale-selection behavior before the fix.

## Why This Change Was Made

Session selection state now has one reconciliation path for explicit controls and replay: accept the complete config response, update only existing non-mode selections, and remove selections whose controls disappeared. Unselected backend defaults remain unpinned. Embedded `AcpxRuntime.setConfigOption` returns the complete accepted response after saving it; third-party implementations of the public runtime interface may still return void.

The reconnect owner restores the saved model before surviving config preferences on genuine new/load/resume connections. It reconciles stale values written by earlier versions against the model acknowledgement, including when the resumed model is already current. Warm reusable sessions do not replay. Explicit replacement controls can replace an obsolete saved selection without first replaying it.

The session owner also keeps notifications and acknowledgements in execution order and never pools a client whose preference replay failed. Initial, idle, active-turn, and reconnect paths share the repaired state ownership. Duplicate prompt-model replay, setter bookkeeping, and idle state mirrors were removed. Legacy `session/set_mode` replay policy is unchanged.

## User Impact

Model switches preserve the conversation while accepted effort adjustments/removals survive reconnects. A failed replay stops visibly; a retry must reconnect and reapply preferences before prompting. No new operator configuration, environment variable, dependency, or storage schema is introduced.

## Evidence

Verified source commit: `af319d35bb8730b472c4525edc6d3a6c8a3fb39e`. Its patch is byte-identical to the reviewed and tested candidate. Production: +368/-421 (net -53); tests: +877/-239 (net +638). Documentation and changelog are separate.

- `pnpm run check && pnpm run check:docs` passed on clean Linux/AWS after a frozen dependency install: **965 tests**, then **140 coverage tests**. The configured coverage target passed at 95.06% lines/statements, 88.81% branches, and 96.63% functions; this is not whole-repository coverage. [Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_746b6d3e95e5), lease `cbx_f049840dc24d`, verified released.
- Local lint, typecheck, production/test builds, formatting, docs, and **139 focused tests** passed. The earlier CLI model integration subset also passed all 14 cases and is covered by the final full suite.
- Independent Codex autoreview completed with **no findings** on the frozen final patch. Review was static; execution proof is reported separately here.
- Regression tests failed before their repairs: stale accepted effort, genuine load/resume replay, explicit replacement, retry after failed replay, earlier notifications overwriting later acknowledgements, initial-save ordering, and later controls invalidated by an earlier replay acknowledgement.

Real Codex ACP **1.6.0** and Claude ACP **0.60.0** ran against the built candidate (`runtime.js` SHA-256 `e9c701679be30172cd623325d976e741deb068f08f4bd43762f963fde334146b`). Independent, source-blind probes exercised model switching, complete accepted responses, saved state, untouched defaults, invalid values, and genuine reconnects. Six no-tool prompts completed; 52 control responses matched the complete real adapter response. Codex Sol → Luna adjusted selected `ultra` to accepted/saved `medium`; Claude Sonnet → Haiku removed effort and its saved preference. Fresh processes resumed the same backend identities and restored selected settings before prompting; marker recall confirmed conversation continuity. Higher efforts were selected only for control probes, never used for inference. Isolated state, native processes, and the credential task window were removed.

Earlier clean-machine attempts were blocked before tests by an undersized image disk and unsupported local Actions hydration. The final run used the same configured AWS provider with a supported disk size and an explicit frozen install. No assertions, deadlines, or test-cache settings were weakened. The existing ineffective dynamic import warning in `output/render.ts` remains unchanged.

Dependency inspection includes the real Codex and Claude ACP adapter control handlers and Codex `rust-v0.149.1` `codex-rs/app-server/src/request_processors/turn_processor.rs:776` (omitted effort is not an explicit clear).

## Review Follow-through

The prior ClawSweeper review requested maintainer review and real resume proof; both are supplied above. This maintainer rewrite broadens the repair only within session selection/reconnect ownership. Diagnostics now say “ACP session” on both fresh and resumed paths; replay logs do not print arbitrary config values. Fresh ClawSweeper review is requested for the rewritten head, and exact-head CI remains a landing gate.
