### PR TITLE
feat(cli): configure one-shot exec sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Repo: https://github.com/openclaw/acpx
 ### Changes
 
 - Dependencies: update runtime schema validation and development tooling, and move source builds to pnpm 11.24.0.
+- CLI/exec: apply repeatable ACP `--config-option <key=value>` selections after the requested model and before a one-shot prompt.
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Persistent sessions keep context between prompts, support parallel named workstr
 acpx codex sessions new --name backend
 acpx codex -s backend "trace the checkout timeout"
 acpx codex exec "summarize this repository"
+acpx --model gpt-5.4 codex exec --config-option reasoning_effort=high "review this repository"
 ```
 
 Session state lives under `~/.acpx/`. The [sessions guide](docs/sessions.md) covers scope, queue ownership, reconnects, export/import, cancellation, and cleanup.

--- a/agents/Codex.md
+++ b/agents/Codex.md
@@ -6,6 +6,7 @@
 - ACPX owns the built-in package range so fresh launches use the repository-selected stable adapter line without requiring a global install.
 - Runtime controls exposed by current codex-acp releases include ACP modes plus separate `model` and `reasoning_effort` session config options.
 - Use the advertised base model id with `acpx --model <id> codex ...` or `acpx codex set model <id>`, then set reasoning effort separately with `acpx codex set reasoning_effort <value>`.
+- For a one-shot run, use `acpx --model <id> codex exec --config-option reasoning_effort=<value> 'prompt'`; the effort is applied after the model and before the prompt.
 - Switching models can adjust reasoning effort. ACPX saves the accepted effort for an existing selection, or removes that selection if the new model has no effort control.
 - Reconnecting restores the saved model and effort before prompting, even when the adapter resumes the conversation with different defaults.
 - Legacy `models` metadata may encode both values in a combined id such as `gpt-5.6-sol[max]`; ACPX uses that form only when the adapter does not advertise the newer model config option.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -257,9 +257,17 @@ acpx [global_options] exec [prompt_options] [prompt_text...]   # defaults to cod
 Behavior:
 
 - Creates temporary ACP session
+- Applies `--model`, then each repeatable `--config-option <key=value>`, before prompting
 - Sends prompt once
 - Does not write/use a saved session record
 - Supports prompt text from args, stdin, `--file <path>`, and `--file -`
+- Stops without prompting if the adapter rejects a requested config option
+
+```bash
+acpx --model gpt-5.4 codex exec \
+  --config-option reasoning_effort=high \
+  'review this checkout'
+```
 
 ## `compare` subcommand
 

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -130,6 +130,21 @@ Behavior varies by adapter:
 
 For mid-session model switches, use `set model <id>` instead. See [Session control](session-control.md#set-key-value).
 
+## One-shot session configuration
+
+`exec` accepts repeatable `--config-option <key=value>` flags for adapter-advertised ACP
+session controls. ACPX applies the requested model first, then the config options in command
+order, and only then sends the prompt:
+
+```bash
+acpx --model gpt-5.4 codex exec \
+  --config-option reasoning_effort=high \
+  'one-shot review'
+```
+
+The temporary selection is not saved. If any `session/set_config_option` request fails, `exec`
+reports the adapter error and does not start the prompt.
+
 ## Permissions inside a prompt
 
 Prompts can trigger permission requests for tool calls. The default policy auto-approves reads and prompts for writes; non-interactive runs default to deny. See [Permissions](permissions.md).

--- a/skills/acpx/SKILL.md
+++ b/skills/acpx/SKILL.md
@@ -147,11 +147,14 @@ Prompt options:
 ```bash
 acpx exec 'summarize this repo'
 acpx codex exec 'summarize this repo'
+acpx --model gpt-5.6-sol codex exec --config-option reasoning_effort=xhigh 'review this repo'
 ```
 
 Behavior:
 
 - Runs a single prompt in a temporary ACP session
+- Applies `--model`, then repeatable `--config-option <key=value>` selections, before prompting
+- Fails before the prompt if the adapter rejects a requested config option
 - Does not reuse or save persistent session state
 
 ### Compare (multi-agent one-shot)

--- a/src/cli/command-handlers.ts
+++ b/src/cli/command-handlers.ts
@@ -461,6 +461,7 @@ export async function handleExec(
       maxTurns: globalFlags.maxTurns,
       systemPrompt: globalFlags.systemPrompt,
     },
+    configOptions: flags.configOption,
   });
 
   applyPermissionExitCode(result, outputPolicy.format === "quiet" ? outputFormatter : undefined);

--- a/src/cli/command-registration.ts
+++ b/src/cli/command-registration.ts
@@ -21,6 +21,7 @@ import { registerCompareCommand } from "./compare-command.js";
 import { registerConfigCommand } from "./config-command.js";
 import type { ResolvedAcpxConfig } from "./config.js";
 import {
+  addExecConfigOption,
   addPromptInputOption,
   addSessionNameOption,
   addSessionOption,
@@ -237,6 +238,7 @@ export function registerSharedAgentSubcommands(
     .argument("[prompt...]", "Prompt text")
     .showHelpAfterError();
   addPromptInputOption(execCommand);
+  addExecConfigOption(execCommand);
   execCommand.action(async function (this: Command, promptParts: string[], flags) {
     await handleExec(explicitAgentName, promptParts, flags, this, config);
   });

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -62,6 +62,12 @@ export type PromptFlags = {
 
 export type ExecFlags = {
   file?: string;
+  configOption?: SessionConfigOptionAssignment[];
+};
+
+export type SessionConfigOptionAssignment = {
+  configId: string;
+  value: string;
 };
 
 export type SessionsNewFlags = {
@@ -193,6 +199,31 @@ export function parseNonEmptyValue(label: string, value: string): string {
     throw new InvalidArgumentError(`${label} must not be empty`);
   }
   return trimmed;
+}
+
+export function parseSessionConfigOptionAssignment(value: string): SessionConfigOptionAssignment {
+  const separator = value.indexOf("=");
+  if (separator <= 0 || separator === value.length - 1) {
+    throw new InvalidArgumentError(
+      'Session config option must use "<key>=<value>" with non-empty parts',
+    );
+  }
+
+  const configId = value.slice(0, separator).trim();
+  const configValue = value.slice(separator + 1).trim();
+  if (configId.length === 0 || configValue.length === 0) {
+    throw new InvalidArgumentError(
+      'Session config option must use "<key>=<value>" with non-empty parts',
+    );
+  }
+  return { configId, value: configValue };
+}
+
+function collectSessionConfigOptionAssignment(
+  value: string,
+  previous: SessionConfigOptionAssignment[] = [],
+): SessionConfigOptionAssignment[] {
+  return [...previous, parseSessionConfigOptionAssignment(value)];
 }
 
 export function parseHistoryLimit(value: string): number {
@@ -410,6 +441,14 @@ function parseOptionalSessionName(value: unknown): string | undefined {
 
 export function addPromptInputOption(command: Command): Command {
   return command.option("-f, --file <path>", "Read prompt text from file path (use - for stdin)");
+}
+
+export function addExecConfigOption(command: Command): Command {
+  return command.option(
+    "--config-option <key=value>",
+    "Set an ACP session config option before the one-shot prompt (repeatable)",
+    collectSessionConfigOptionAssignment,
+  );
 }
 
 export function resolveGlobalFlags(command: Command, config: ResolvedAcpxConfig): GlobalFlags {

--- a/src/cli/session/contracts.ts
+++ b/src/cli/session/contracts.ts
@@ -60,6 +60,7 @@ export type RunOnceOptions = {
   suppressSdkConsoleErrors?: boolean;
   verbose?: boolean;
   sessionOptions?: SessionAgentOptions;
+  configOptions?: Array<{ configId: string; value: string }>;
   promptRetries?: number;
 } & TimedRunOptions;
 

--- a/src/cli/session/runtime.ts
+++ b/src/cli/session/runtime.ts
@@ -1139,6 +1139,12 @@ export async function runOnce(options: RunOnceOptions): Promise<RunPromptResult>
             ? undefined
             : (message) => process.stderr.write(`[acpx] warning: ${message}\n`),
         });
+        for (const configOption of options.configOptions ?? []) {
+          await withTimeout(
+            client.setSessionConfigOption(sessionId, configOption.configId, configOption.value),
+            options.timeoutMs,
+          );
+        }
 
         output.setContext({
           sessionId,

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -169,6 +169,8 @@ test("session config option assignments preserve values and reject incomplete pa
   assert.throws(() => parseSessionConfigOptionAssignment("reasoning_effort"), /<key>=<value>/);
   assert.throws(() => parseSessionConfigOptionAssignment("=xhigh"), /<key>=<value>/);
   assert.throws(() => parseSessionConfigOptionAssignment("reasoning_effort="), /<key>=<value>/);
+  assert.throws(() => parseSessionConfigOptionAssignment("  =xhigh"), /<key>=<value>/);
+  assert.throws(() => parseSessionConfigOptionAssignment("reasoning_effort=   "), /<key>=<value>/);
 });
 
 test("history and prune parsers validate positive numbers and dates", () => {

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { Command } from "commander";
 import type { ResolvedAcpxConfig } from "../src/cli/config.js";
 import {
+  addExecConfigOption,
   addGlobalFlags,
   addPromptInputOption,
   addSessionNameOption,
@@ -17,6 +18,7 @@ import {
   parseOutputFormat,
   parsePruneBeforeDate,
   parsePromptRetries,
+  parseSessionConfigOptionAssignment,
   parseSessionName,
   parseTimeoutSeconds,
   parseTtlSeconds,
@@ -153,6 +155,20 @@ test("string list flag parsers normalize valid values and reject empty entries",
   assert.deepEqual(parseAllowedTools("   "), []);
   assert.deepEqual(parseAllowedTools("Read, Edit , Bash"), ["Read", "Edit", "Bash"]);
   assert.throws(() => parseAllowedTools("Read,,Edit"), /without empty entries/);
+});
+
+test("session config option assignments preserve values and reject incomplete pairs", () => {
+  assert.deepEqual(parseSessionConfigOptionAssignment(" reasoning_effort = xhigh "), {
+    configId: "reasoning_effort",
+    value: "xhigh",
+  });
+  assert.deepEqual(parseSessionConfigOptionAssignment("endpoint=https://example.com?a=b"), {
+    configId: "endpoint",
+    value: "https://example.com?a=b",
+  });
+  assert.throws(() => parseSessionConfigOptionAssignment("reasoning_effort"), /<key>=<value>/);
+  assert.throws(() => parseSessionConfigOptionAssignment("=xhigh"), /<key>=<value>/);
+  assert.throws(() => parseSessionConfigOptionAssignment("reasoning_effort="), /<key>=<value>/);
 });
 
 test("history and prune parsers validate positive numbers and dates", () => {
@@ -431,6 +447,19 @@ test("session and prompt option registration parse command-local flags", () => {
 
   const promptCommand = parseCommand(addPromptInputOption(new Command()), ["--file", "-"]);
   assert.deepEqual(promptCommand.opts(), { file: "-" });
+
+  const execCommand = parseCommand(addExecConfigOption(new Command()), [
+    "--config-option",
+    "reasoning_effort=high",
+    "--config-option",
+    "verbosity=terse",
+  ]);
+  assert.deepEqual(execCommand.opts(), {
+    configOption: [
+      { configId: "reasoning_effort", value: "high" },
+      { configId: "verbosity", value: "terse" },
+    ],
+  });
 });
 
 test("resolveSessionNameFromFlags falls back through global and parent command options", () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1490,6 +1490,8 @@ test("integration: exec applies config options after the model and before the pr
           "fast-model",
           "exec",
           "--config-option",
+          "reasoning_effort=high",
+          "--config-option",
           "reasoning_effort=xhigh",
           "echo hello",
         ],
@@ -1503,7 +1505,14 @@ test("integration: exec applies config options after the model and before the pr
           payload.method === "session/set_config_option" &&
           (payload.params as { configId?: unknown } | undefined)?.configId === "model",
       );
-      const effortIndex = payloads.findIndex(
+      const highEffortIndex = payloads.findIndex(
+        (payload) =>
+          payload.method === "session/set_config_option" &&
+          (payload.params as { configId?: unknown; value?: unknown } | undefined)?.configId ===
+            "reasoning_effort" &&
+          (payload.params as { value?: unknown } | undefined)?.value === "high",
+      );
+      const xhighEffortIndex = payloads.findIndex(
         (payload) =>
           payload.method === "session/set_config_option" &&
           (payload.params as { configId?: unknown; value?: unknown } | undefined)?.configId ===
@@ -1512,8 +1521,12 @@ test("integration: exec applies config options after the model and before the pr
       );
       const promptIndex = payloads.findIndex((payload) => payload.method === "session/prompt");
       assert(modelIndex >= 0, "expected model config request");
-      assert(effortIndex > modelIndex, "expected reasoning effort after model selection");
-      assert(promptIndex > effortIndex, "expected prompt after config option selection");
+      assert(highEffortIndex > modelIndex, "expected first config option after model selection");
+      assert(
+        xhighEffortIndex > highEffortIndex,
+        "expected repeated config options in command-line order",
+      );
+      assert(promptIndex > xhighEffortIndex, "expected prompt after all config option selections");
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
@@ -1543,9 +1556,24 @@ test("integration: exec stops before prompting when a config option is rejected"
         homeDir,
       );
       assert.notEqual(result.code, 0, "expected non-zero exit");
-      assert.match(`${result.stderr}\n${result.stdout}`, /session\/set_config_option/i);
 
       const payloads = parseJsonRpcOutputLines(result.stdout);
+      const rejectedRequest = payloads.find(
+        (payload) =>
+          payload.method === "session/set_config_option" &&
+          (payload.params as { configId?: unknown } | undefined)?.configId === "reasoning_effort",
+      ) as { id?: unknown } | undefined;
+      assert(rejectedRequest, "expected rejected config option request");
+      const rejection = payloads.find(
+        (payload) => payload.id === rejectedRequest.id && "error" in payload,
+      ) as
+        | {
+            error?: { code?: unknown; message?: unknown; data?: { details?: unknown } };
+          }
+        | undefined;
+      assert.equal(rejection?.error?.code, -32603);
+      assert.equal(rejection?.error?.message, "Internal error");
+      assert.equal(rejection?.error?.data?.details, "Invalid params");
       assert.equal(
         payloads.some((payload) => payload.method === "session/prompt"),
         false,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1471,6 +1471,92 @@ test("integration: exec --model sets the advertised model config option", async 
   });
 });
 
+test("integration: exec applies config options after the model and before the prompt", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const configAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-config-options`;
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          configAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "--model",
+          "fast-model",
+          "exec",
+          "--config-option",
+          "reasoning_effort=xhigh",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.equal(result.code, 0, result.stderr);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      const modelIndex = payloads.findIndex(
+        (payload) =>
+          payload.method === "session/set_config_option" &&
+          (payload.params as { configId?: unknown } | undefined)?.configId === "model",
+      );
+      const effortIndex = payloads.findIndex(
+        (payload) =>
+          payload.method === "session/set_config_option" &&
+          (payload.params as { configId?: unknown; value?: unknown } | undefined)?.configId ===
+            "reasoning_effort" &&
+          (payload.params as { value?: unknown } | undefined)?.value === "xhigh",
+      );
+      const promptIndex = payloads.findIndex((payload) => payload.method === "session/prompt");
+      assert(modelIndex >= 0, "expected model config request");
+      assert(effortIndex > modelIndex, "expected reasoning effort after model selection");
+      assert(promptIndex > effortIndex, "expected prompt after config option selection");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("integration: exec stops before prompting when a config option is rejected", async () => {
+  await withTempHome(async (homeDir) => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));
+    const rejectingAgentCommand = `${MOCK_AGENT_COMMAND} --advertise-config-options --set-session-config-invalid-params`;
+
+    try {
+      const result = await runCli(
+        [
+          "--agent",
+          rejectingAgentCommand,
+          "--approve-all",
+          "--cwd",
+          cwd,
+          "--format",
+          "json",
+          "exec",
+          "--config-option",
+          "reasoning_effort=xhigh",
+          "echo hello",
+        ],
+        homeDir,
+      );
+      assert.notEqual(result.code, 0, "expected non-zero exit");
+      assert.match(`${result.stderr}\n${result.stdout}`, /session\/set_config_option/i);
+
+      const payloads = parseJsonRpcOutputLines(result.stdout);
+      assert.equal(
+        payloads.some((payload) => payload.method === "session/prompt"),
+        false,
+        "prompt must not start after a rejected config option",
+      );
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 test("integration: exec --model fails when agent does not advertise models", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));


### PR DESCRIPTION
One-shot exec runs can now apply adapter-advertised ACP session settings through repeatable `--config-option <key=value>` flags. The requested model is selected first, options are applied in command-line order, and the prompt starts only after every selection succeeds. Invalid or rejected selections stop before prompting; temporary selections are not persisted.

The contributor implementation is preserved, the changelog conflict is resolved against current main, and the Unreleased entry credits @superbiche. No contributor history was rewritten.

Validation on head `08c51474aec36c65b96d0cc466f2aea46915df8c`: formatting, typecheck, lint, build, viewer checks, and documentation checks passed. The new regression cases and a real built-CLI run prove model/option/prompt ordering, repeated values, and rejection without prompt submission. Local and branch Codex autoreview are scoped clean through P2.

The complete hosted CI run is green, including Test, Mutation, Slophammer, and Docs: https://github.com/openclaw/acpx/actions/runs/33994537600. Local full-suite attempts encountered an unrelated Gemini fixture failure and then a viewer-test stall; the hosted Test job supplies the complete suite gate. Captured built-CLI execution output is posted in the proof comment.
