### PR TITLE
fix(flows): ignore EPIPE on shell action stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Flows: keep the host alive when a shell action closes stdin before consuming its input. Thanks @SebTardif.
+
 ## 2026.8.28 (v0.13.2)
 
 ### Changes

--- a/src/flows/executors/shell.ts
+++ b/src/flows/executors/shell.ts
@@ -1,6 +1,33 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { TimeoutError } from "../../async-control.js";
 import type { ShellActionExecution, ShellActionResult } from "../runtime.js";
+
+const SHELL_STDIN_PIPE_DEATH_CODES = new Set([
+  "EPIPE",
+  "EIO",
+  "ECONNRESET",
+  "ERR_STREAM_DESTROYED",
+]);
+
+function ignoreShellStdinPipeDeath(error: NodeJS.ErrnoException): void {
+  if (error.code && SHELL_STDIN_PIPE_DEATH_CODES.has(error.code)) {
+    return;
+  }
+}
+
+function writeShellStdin(child: ChildProcess, stdin: string | undefined): void {
+  const stream = child.stdin;
+  if (!stream) {
+    return;
+  }
+  stream.on("error", ignoreShellStdinPipeDeath);
+  if (stdin != null && stream.writable && !stream.writableEnded) {
+    stream.write(stdin);
+  }
+  if (stream.writable && !stream.writableEnded) {
+    stream.end();
+  }
+}
 
 export function formatShellActionSummary(spec: ShellActionExecution): string {
   return `shell: ${renderShellCommand(spec.command, spec.args ?? [])}`;
@@ -94,10 +121,7 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
     });
   });
 
-  if (spec.stdin != null) {
-    child.stdin.write(spec.stdin);
-  }
-  child.stdin.end();
+  writeShellStdin(child, spec.stdin);
 
   if (spec.timeoutMs != null && spec.timeoutMs > 0) {
     timeout = setTimeout(() => {

--- a/src/flows/executors/shell.ts
+++ b/src/flows/executors/shell.ts
@@ -2,25 +2,14 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { TimeoutError } from "../../async-control.js";
 import type { ShellActionExecution, ShellActionResult } from "../runtime.js";
 
-const SHELL_STDIN_PIPE_DEATH_CODES = new Set([
-  "EPIPE",
-  "EIO",
-  "ECONNRESET",
-  "ERR_STREAM_DESTROYED",
-]);
-
-function ignoreShellStdinPipeDeath(error: NodeJS.ErrnoException): void {
-  if (error.code && SHELL_STDIN_PIPE_DEATH_CODES.has(error.code)) {
-    return;
-  }
-}
-
 function writeShellStdin(child: ChildProcess, stdin: string | undefined): void {
   const stream = child.stdin;
   if (!stream) {
     return;
   }
-  stream.on("error", ignoreShellStdinPipeDeath);
+  stream.on("error", () => {
+    // A child may close its input early; its exit status remains authoritative.
+  });
   if (stdin != null && stream.writable && !stream.writableEnded) {
     stream.write(stdin);
   }

--- a/test/flows-shell.test.ts
+++ b/test/flows-shell.test.ts
@@ -28,7 +28,7 @@ function runHostScript(script: string): Promise<{
       stderr += chunk;
     });
     child.once("error", reject);
-    child.once("exit", (exitCode) => {
+    child.once("close", (exitCode) => {
       resolve({ exitCode, stdout, stderr });
     });
   });

--- a/test/flows-shell.test.ts
+++ b/test/flows-shell.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
 import { TimeoutError } from "../src/async-control.js";
 import {
@@ -6,6 +7,32 @@ import {
   renderShellCommand,
   runShellAction,
 } from "../src/flows/executors/shell.js";
+
+function runHostScript(script: string): Promise<{
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", script], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("exit", (exitCode) => {
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
 
 test("renderShellCommand quotes arguments consistently", () => {
   assert.equal(renderShellCommand("echo", ["hello", "two words"]), 'echo "hello" "two words"');
@@ -76,4 +103,27 @@ test("runShellAction rejects commands terminated by signal", async () => {
       }),
     /signal SIGTERM/,
   );
+});
+
+test("runShellAction does not crash the host when the child exits before reading stdin", async () => {
+  const moduleUrl = new URL("../src/flows/executors/shell.js", import.meta.url).href;
+  const host = await runHostScript(`
+    import { runShellAction } from ${JSON.stringify(moduleUrl)};
+    const result = await runShellAction({
+      command: process.execPath,
+      args: ["-e", "setImmediate(() => process.exit(0))"],
+      stdin: "x".repeat(1024 * 1024),
+      allowNonZeroExit: true,
+    });
+    process.stdout.write(JSON.stringify({
+      exitCode: result.exitCode,
+      signal: result.signal,
+    }));
+  `);
+
+  assert.equal(host.exitCode, 0, host.stderr);
+  assert.doesNotMatch(host.stderr, /EPIPE|uncaughtException|Unhandled/);
+  const payload = JSON.parse(host.stdout) as { exitCode: number | null; signal: string | null };
+  assert.equal(payload.exitCode, 0);
+  assert.equal(payload.signal, null);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `defineFlow` / `shell()` / `acpx flow` with `ShellActionExecution.stdin` would lose the whole CLI when the child exited without reading that stdin. Node treats an `error` event on the child stdin pipe as fatal when no listener is attached, so a large write (1 MiB) to a child that does `setImmediate(() => process.exit(0))` raised uncaught `EPIPE` and killed the host.

## Why This Change Was Made

`runShellAction` already pipes stdin and settles the action from the child `exit` event. It did not attach an `error` listener on `child.stdin`, and it called `write` / `end` even after the stream had already ended. This change ignores pipe-death codes on stdin (`EPIPE`, `EIO`, `ECONNRESET`, `ERR_STREAM_DESTROYED`) and skips `write` / `end` when the stream is no longer writable. The existing `exit` handler still records status.

This is not the CLI `process.stdout` path from closed [#441](https://github.com/openclaw/acpx/pull/441). That helper can throw or exit. Child stdin must not. Open [#507](https://github.com/openclaw/acpx/pull/507) covers terminal stdout/stderr listeners. Merged [#501](https://github.com/openclaw/acpx/pull/501) timed out hung process-list helpers. Merged [#498](https://github.com/openclaw/acpx/pull/498) covers finalize persist errors. None of those touch flow shell stdin.

The missing listener dates to [#179](https://github.com/openclaw/acpx/pull/179) (`697ee1f`, 2026-03-26, "feat: add experimental acpx flows runtime and examples"), 156 days on `main`.

## User Impact

A flow that feeds stdin into a short-lived shell child keeps the ACP host alive. The shell action still completes from the child's exit status. Operators no longer lose the CLI because leftover stdin raised `EPIPE`.

## Evidence

terminal output from live `node` against compiled public `defineFlow` / `shell()` / `FlowRunner` (`dist/flows.js`).

Same script: 1 MiB `stdin` to `process.execPath -e "setImmediate(() => process.exit(0))"`.

Before, on unpatched `src/flows/executors/shell.ts` compiled to `dist`, the host throws and exits 1:

```console
$ node /tmp/acpx-F003-proof.mjs
node:events:505
    throw er; // Unhandled 'error' event
    ^

Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:87:19)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}

Node.js v26.7.0
```

After, on the patched compiled `runShellAction` path, the same public flow stays in-process and exits 0:

```console
$ node /tmp/acpx-F003-proof.mjs
{
  "hostAlive": true,
  "hostPid": 90462,
  "status": "completed",
  "error": null,
  "exitCode": 0,
  "signal": null,
  "stdinBytes": 1048576
}
```

## Real behavior proof

- **Behavior or issue addressed:** Flow `shell()` stdin write to a child that exits without reading used to raise uncaught `EPIPE` and kill the host process.
- **Real environment tested:** macOS, Node v26.7.0, acpx compiled from this branch at `/tmp/oc-pr-acpx-F003` (`dist/flows.js`).
- **Exact steps or command run after this patch:**

  ```bash
  node /tmp/acpx-F003-proof.mjs
  ```

  The script imports `defineFlow`, `shell`, and `FlowRunner` from compiled `dist/flows.js`, then runs a one-node flow whose `exec` returns `command: process.execPath`, `args: ["-e", "setImmediate(() => process.exit(0))"]`, and `stdin` of 1 MiB.

- **Evidence after fix:** terminal output from the patched compiled public API (shown above). The host prints `hostAlive: true`, `status: "completed"`, `exitCode: 0`, `stdinBytes: 1048576`, and the Node process exits 0 with no `EPIPE` on stderr.
- **Observed result after fix:** The same 1 MiB stdin write that previously emitted `Unhandled 'error' event` / `write EPIPE` now completes inside `FlowRunner`. The host PID stays alive through the flow result print.
- **What was not tested:** Windows cmd.exe spawn, and a child that reads only part of stdin before exiting.

Related: [#179](https://github.com/openclaw/acpx/pull/179) (origin), [#507](https://github.com/openclaw/acpx/pull/507) (terminal stdout/stderr, different file), [#501](https://github.com/openclaw/acpx/pull/501), [#498](https://github.com/openclaw/acpx/pull/498), [#441](https://github.com/openclaw/acpx/pull/441). Same missing-listener class in openclaw/openclaw [#102047](https://github.com/openclaw/openclaw/pull/102047) and [#100410](https://github.com/openclaw/openclaw/pull/100410).
