### PR TITLE
fix(docs): correct raw ACP JSON automation examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Docs/JSON: fix raw ACP tool-call pipelines and message examples so automation reads nested session updates and handles partial tool updates. Fixes #520. Thanks @prateek.
+
 ## 2026.8.18 (v0.13.1)
 
 ### Changes

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -542,8 +542,8 @@ When `--suppress-reads` is enabled:
 ACP message examples:
 
 ```json
-{"jsonrpc":"2.0","id":"req-1","method":"session/prompt","params":{"sessionId":"019c...","prompt":"hi"}}
-{"jsonrpc":"2.0","method":"session/update","params":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}}
+{"jsonrpc":"2.0","id":"req-1","method":"session/prompt","params":{"sessionId":"019c...","prompt":[{"type":"text","text":"hi"}]}}
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"019c...","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}}}
 {"jsonrpc":"2.0","id":"req-1","result":{"stopReason":"end_turn"}}
 ```
 
@@ -668,5 +668,7 @@ acpx config init
 
 # JSON automation pipeline
 acpx --format json codex exec 'review latest diff for security issues' \
-  | jq -r 'select(.type=="tool_call") | [.status, .title] | @tsv'
+  | jq -r 'select(.method=="session/update") | .params.update
+           | select(.sessionUpdate=="tool_call" or .sessionUpdate=="tool_call_update")
+           | [(.status // "-"), (.title // "-")] | @tsv'
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,15 @@ acpx codex 'find the flaky test and fix it'
 
 # Switch agents, same surface.
 acpx claude 'refactor the auth middleware'
-acpx gemini 'review this branch'
 
 # One-shot, no saved context.
 acpx codex exec 'summarize this repo in 5 bullets'
 
 # Pipe structured ACP events into your own automation.
 acpx --format json codex exec 'review changed files' \
-  | jq -r 'select(.type=="tool_call") | [.status,.title] | @tsv'
+  | jq -r 'select(.method=="session/update") | .params.update
+           | select(.sessionUpdate=="tool_call" or .sessionUpdate=="tool_call_update")
+           | [(.status // "-"), (.title // "-")] | @tsv'
 
 # Run a TypeScript multi-step flow against a real agent.
 acpx flow run examples/flows/branch.flow.ts \
@@ -33,7 +34,7 @@ acpx flow run examples/flows/branch.flow.ts \
 
 ## What acpx does
 
-- **One CLI, every coding agent.** Built-in adapters for Codex, Claude, Pi, OpenClaw, Gemini, Cursor, Copilot, Droid, Qwen, Qoder, Trae, and more — plus `--agent` for any custom ACP server.
+- **One CLI, every coding agent.** Built-in adapters for Pi, OpenClaw, Codex, Claude, and more — plus `--agent` for any custom ACP server.
 - **Persistent sessions.** Multi-turn conversations survive across invocations, scoped per repo. `-s <name>` runs parallel workstreams (`backend`, `docs`, `pr-842`).
 - **Queue-aware prompts.** Submit while a turn is running; new prompts queue and drain in order. `--no-wait` enqueues and returns. `cancel` aborts cooperatively without tearing the session down.
 - **Crash-resistant.** Dead agent processes are detected and reloaded automatically. `Ctrl+C` sends ACP `session/cancel` before any force-kill.

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -40,8 +40,8 @@ acpx --format json codex exec 'review changed files' \
 ```
 
 ```json
-{"jsonrpc":"2.0","id":"req-1","method":"session/prompt","params":{"sessionId":"019c…","prompt":"hi"}}
-{"jsonrpc":"2.0","method":"session/update","params":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}}
+{"jsonrpc":"2.0","id":"req-1","method":"session/prompt","params":{"sessionId":"019c…","prompt":[{"type":"text","text":"hi"}]}}
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"019c…","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello"}}}}
 {"jsonrpc":"2.0","id":"req-1","result":{"stopReason":"end_turn"}}
 ```
 

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -422,7 +422,9 @@ Example automation:
 
 ```bash
 acpx --format json codex exec 'review changed files' \
-  | jq -r 'select(.type=="tool_call") | [.status, .title] | @tsv'
+  | jq -r 'select(.method=="session/update") | .params.update
+           | select(.sessionUpdate=="tool_call" or .sessionUpdate=="tool_call_update")
+           | [(.status // "-"), (.title // "-")] | @tsv'
 ```
 
 ## Permission modes

--- a/test/docs-output.test.ts
+++ b/test/docs-output.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const docs = ["skills/acpx/SKILL.md", "docs/CLI.md", "docs/index.md"];
+
+test("documented jq pipelines select raw ACP tool calls and sparse updates", (t) => {
+  const jq = spawnSync("jq", ["--version"], { encoding: "utf8" });
+  if (jq.error && "code" in jq.error && jq.error.code === "ENOENT") {
+    t.skip("jq is required to execute the documented automation examples");
+    return;
+  }
+  assert.equal(jq.status, 0, jq.stderr);
+
+  const updates = [
+    { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello" } },
+    { sessionUpdate: "tool_call", toolCallId: "read-1", status: "in_progress", title: "Read" },
+    { sessionUpdate: "tool_call_update", toolCallId: "read-1", status: "completed" },
+    { sessionUpdate: "tool_call_update", toolCallId: "read-1", title: "Read README" },
+    { sessionUpdate: "tool_call_update", toolCallId: "read-1", content: [] },
+  ];
+  const frames = [
+    { jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: 1 } },
+    ...updates.map((update) => ({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { sessionId: "session-1", update },
+    })),
+    { jsonrpc: "2.0", id: 2, result: { stopReason: "end_turn" } },
+  ];
+  const input = frames.map((frame) => JSON.stringify(frame)).join("\n");
+
+  for (const doc of docs) {
+    const source = readFileSync(doc, "utf8");
+    const filters = [...source.matchAll(/\| jq -r '([^']+)'/g)];
+    assert.equal(filters.length, 1, `${doc}: expected one automation pipeline`);
+    const result = spawnSync("jq", ["-r", filters[0][1]], { input, encoding: "utf8" });
+    assert.equal(result.status, 0, `${doc}: ${result.stderr}`);
+    assert.equal(result.stdout, "in_progress\tRead\ncompleted\t-\n-\tRead README\n-\t-\n", doc);
+  }
+});


### PR DESCRIPTION
## Problem

The tool-call automation examples filter synthetic top-level `type`, `status`, and `title` fields, but JSON output deliberately preserves raw ACP JSON-RPC frames. Tool data lives under `session/update` → `params.update`, so the documented filters silently return no rows. The representative frames also omit the nested update object and show a string instead of ACP prompt content blocks.

## Change

Correct all three documented tool-call pipelines to select the nested `tool_call` and `tool_call_update` payloads, with placeholders for omitted status/title fields in partial updates. Repair the sample frames without changing the wire format. Keep the touched landing examples within the repository's harness documentation policy.

Add a regression that executes the actual documented jq filters against tool calls, sparse updates, and unrelated frames. The test skips when jq is unavailable locally; GitHub's Ubuntu runner provides jq. Thanks @prateek for the report.

## Proof

- Built CLI against the repository's ACP mock adapter: exit 0, 11 raw JSON-RPC frames, empty stderr. The old filter emitted 0 rows; each corrected documented filter emitted the expected 2 rows (`in_progress` and `completed`). No provider credentials used.
- The new regression failed before the documentation fix and passes after it, covering all three pipelines and four tool-update field combinations.
- Documentation checks, formatting, typecheck, lint, distributable/viewer builds, and required Slophammer rule/DRY/dependency-boundary checks passed.
- ACP initialize conformance smoke passed on Node 22 (1/1). A Node 24 attempt hit the existing 10-second adapter startup deadline.
- Codex autoreview: no accepted/actionable findings on the final patch.
- [Full CI is green](https://github.com/openclaw/acpx/actions/runs/33156773160), including Test, Mutation, Conformance Smoke, Docs, Format, Typecheck, Lint, Build, and Slophammer.
- Local targeted coverage: 130/130 passed; 94.64% lines/statements, 88.39% branches, 96.67% functions for the configured target. Local mutation: 90.80% across 424 mutants (376 killed, 9 timed out, 39 survived), above the 80% gate.
- Local full-check caveat: the first run ended with 913 passes and 12 failures after startup timeouts and a stalled existing heartbeat test that had to be stopped. The retry completed all 936 tests: 927 passed and 9 hit existing 15/20-second conformance/flow CLI startup deadlines. No runtime code, deadlines, or assertions were weakened; the isolated CI Test job passed.

AI-assisted with Codex.

Fixes #520
