### PR TITLE
fix(acp): bound Windows terminal cleanup

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -637,6 +637,7 @@ Related runtime behavior:
 
 - session storage path is derived from OS home directory (`~/.acpx/sessions`)
 - child processes inherit the current environment by default
+- Windows terminal kill and release requests fail if process cleanup cannot finish after escalation. The terminal remains available for a cleanup retry; restore a working `taskkill` command before retrying.
 
 ## Practical examples
 

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -476,7 +476,7 @@ export class TerminalManager {
       return;
     }
 
-    await this.waitForCleanupAfterSignal(terminal);
+    await this.waitForFinalCleanup(terminal);
   }
 
   private async signalProcess(terminal: ManagedTerminal, signal: NodeJS.Signals): Promise<void> {
@@ -530,6 +530,13 @@ export class TerminalManager {
     }
     for (const descendantPid of await listDescendantPids(pid, terminal.processHelperTimeoutMs)) {
       terminal.descendantPids.add(descendantPid);
+    }
+  }
+
+  private async waitForFinalCleanup(terminal: ManagedTerminal): Promise<void> {
+    const cleaned = await this.waitForCleanupAfterSignal(terminal);
+    if (!cleaned && process.platform === "win32") {
+      throw new Error("Terminal process cleanup did not finish after SIGKILL");
     }
   }
 

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -499,11 +499,11 @@ export class TerminalManager {
   ): Promise<void> {
     await this.captureDescendantPids(terminal, pid);
     if (this.isRunning(terminal)) {
-      await killWindowsProcessTree(pid, signal);
+      await killWindowsProcessTree(pid, signal, terminal.processHelperTimeoutMs);
       return;
     }
     for (const descendantPid of terminal.descendantPids) {
-      await killWindowsProcessTree(descendantPid, signal);
+      await killWindowsProcessTree(descendantPid, signal, terminal.processHelperTimeoutMs);
     }
   }
 
@@ -762,19 +762,20 @@ async function runWindowsProcessListCommand(timeoutMs: number): Promise<string> 
   );
 }
 
-async function killWindowsProcessTree(pid: number, signal: NodeJS.Signals): Promise<void> {
+export async function killWindowsProcessTree(
+  pid: number,
+  signal: NodeJS.Signals,
+  timeoutMs: number = PROCESS_HELPER_TIMEOUT_MS,
+): Promise<void> {
   const args = ["/pid", String(pid), "/t"];
   if (signal === "SIGKILL") {
     args.push("/f");
   }
-  await new Promise<void>((resolve) => {
-    const child = spawn("taskkill", args, {
-      stdio: ["ignore", "ignore", "ignore"],
-      windowsHide: true,
-    });
-    child.once("error", () => resolve());
-    child.once("close", () => resolve());
-  });
+  try {
+    await runTimedExecFile("taskkill", args, { timeoutMs, windowsHide: true });
+  } catch {
+    // Hung or missing taskkill must not block terminal/kill or terminal/release.
+  }
 }
 
 function sendSignal(pid: number, signal: NodeJS.Signals): void {

--- a/test/terminal-taskkill.test.ts
+++ b/test/terminal-taskkill.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+import { TerminalManager, killWindowsProcessTree } from "../src/acp/terminal-manager.js";
+
+function getManagedPid(manager: TerminalManager, terminalId: string): number | undefined {
+  const terminals = (
+    manager as unknown as {
+      terminals: Map<string, { process: { pid?: number } }>;
+    }
+  ).terminals;
+  return terminals.get(terminalId)?.process.pid;
+}
+
+async function rejectIfHung<T>(
+  operation: Promise<T>,
+  message: string,
+  timeoutMs = 1_500,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(message));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function killRecordedHelperPids(pidPath: string): Promise<void> {
+  try {
+    const pids = (await fs.readFile(pidPath, "utf8"))
+      .split("\n")
+      .map((line) => Number(line))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+    for (const pid of pids) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // best-effort cleanup of the hung helper
+      }
+    }
+  } catch {
+    // no helper pids recorded
+  }
+}
+
+function resolveWindowsCscPath(): string | undefined {
+  const windir = process.env.WINDIR ?? "C:\\Windows";
+  const candidates = [
+    path.join(windir, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe"),
+    path.join(windir, "Microsoft.NET", "Framework", "v4.0.30319", "csc.exe"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+async function installWindowsHangingTaskkill(bin: string): Promise<void> {
+  const csc = resolveWindowsCscPath();
+  if (csc) {
+    await fs.writeFile(
+      path.join(bin, "hang.cs"),
+      [
+        "using System.Diagnostics;",
+        "using System.IO;",
+        "using System.Threading;",
+        "class P {",
+        "  static void Main() {",
+        '    File.AppendAllText("taskkill.pid", Process.GetCurrentProcess().Id + "\\n");',
+        "    Thread.Sleep(Timeout.Infinite);",
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    execFileSync(csc, ["/nologo", "/out:taskkill.exe", "hang.cs"], { cwd: bin, stdio: "ignore" });
+    return;
+  }
+
+  await fs.copyFile(process.execPath, path.join(bin, "taskkill.exe"));
+  await fs.writeFile(
+    path.join(bin, "hang.cjs"),
+    [
+      "const fs = require('node:fs');",
+      "fs.appendFileSync('taskkill.pid', String(process.pid) + '\\n');",
+      "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);",
+      "",
+    ].join("\n"),
+  );
+  process.env.NODE_OPTIONS = "--require ./hang.cjs";
+}
+
+async function withHangingTaskkillCommand<T>(run: () => Promise<T>): Promise<T> {
+  const bin = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-hanging-taskkill-"));
+  const pidPath = path.join(bin, "taskkill.pid");
+  const previousCwd = process.cwd();
+  const previousPath = process.env.PATH ?? "";
+  const previousNodeOptions = process.env.NODE_OPTIONS;
+  try {
+    if (process.platform === "win32") {
+      await installWindowsHangingTaskkill(bin);
+      process.chdir(bin);
+    } else {
+      await fs.writeFile(
+        path.join(bin, "taskkill"),
+        `#!/bin/sh\nprintf '%s\\n' "$$" >> ${JSON.stringify(pidPath)}\nexec sleep 3600\n`,
+        { mode: 0o755 },
+      );
+      process.env.PATH = `${bin}${path.delimiter}${previousPath}`;
+    }
+    return await run();
+  } finally {
+    process.chdir(previousCwd);
+    process.env.PATH = previousPath;
+    if (previousNodeOptions === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = previousNodeOptions;
+    }
+    await killRecordedHelperPids(pidPath);
+    try {
+      await fs.rm(bin, { recursive: true, force: true });
+    } catch {
+      // Windows can keep a brief lock on a just-killed helper executable.
+    }
+  }
+}
+
+describe("hung Windows taskkill", { concurrency: false }, () => {
+  test("killWindowsProcessTree returns after hung taskkill times out", async () => {
+    await withHangingTaskkillCommand(async () => {
+      await rejectIfHung(
+        killWindowsProcessTree(1, "SIGKILL", 200),
+        "killWindowsProcessTree hung on taskkill",
+      );
+    });
+  });
+
+  test("terminal manager kill finishes when taskkill hangs", async (t) => {
+    if (process.platform !== "win32") {
+      t.skip("Windows taskkill hang assertion");
+      return;
+    }
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+    const manager = new TerminalManager({
+      cwd: tmp,
+      permissionMode: "approve-all",
+      killGraceMs: 200,
+      processHelperTimeoutMs: 200,
+    });
+    let createdTerminalId: string | undefined;
+    try {
+      const created = await manager.createTerminal({
+        sessionId: "session-1",
+        command: "ping -t 127.0.0.1",
+      });
+      createdTerminalId = created.terminalId;
+
+      await withHangingTaskkillCommand(async () => {
+        await rejectIfHung(
+          manager.killTerminal({
+            sessionId: "session-1",
+            terminalId: created.terminalId,
+          }),
+          "terminal/kill hung on taskkill",
+          3_000,
+        );
+      });
+    } finally {
+      const pid = createdTerminalId ? getManagedPid(manager, createdTerminalId) : undefined;
+      if (pid) {
+        try {
+          execFileSync("taskkill", ["/pid", String(pid), "/t", "/f"], { stdio: "ignore" });
+        } catch {
+          // best-effort cleanup after a stubbed taskkill
+        }
+      }
+      try {
+        await fs.rm(tmp, { recursive: true, force: true });
+      } catch {
+        // The shell child can outlive a hung taskkill and keep the temp dir locked.
+      }
+    }
+  });
+});

--- a/test/terminal-taskkill.test.ts
+++ b/test/terminal-taskkill.test.ts
@@ -1,4 +1,6 @@
-import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -108,15 +110,15 @@ async function withHangingTaskkillCommand<T>(run: () => Promise<T>): Promise<T> 
   try {
     if (process.platform === "win32") {
       await installWindowsHangingTaskkill(bin);
-      process.chdir(bin);
     } else {
       await fs.writeFile(
         path.join(bin, "taskkill"),
-        `#!/bin/sh\nprintf '%s\\n' "$$" >> ${JSON.stringify(pidPath)}\nexec sleep 3600\n`,
+        `#!/bin/sh\nprintf '%s\\n' "$$" >> taskkill.pid\nexec sleep 3600\n`,
         { mode: 0o755 },
       );
       process.env.PATH = `${bin}${path.delimiter}${previousPath}`;
     }
+    process.chdir(bin);
     return await run();
   } finally {
     process.chdir(previousCwd);
@@ -137,59 +139,85 @@ async function withHangingTaskkillCommand<T>(run: () => Promise<T>): Promise<T> 
 
 describe("hung Windows taskkill", { concurrency: false }, () => {
   test("killWindowsProcessTree returns after hung taskkill times out", async () => {
-    await withHangingTaskkillCommand(async () => {
-      await rejectIfHung(
-        killWindowsProcessTree(1, "SIGKILL", 200),
-        "killWindowsProcessTree hung on taskkill",
-      );
+    const target = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
     });
-  });
-
-  test("terminal manager kill finishes when taskkill hangs", async (t) => {
-    if (process.platform !== "win32") {
-      t.skip("Windows taskkill hang assertion");
-      return;
-    }
-
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
-    const manager = new TerminalManager({
-      cwd: tmp,
-      permissionMode: "approve-all",
-      killGraceMs: 200,
-      processHelperTimeoutMs: 200,
-    });
-    let createdTerminalId: string | undefined;
+    await once(target, "spawn");
+    const targetPid = target.pid;
+    assert.ok(targetPid);
     try {
-      const created = await manager.createTerminal({
-        sessionId: "session-1",
-        command: "ping -t 127.0.0.1",
-      });
-      createdTerminalId = created.terminalId;
-
       await withHangingTaskkillCommand(async () => {
         await rejectIfHung(
-          manager.killTerminal({
-            sessionId: "session-1",
-            terminalId: created.terminalId,
-          }),
-          "terminal/kill hung on taskkill",
-          3_000,
+          killWindowsProcessTree(targetPid, "SIGKILL", 200),
+          "killWindowsProcessTree hung on taskkill",
         );
       });
     } finally {
-      const pid = createdTerminalId ? getManagedPid(manager, createdTerminalId) : undefined;
-      if (pid) {
-        try {
-          execFileSync("taskkill", ["/pid", String(pid), "/t", "/f"], { stdio: "ignore" });
-        } catch {
-          // best-effort cleanup after a stubbed taskkill
-        }
-      }
-      try {
-        await fs.rm(tmp, { recursive: true, force: true });
-      } catch {
-        // The shell child can outlive a hung taskkill and keep the temp dir locked.
+      if (target.exitCode === null && target.signalCode === null) {
+        const closed = once(target, "close");
+        target.kill("SIGKILL");
+        await closed;
       }
     }
   });
+
+  for (const operation of ["killTerminal", "releaseTerminal"] as const) {
+    test(`terminal manager ${operation} rejects and retains cleanup state when taskkill hangs`, async (t) => {
+      if (process.platform !== "win32") {
+        t.skip("Windows taskkill hang assertion");
+        return;
+      }
+
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+      const manager = new TerminalManager({
+        cwd: tmp,
+        permissionMode: "approve-all",
+        killGraceMs: 200,
+        processHelperTimeoutMs: 200,
+      });
+      let createdTerminalId: string | undefined;
+      try {
+        const created = await manager.createTerminal({
+          sessionId: "session-1",
+          command: "ping -t 127.0.0.1",
+        });
+        createdTerminalId = created.terminalId;
+        const pid = getManagedPid(manager, created.terminalId);
+        assert.ok(pid);
+
+        await withHangingTaskkillCommand(async () => {
+          await assert.rejects(
+            rejectIfHung(
+              manager[operation]({
+                sessionId: "session-1",
+                terminalId: created.terminalId,
+              }),
+              `${operation} hung on taskkill`,
+              3_000,
+            ),
+            /Terminal process cleanup did not finish after SIGKILL/,
+          );
+          assert.equal(getManagedPid(manager, created.terminalId), pid);
+          assert.doesNotThrow(() => process.kill(pid, 0));
+        });
+        await manager.releaseTerminal({ sessionId: "session-1", terminalId: created.terminalId });
+        assert.equal(getManagedPid(manager, created.terminalId), undefined);
+        assert.throws(() => process.kill(pid, 0));
+      } finally {
+        const pid = createdTerminalId ? getManagedPid(manager, createdTerminalId) : undefined;
+        if (pid) {
+          try {
+            execFileSync("taskkill", ["/pid", String(pid), "/t", "/f"], { stdio: "ignore" });
+          } catch {
+            // best-effort cleanup after a stubbed taskkill
+          }
+        }
+        try {
+          await fs.rm(tmp, { recursive: true, force: true });
+        } catch {
+          // The shell child can outlive a hung taskkill and keep the temp dir locked.
+        }
+      }
+    });
+  }
 });


### PR DESCRIPTION
A hung Windows `taskkill` can block terminal cleanup. Timing out that helper alone also leaves a second bug: kill can report success while the command remains alive, and release can then wait forever for its exit.

Bound helper execution with the existing timeout mechanism and reject Windows kill/release when final cleanup remains incomplete. Preserve the terminal record so cleanup can be retried after `taskkill` is working again. Tests cover helper timeout, both terminal operations, retained state, and a successful cleanup retry. Helper tests target only a process they created.

Credit to @SebTardif for the original timeout fix and reproduction. The maintainer repair preserves that work and adds the missing final-cleanup check, regression coverage, and documentation.

Validation on head `af44b4b0160656becf6c0b4b17822d4a426e8712`: full local check passed (990 tests, two native Windows cases skipped, plus 145 coverage tests); docs passed; local and branch Codex autoreview are scoped clean through P2.

Native Windows proof passed on Node 24.11.1 with the exact source commit verified before building. All three native regression tests passed. A real built CLI session with structured agent argv injected a hanging taskkill: the original PR commit left release pending after 35 seconds with its child alive; this head returned the cleanup error after 20.137 seconds, retained the terminal, and successfully released it after taskkill was restored. The managed child and timed-out helpers were verified exited.

Exact-head CI passed: https://github.com/openclaw/acpx/actions/runs/33993565322. No merge or release was performed.
