### PR TITLE
fix(flows): kill shell children on interrupt and node timeout

### DIFF
--- a/src/flows/executors/shell.ts
+++ b/src/flows/executors/shell.ts
@@ -1,6 +1,15 @@
-import { spawn } from "node:child_process";
-import { TimeoutError } from "../../async-control.js";
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { InterruptedError, TimeoutError } from "../../async-control.js";
 import type { ShellActionExecution, ShellActionResult } from "../runtime.js";
+
+const SHELL_CHILD_KILL_GRACE_MS = 1_000;
+
+function terminateShellChild(child: ChildProcess): void {
+  child.kill("SIGTERM");
+  setTimeout(() => {
+    child.kill("SIGKILL");
+  }, SHELL_CHILD_KILL_GRACE_MS).unref();
+}
 
 export function formatShellActionSummary(spec: ShellActionExecution): string {
   return `shell: ${renderShellCommand(spec.command, spec.args ?? [])}`;
@@ -40,11 +49,35 @@ function rejectIfShellFailed(
   return undefined;
 }
 
-export async function runShellAction(spec: ShellActionExecution): Promise<ShellActionResult> {
-  const cwd = spec.cwd ?? process.cwd();
-  const args = spec.args ?? [];
-  const startMs = Date.now();
-  const child = spawn(spec.command, args, {
+function settleShellResult(
+  spec: ShellActionExecution,
+  args: string[],
+  result: ShellActionResult,
+  timedOut: boolean,
+  aborted: boolean,
+): Error | undefined {
+  if (aborted && !timedOut) {
+    return new InterruptedError();
+  }
+  return rejectIfShellFailed(spec, args, result, timedOut);
+}
+
+function scheduleShellTimeout(
+  timeoutMs: number | undefined,
+  onTimeout: () => void,
+): NodeJS.Timeout | undefined {
+  if (timeoutMs == null || timeoutMs <= 0) {
+    return undefined;
+  }
+  return setTimeout(onTimeout, timeoutMs);
+}
+
+function spawnShellChild(
+  spec: ShellActionExecution,
+  cwd: string,
+  args: string[],
+): ChildProcessWithoutNullStreams {
+  return spawn(spec.command, args, {
     cwd,
     env: {
       ...process.env,
@@ -54,13 +87,56 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   });
+}
 
+function writeShellStdin(child: ChildProcessWithoutNullStreams, stdin: string | undefined): void {
+  if (stdin != null) {
+    child.stdin.write(stdin);
+  }
+  child.stdin.end();
+}
+
+function bindShellAbort(
+  signal: AbortSignal | undefined,
+  child: ChildProcess,
+): { isAborted: () => boolean; dispose: () => void } {
+  let aborted = false;
+  const onAbort = () => {
+    if (aborted) {
+      return;
+    }
+    aborted = true;
+    terminateShellChild(child);
+  };
+  if (!signal) {
+    return {
+      isAborted: () => aborted,
+      dispose: () => undefined,
+    };
+  }
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+  return {
+    isAborted: () => aborted,
+    dispose: () => {
+      signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+function waitForShellExit(
+  child: ChildProcessWithoutNullStreams,
+  spec: ShellActionExecution,
+  args: string[],
+  cwd: string,
+  startMs: number,
+  getFlags: () => { timedOut: boolean; aborted: boolean },
+): Promise<ShellActionResult> {
   let stdout = "";
   let stderr = "";
-  let timedOut = false;
-  let timeout: NodeJS.Timeout | undefined;
-
-  const finish = new Promise<ShellActionResult>((resolve, reject) => {
+  return new Promise<ShellActionResult>((resolve, reject) => {
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
@@ -69,9 +145,9 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
     });
-
     child.once("error", reject);
-    child.once("exit", (exitCode, signal) => {
+    child.once("exit", (exitCode, exitSignal) => {
+      const flags = getFlags();
       const result: ShellActionResult = {
         command: spec.command,
         args,
@@ -80,34 +156,38 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
         stderr,
         combinedOutput: `${stdout}${stderr}`,
         exitCode,
-        signal,
+        signal: exitSignal,
         durationMs: Date.now() - startMs,
       };
-
-      const error = rejectIfShellFailed(spec, args, result, timedOut);
+      const error = settleShellResult(spec, args, result, flags.timedOut, flags.aborted);
       if (error) {
         reject(error);
         return;
       }
-
       resolve(result);
     });
   });
+}
 
-  if (spec.stdin != null) {
-    child.stdin.write(spec.stdin);
-  }
-  child.stdin.end();
-
-  if (spec.timeoutMs != null && spec.timeoutMs > 0) {
-    timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-      setTimeout(() => {
-        child.kill("SIGKILL");
-      }, 1_000).unref();
-    }, spec.timeoutMs);
-  }
+async function runSpawnedShellAction(
+  spec: ShellActionExecution,
+  signal: AbortSignal | undefined,
+): Promise<ShellActionResult> {
+  const cwd = spec.cwd ?? process.cwd();
+  const args = spec.args ?? [];
+  const startMs = Date.now();
+  const child = spawnShellChild(spec, cwd, args);
+  let timedOut = false;
+  const abort = bindShellAbort(signal, child);
+  const finish = waitForShellExit(child, spec, args, cwd, startMs, () => ({
+    timedOut,
+    aborted: abort.isAborted(),
+  }));
+  writeShellStdin(child, spec.stdin);
+  const timeout = scheduleShellTimeout(spec.timeoutMs, () => {
+    timedOut = true;
+    terminateShellChild(child);
+  });
 
   try {
     return await finish;
@@ -115,5 +195,16 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
     if (timeout) {
       clearTimeout(timeout);
     }
+    abort.dispose();
   }
+}
+
+export async function runShellAction(
+  spec: ShellActionExecution,
+  options?: { signal?: AbortSignal },
+): Promise<ShellActionResult> {
+  if (options?.signal?.aborted) {
+    throw new InterruptedError();
+  }
+  return await runSpawnedShellAction(spec, options?.signal);
 }

--- a/src/flows/runtime-support.ts
+++ b/src/flows/runtime-support.ts
@@ -28,16 +28,19 @@ export function isoNow(): string {
   return new Date().toISOString();
 }
 
+export function isRunFailureFinalized(state: FlowRunState): boolean {
+  return (
+    state.finishedAt !== undefined && (state.status === "failed" || state.status === "timed_out")
+  );
+}
+
 export function persistRunFailure(
   store: FlowRunStore,
   runDir: string,
   state: FlowRunState,
   error: unknown,
 ): Promise<void> {
-  if (
-    state.finishedAt !== undefined &&
-    (state.status === "failed" || state.status === "timed_out")
-  ) {
+  if (isRunFailureFinalized(state)) {
     return Promise.resolve();
   }
 

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -36,6 +36,7 @@ import {
   finalizeStepTrace,
   findConversationDeltaStart,
   isoNow,
+  isRunFailureFinalized,
   makeFlowNodeContext,
   markNodeStarted,
   nextAttemptId,
@@ -224,8 +225,11 @@ export class FlowRunner {
       return await withInterrupt(
         async () => await this.executeFlowRun(flow, input, runDir, state),
         async () => {
-          runAbort.abort();
-          await persistRunFailure(this.store, runDir, state, new InterruptedError());
+          try {
+            await persistRunFailure(this.store, runDir, state, new InterruptedError());
+          } finally {
+            runAbort.abort();
+          }
         },
       );
     } finally {
@@ -331,8 +335,14 @@ export class FlowRunner {
         params.node,
         context,
       );
+      if (isRunFailureFinalized(params.state)) {
+        throw new InterruptedError();
+      }
       return await this.createSuccessfulFlowStep(params, executed);
     } catch (error) {
+      if (isRunFailureFinalized(params.state)) {
+        throw error;
+      }
       return await this.createFailedFlowStep(params, error);
     }
   }
@@ -486,6 +496,9 @@ export class FlowRunner {
       statusDetail?: string;
     } = {},
   ): Promise<void> {
+    if (isRunFailureFinalized(state)) {
+      return;
+    }
     state.updatedAt = isoNow();
     clearActiveNode(state, overrides.statusDetail);
     state.steps.push({

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -67,6 +67,7 @@ import type {
   FlowNodeResult,
   ResolvedFlowAgent,
   ShellActionExecution,
+  ShellActionNodeDefinition,
 } from "./types.js";
 
 export { acp, action, checkpoint, compute, defineFlow, shell };
@@ -160,6 +161,7 @@ export class FlowRunner {
   private readonly services;
   private readonly store;
   private readonly pendingPersistentSessionClients = new Map<string, AcpClient>();
+  private activeRunAbort: AbortController | null = null;
 
   constructor(options: FlowRunnerOptions) {
     this.resolveAgent = options.resolveAgent;
@@ -216,14 +218,20 @@ export class FlowRunner {
       inputArtifact,
     });
 
+    const runAbort = new AbortController();
+    this.activeRunAbort = runAbort;
     try {
       return await withInterrupt(
         async () => await this.executeFlowRun(flow, input, runDir, state),
         async () => {
+          runAbort.abort();
           await persistRunFailure(this.store, runDir, state, new InterruptedError());
         },
       );
     } finally {
+      if (this.activeRunAbort === runAbort) {
+        this.activeRunAbort = null;
+      }
       await this.closePendingPersistentSessionClients();
     }
   }
@@ -583,108 +591,159 @@ export class FlowRunner {
       };
     }
 
-    const { output, rawText, trace } = await this.runWithHeartbeat(
-      runDir,
-      state,
-      state.currentNode ?? "",
-      node,
-      nodeTimeoutMs,
-      async () => {
-        const execution = await Promise.resolve(node.exec(context));
-        const effectiveExecution: ShellActionExecution = {
-          ...execution,
-          cwd: resolveShellActionCwd(this.defaultCwd, execution.cwd),
-          timeoutMs: execution.timeoutMs ?? nodeTimeoutMs,
-        };
-        updateStatusDetail(state, formatShellActionSummary(effectiveExecution));
-        await this.store.writeLive(runDir, state, {
-          scope: "node",
-          type: "node_heartbeat",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-          payload: {
-            statusDetail: state.statusDetail,
-          },
-        });
-        await this.store.appendTrace(runDir, state, {
-          scope: "action",
-          type: "action_prepared",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-          payload: {
-            action: {
-              actionType: "shell",
-              command: effectiveExecution.command,
-              args: effectiveExecution.args ?? [],
-              cwd: effectiveExecution.cwd,
-            },
-          },
-        });
-        const result = await runShellAction(effectiveExecution);
-        const stdoutArtifact = await this.store.writeArtifact(runDir, state, result.stdout, {
-          mediaType: "text/plain",
-          extension: "txt",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-        });
-        const stderrArtifact = await this.store.writeArtifact(runDir, state, result.stderr, {
-          mediaType: "text/plain",
-          extension: "txt",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-        });
-        await this.store.appendTrace(runDir, state, {
-          scope: "action",
-          type: "action_completed",
-          nodeId: state.currentNode,
-          attemptId: state.currentAttemptId,
-          payload: {
-            action: {
-              actionType: "shell",
-              command: result.command,
-              args: result.args,
-              cwd: result.cwd,
-              exitCode: result.exitCode,
-              signal: result.signal,
-              durationMs: result.durationMs,
-            },
-            stdoutArtifact,
-            stderrArtifact,
-          },
-        });
-        const trace: FlowStepTrace = {
-          action: {
-            actionType: "shell",
-            command: result.command,
-            args: result.args,
-            cwd: result.cwd,
-            exitCode: result.exitCode,
-            signal: result.signal,
-            durationMs: result.durationMs,
-          },
-          stdoutArtifact,
-          stderrArtifact,
-        };
-        let parsedOutput: unknown;
-        try {
-          parsedOutput = node.parse ? await node.parse(result, context) : result;
-        } catch (error) {
-          throw attachStepTrace(error, trace);
-        }
-        return {
-          output: parsedOutput,
-          rawText: result.combinedOutput,
-          trace,
-        };
+    const shellAbort = this.createShellActionAbort();
+    try {
+      const { output, rawText, trace } = await this.runWithHeartbeat(
+        runDir,
+        state,
+        state.currentNode ?? "",
+        node,
+        nodeTimeoutMs,
+        async () =>
+          await this.executeShellAction(
+            runDir,
+            state,
+            node,
+            context,
+            nodeTimeoutMs,
+            shellAbort.signal,
+          ),
+        async () => {
+          shellAbort.abort();
+        },
+      );
+      return {
+        output,
+        promptText: null,
+        rawText,
+        sessionInfo: null,
+        agentInfo: null,
+        trace,
+      };
+    } finally {
+      shellAbort.dispose();
+    }
+  }
+
+  private async executeShellAction(
+    runDir: string,
+    state: FlowRunState,
+    node: ShellActionNodeDefinition,
+    context: FlowNodeContext,
+    nodeTimeoutMs: number | undefined,
+    signal: AbortSignal,
+  ): Promise<{ output: unknown; rawText: string; trace: FlowStepTrace }> {
+    const execution = await Promise.resolve(node.exec(context));
+    const effectiveExecution: ShellActionExecution = {
+      ...execution,
+      cwd: resolveShellActionCwd(this.defaultCwd, execution.cwd),
+      timeoutMs: execution.timeoutMs ?? nodeTimeoutMs,
+    };
+    updateStatusDetail(state, formatShellActionSummary(effectiveExecution));
+    await this.store.writeLive(runDir, state, {
+      scope: "node",
+      type: "node_heartbeat",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+      payload: {
+        statusDetail: state.statusDetail,
       },
-    );
+    });
+    await this.store.appendTrace(runDir, state, {
+      scope: "action",
+      type: "action_prepared",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+      payload: {
+        action: {
+          actionType: "shell",
+          command: effectiveExecution.command,
+          args: effectiveExecution.args ?? [],
+          cwd: effectiveExecution.cwd,
+        },
+      },
+    });
+    const result = await runShellAction(effectiveExecution, { signal });
+    const stdoutArtifact = await this.store.writeArtifact(runDir, state, result.stdout, {
+      mediaType: "text/plain",
+      extension: "txt",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+    });
+    const stderrArtifact = await this.store.writeArtifact(runDir, state, result.stderr, {
+      mediaType: "text/plain",
+      extension: "txt",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+    });
+    await this.store.appendTrace(runDir, state, {
+      scope: "action",
+      type: "action_completed",
+      nodeId: state.currentNode,
+      attemptId: state.currentAttemptId,
+      payload: {
+        action: {
+          actionType: "shell",
+          command: result.command,
+          args: result.args,
+          cwd: result.cwd,
+          exitCode: result.exitCode,
+          signal: result.signal,
+          durationMs: result.durationMs,
+        },
+        stdoutArtifact,
+        stderrArtifact,
+      },
+    });
+    const trace: FlowStepTrace = {
+      action: {
+        actionType: "shell",
+        command: result.command,
+        args: result.args,
+        cwd: result.cwd,
+        exitCode: result.exitCode,
+        signal: result.signal,
+        durationMs: result.durationMs,
+      },
+      stdoutArtifact,
+      stderrArtifact,
+    };
+    let parsedOutput: unknown;
+    try {
+      parsedOutput = node.parse ? await node.parse(result, context) : result;
+    } catch (error) {
+      throw attachStepTrace(error, trace);
+    }
     return {
-      output,
-      promptText: null,
-      rawText,
-      sessionInfo: null,
-      agentInfo: null,
+      output: parsedOutput,
+      rawText: result.combinedOutput,
       trace,
+    };
+  }
+
+  private createShellActionAbort(): {
+    signal: AbortSignal;
+    abort: () => void;
+    dispose: () => void;
+  } {
+    const controller = new AbortController();
+    const parent = this.activeRunAbort?.signal;
+    const onParentAbort = () => {
+      controller.abort();
+    };
+    if (parent?.aborted) {
+      controller.abort();
+    } else {
+      parent?.addEventListener("abort", onParentAbort, { once: true });
+    }
+    return {
+      signal: controller.signal,
+      abort: () => {
+        controller.abort();
+      },
+      dispose: () => {
+        parent?.removeEventListener("abort", onParentAbort);
+      },
     };
   }
 
@@ -1024,9 +1083,13 @@ export class FlowRunner {
       }, heartbeatMs);
     }
 
+    const runPromise = run();
     try {
-      return await withTimeout(run(), timeoutMs);
+      return await withTimeout(runPromise, timeoutMs);
     } catch (error) {
+      void runPromise.catch(() => {
+        // ignore
+      });
       if (error instanceof TimeoutError && onTimeout) {
         await onTimeout().catch(() => {
           // best effort cancellation only

--- a/test/flows-shell.test.ts
+++ b/test/flows-shell.test.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { TimeoutError } from "../src/async-control.js";
+import { InterruptedError, TimeoutError } from "../src/async-control.js";
 import {
   formatShellActionSummary,
   renderShellCommand,
   runShellAction,
 } from "../src/flows/executors/shell.js";
+import { isProcessAlive } from "../src/process-liveness.js";
 
 test("renderShellCommand quotes arguments consistently", () => {
   assert.equal(renderShellCommand("echo", ["hello", "two words"]), 'echo "hello" "two words"');
@@ -77,3 +81,88 @@ test("runShellAction rejects commands terminated by signal", async () => {
     /signal SIGTERM/,
   );
 });
+
+test("runShellAction already-aborted signal does not spawn a child", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    async () =>
+      await runShellAction(
+        {
+          command: process.execPath,
+          args: ["-e", "process.exit(0)"],
+        },
+        { signal: controller.signal },
+      ),
+    InterruptedError,
+  );
+});
+
+test("runShellAction abort kills the child process", async () => {
+  const pidDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-shell-abort-"));
+  const pidPath = path.join(pidDir, "pid");
+  const controller = new AbortController();
+  let pid: number | undefined;
+  const run = runShellAction(
+    {
+      command: process.execPath,
+      args: ["-e", writePidAndKeepAliveScript(pidPath)],
+    },
+    { signal: controller.signal },
+  );
+
+  try {
+    pid = await waitForPidFile(pidPath, 2_000);
+    assert.equal(isProcessAlive(pid), true);
+    const rejected = assert.rejects(async () => await run, InterruptedError);
+    controller.abort();
+    assert.equal(await waitUntilDead(pid, 1_500), true);
+    await rejected;
+  } finally {
+    forceKill(pid);
+    await run.catch(() => undefined);
+    await fs.rm(pidDir, { recursive: true, force: true });
+  }
+});
+
+function writePidAndKeepAliveScript(pidPath: string): string {
+  return `require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); setInterval(() => {}, 60_000);`;
+}
+
+async function waitForPidFile(pidPath: string, timeoutMs: number): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const value = Number(await fs.readFile(pidPath, "utf8"));
+      if (Number.isInteger(value) && value > 0) {
+        return value;
+      }
+    } catch {
+      // not written yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for pid file ${pidPath}`);
+}
+
+async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return !isProcessAlive(pid);
+}
+
+function forceKill(pid: number | undefined): void {
+  if (!pid || !isProcessAlive(pid)) {
+    return;
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already gone
+  }
+}

--- a/test/flows.test.ts
+++ b/test/flows.test.ts
@@ -25,6 +25,7 @@ import type {
   ShellActionNodeDefinition,
 } from "../src/flows/runtime.js";
 import { flowRunsBaseDir } from "../src/flows/store.js";
+import { isProcessAlive } from "../src/process-liveness.js";
 import type { PromptInput } from "../src/types.js";
 
 const MOCK_AGENT_PATH = fileURLToPath(new URL("./mock-agent.js", import.meta.url));
@@ -1407,6 +1408,72 @@ test("FlowRunner keeps same session handles isolated by working directory", asyn
       await fs.rm(baseCwd, { recursive: true, force: true });
       await fs.rm(worktreeA, { recursive: true, force: true });
       await fs.rm(worktreeB, { recursive: true, force: true });
+    }
+  });
+});
+
+test("FlowRunner kills shell child when outer node timeout fires", async () => {
+  await withTempHome(async () => {
+    const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-flow-store-"));
+    const pidDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-flow-shell-pid-"));
+    const pidPath = path.join(pidDir, "pid");
+    let pid: number | undefined;
+    const runner = new FlowRunner({
+      resolveAgent: () => ({
+        agentName: "unused",
+        agentCommand: "unused",
+        cwd: process.cwd(),
+      }),
+      permissionMode: "approve-all",
+      outputRoot,
+    });
+
+    const flow = defineFlow({
+      name: "outer-timeout-kills-shell",
+      startAt: "slow",
+      nodes: {
+        slow: shell({
+          timeoutMs: 200,
+          exec: () => ({
+            command: process.execPath,
+            args: [
+              "-e",
+              `require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); setInterval(() => {}, 60_000);`,
+            ],
+            timeoutMs: 0,
+          }),
+        }),
+      },
+      edges: [],
+    });
+
+    const runPromise = runner.run(flow, {});
+    try {
+      pid = await waitFor(async () => {
+        try {
+          const value = Number(await fs.readFile(pidPath, "utf8"));
+          return Number.isInteger(value) && value > 0 ? value : null;
+        } catch {
+          return null;
+        }
+      }, 2_000);
+      assert.equal(isProcessAlive(pid), true);
+      await assert.rejects(async () => await runPromise, TimeoutError);
+      const deadline = Date.now() + 1_500;
+      while (isProcessAlive(pid) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      assert.equal(isProcessAlive(pid), false);
+    } finally {
+      if (pid && isProcessAlive(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+      await runPromise.catch(() => undefined);
+      await fs.rm(pidDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `acpx flow` / `FlowRunner.run` with a `shell()` node would leave the spawned command running after Ctrl+C or after an outer node timeout. `runShellAction` only sent SIGTERM/SIGKILL on its own `timeoutMs`. `FlowRunner.run` persisted the interrupted bundle and rejected; the CLI then `process.exit`ed and orphaned the child. The same orphan happens when the node timer fires (`timeoutMs: 200`) while the action sets `execution.timeoutMs: 0`, so the inner kill timer never starts.

## Why This Change Was Made

`runShellAction` now accepts an `AbortSignal`. Abort and the existing inner timeout share the same SIGTERM then SIGKILL grace (1s). `FlowRunner.run` aborts that signal on SIGINT/SIGTERM/SIGHUP. `executeActionNode` also aborts it from `runWithHeartbeat`'s `onTimeout`, matching how ACP nodes cancel a session on node timeout.

This is not stdin EPIPE handling (open [#529](https://github.com/openclaw/acpx/pull/529)). It is not output bounding. It does not change successful shell completion.

The missing abort dates to [#179](https://github.com/openclaw/acpx/pull/179) (`697ee1f`, 2026-03-26, "feat: add experimental acpx flows runtime and examples"), 156 days on `main`. [#188](https://github.com/openclaw/acpx/pull/188) persisted interrupted runs and still did not reap the spawn.

## User Impact

A flow `shell()` child is reaped when the operator interrupts the run or when the node timeout fires, including when the action sets `timeoutMs: 0`. The host still reports `TimeoutError` / `InterruptedError`. Operators no longer leak long-running `sleep` / compiler / `yes` processes after the CLI has exited.

## Evidence

terminal output from live `node` against compiled public `defineFlow` / `shell()` / `FlowRunner` (`dist/flows.js`).

Same scripts: one-node flow whose `exec` returns `command: process.execPath`, `args` that write `process.pid` then `setInterval`, and `timeoutMs: 0`. Outer node timeout is 250ms. Interrupt script starts the same flow in a child host, then sends SIGINT.

Before, on unpatched `src/flows/executors/shell.ts` and `src/flows/runtime.ts` compiled to `dist`, the host rejects but the child stays alive:

```console
$ ACPX_ROOT=/tmp/oc-pr-acpx-F004 node /tmp/acpx-F004-proof.mjs
{
  "hostAlive": true,
  "hostPid": 56463,
  "status": "rejected",
  "errorName": "TimeoutError",
  "errorMessage": "Timed out after 250ms",
  "childPid": 56471,
  "childAliveAfterTimeout": true
}
```

```console
$ SIGINT to FlowRunner host after the shell child wrote its pid
{
  "hostPid": 56490,
  "hostExit": 130,
  "childPid": 56499,
  "childAliveBeforeSigint": true,
  "childAliveAfterHostExit": true
}
```

After, on the patched compiled public API, the same flows reject and the child is gone:

```console
$ ACPX_ROOT=/tmp/oc-pr-acpx-F004 node /tmp/acpx-F004-proof.mjs
{
  "hostAlive": true,
  "hostPid": 56583,
  "status": "rejected",
  "errorName": "TimeoutError",
  "errorMessage": "Timed out after 250ms",
  "childPid": 56590,
  "childAliveAfterTimeout": false
}
```

```console
$ SIGINT to FlowRunner host after the shell child wrote its pid
{
  "hostPid": 56619,
  "hostExit": 130,
  "childPid": 56627,
  "childAliveBeforeSigint": true,
  "childAliveAfterHostExit": false
}
```

## Real behavior proof

- **Behavior or issue addressed:** Flow `shell()` children stayed running after Ctrl+C and after an outer node timeout when `execution.timeoutMs` was 0, so `process.exit` orphaned the spawn.
- **Real environment tested:** macOS, Node v26.7.0, acpx compiled from this branch at `/tmp/oc-pr-acpx-F004` (`dist/flows.js`).
- **Exact steps or command run after this patch:**

  ```bash
  ACPX_ROOT=/tmp/oc-pr-acpx-F004 node /tmp/acpx-F004-proof.mjs
  ACPX_ROOT=/tmp/oc-pr-acpx-F004 ACPX_F004_PID=/tmp/acpx-f004-int.pid node /tmp/acpx-F004-interrupt-host.mjs
  ```

  The timeout script imports `defineFlow`, `shell`, and `FlowRunner` from compiled `dist/flows.js`, then runs a one-node flow with node `timeoutMs: 250` and action `timeoutMs: 0`. The interrupt host runs the same long child; the parent sends SIGINT after the pid file appears.

- **Evidence after fix:** terminal output from the patched compiled public API (shown above). Timeout path prints `childAliveAfterTimeout: false`. Interrupt path prints `childAliveAfterHostExit: false` and host exit 130.
- **Observed result after fix:** The same pid-writing `setInterval` child that stayed alive after TimeoutError and after SIGINT on unpatched `dist` is now gone once the host rejects. The host still surfaces `TimeoutError` / `InterruptedError`.
- **What was not tested:** Windows cmd.exe spawn, and a child that ignores SIGTERM for the full 1s grace before SIGKILL when the CLI `process.exit`s immediately.

Related: [#179](https://github.com/openclaw/acpx/pull/179) (origin), [#188](https://github.com/openclaw/acpx/pull/188) (interrupt persist only), [#529](https://github.com/openclaw/acpx/pull/529) (stdin EPIPE, different file), [#501](https://github.com/openclaw/acpx/pull/501), [#498](https://github.com/openclaw/acpx/pull/498). Same leftover-child class as merged process-list timeouts in [#501](https://github.com/openclaw/acpx/pull/501).
