### PR TITLE
refactor(session): drop unused appendLegacyHistory + LegacyHistoryEntry

### DIFF
--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -26,12 +26,6 @@ import type {
 } from "../types.js";
 import { applyConfigOptionsModelState } from "./model-state.js";
 
-export type LegacyHistoryEntry = {
-  role: "user" | "assistant";
-  timestamp: string;
-  textPreview: string;
-};
-
 const MAX_RUNTIME_MESSAGES = 200;
 const MAX_RUNTIME_AGENT_TEXT_CHARS = 8_000;
 const MAX_RUNTIME_THINKING_CHARS = 4_000;
@@ -601,36 +595,6 @@ function cloneSystemPromptOption(
   option: NonNullable<NonNullable<SessionAcpxState["session_options"]>["system_prompt"]>,
 ): NonNullable<NonNullable<SessionAcpxState["session_options"]>["system_prompt"]> {
   return typeof option === "string" ? option : { append: option.append };
-}
-
-export function appendLegacyHistory(
-  conversation: SessionConversation,
-  entries: LegacyHistoryEntry[],
-): void {
-  for (const entry of entries) {
-    const text = entry.textPreview?.trim();
-    if (!text) {
-      continue;
-    }
-
-    if (entry.role === "user") {
-      conversation.messages.push({
-        User: {
-          id: nextUserMessageId(),
-          content: [{ Text: text }],
-        },
-      });
-    } else {
-      conversation.messages.push({
-        Agent: {
-          content: [{ Text: text }],
-          tool_results: {},
-        },
-      });
-    }
-
-    updateConversationTimestamp(conversation, entry.timestamp || conversation.updated_at);
-  }
 }
 
 export function recordPromptSubmission(


### PR DESCRIPTION
## What Problem This Solves

`src/session/conversation-model.ts` exported `appendLegacyHistory` (a function that pushed `LegacyHistoryEntry` items onto a `SessionConversation`) together with its input type `LegacyHistoryEntry`. Both are dead code: a repository-wide search finds each symbol only at its own definition — no production caller, no test, and no other file references them. `appendLegacyHistory` was the only consumer of `LegacyHistoryEntry`, and nothing anywhere constructs a `LegacyHistoryEntry[]` to feed it, so the pair is a fully-orphaned legacy history-import path left behind after its caller was removed.

It is not part of the published API surface: the package builds `src/cli.ts`, `src/runtime.ts`, and `src/flows.ts`, and none of those entry graphs re-export either symbol (no `export *` barrel carries `conversation-model.ts`). The live conversation builders in the same file — `recordPromptSubmission`, `recordSessionUpdate`, `recordClientOperation`, `trimConversationForRuntime` — are untouched.

## Why This Change Was Made

Debt cleanup (family: dead-code removal). Remove the unused exported function and its unused input type. The shared helpers the function called — `nextUserMessageId` (3 remaining callers) and `updateConversationTimestamp` (5 remaining callers) — stay in use by the live builders, so no import or helper is orphaned by the removal. Behavior-preserving, single production file, net **−36 / 0** production lines, no tests touched.

**Scope boundary:** only the two dead symbols are removed. No runtime, CLI, config, persistence, or public-API behavior changes; no `export`-surface change reachable from `cli`/`runtime`/`flows`; no other function in `conversation-model.ts` is modified.

## User Impact

None. No runtime, CLI, config, or public-API behavior changes — the removed symbols were reachable from nothing (unexported from the `cli`/`runtime`/`flows` entry graphs, referenced nowhere, with no producer of their input). Published `.d.ts` output for the `cli`/`runtime`/`flows` entries is unaffected because neither symbol was in those surfaces.

## Evidence

Branched off current `main` (`95a9466`), Linux, Node 22, `pnpm install --frozen-lockfile`.

- **Dead-symbol proof** — `git grep appendLegacyHistory` and `git grep LegacyHistoryEntry` each return only their own definition line in `src/session/conversation-model.ts` before the change, and **0 hits** after.
- **No producer** — nothing anywhere constructs a `LegacyHistoryEntry` / `LegacyHistoryEntry[]`; the removed function had no caller and no test.
- Typecheck (`tsc --noEmit`) → exit 0.
- Lint (`oxlint --type-aware --deny-warnings src scripts examples test conformance`) → exit 0 (confirms no now-unused import or binding remains).
- Format (`oxfmt --check`) → clean.
- Build (`tsdown` for `cli`/`runtime`/`flows`) → exit 0.
- **Full test suite** (`node --test` over the built `dist-test`) → **972 pass, 0 fail** on this branch. The removed symbols had no test, so the count matches `main`; behavior is preserved.

Diff: **0 / −36, 1 file**. Same shape as the merged dead-export cleanups #457 and #509.

_AI-assisted contribution._

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmNtQi5Mptz9SN2PaCLLv9)_