### PR TITLE
fix(runtime): preserve session environment key casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Repo: https://github.com/openclaw/acpx
 - ACP/terminal: handle child stdout and stderr errors without terminating the host, so wait and release can finish. Thanks @SebTardif.
 - ACP/launch: preserve process-spawn `ENOENT` as additive `AGENT_SPAWN_ENOENT` detail and include qualified remediation while keeping the broad runtime code and other spawn failures unchanged. Fixes #510. Thanks @anyech.
 - Flows: preserve unlimited shell timeouts while enclosing deadlines and interrupts cancel active shell commands and attributable descendants before completing, and prevent late executors from launching after cancellation. Thanks @SebTardif.
+- Runtime/sessions: preserve uppercase and mixed-case environment variable names when saving and reloading session options. Thanks @coding-ax.
 
 ## 2026.8.28 (v0.13.2)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,6 +153,7 @@ Other ACP-relevant behavior:
 
 - Session storage path is derived from the OS home directory (`~/.acpx/sessions`).
 - Child adapter processes inherit the current environment by default.
+- Embedded clients can persist per-session overrides through `SessionAgentOptions.env`; environment variable names retain their exact casing when saved and reloaded.
 - Some adapters look at their own env vars (e.g., `QODER_PERSONAL_ACCESS_TOKEN`) — see [Agents](agents.md) for per-adapter notes.
 
 ## Practical config recipes

--- a/src/persisted-key-policy.ts
+++ b/src/persisted-key-policy.ts
@@ -13,7 +13,11 @@ const ZED_TAG_KEYS = new Set([
   "ToolUse",
 ]);
 
-const MAP_OBJECT_PATHS = new Set(["request_token_usage", "messages.Agent.tool_results"]);
+const MAP_OBJECT_PATHS = new Set([
+  "request_token_usage",
+  "messages.Agent.tool_results",
+  "acpx.session_options.env",
+]);
 
 const OPAQUE_VALUE_PATHS = new Set([
   "agent_capabilities",

--- a/test/persisted-key-policy.test.ts
+++ b/test/persisted-key-policy.test.ts
@@ -100,3 +100,18 @@ test("persisted key policy rejects camelCase acpx-owned keys", () => {
     assertPersistedKeyPolicy(persisted);
   }, /snake_case/);
 });
+
+test("session environment names are map keys while session option names remain validated", () => {
+  const record = makeRecord();
+  record.acpx = {
+    session_options: { env: { INITIAL_AGENT_MODE: "read-only", MixedCase: "value" } },
+  };
+  const persisted = serializeSessionRecordForDisk(record);
+  assertPersistedKeyPolicy(persisted);
+  assert.deepEqual(
+    findPersistedKeyPolicyViolations({
+      acpx: { session_options: { unexpectedOption: true, env: { UPPER_CASE: "value" } } },
+    }),
+    ["acpx.session_options.unexpectedOption"],
+  );
+});

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -352,6 +352,20 @@ test("createFileSessionStore persists records inside the provided state director
   );
 });
 
+test("createFileSessionStore preserves environment name casing across reloads", async (t) => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-env-store-"));
+  t.after(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+  const env = { INITIAL_AGENT_MODE: "read-only", CustomMixedCase: "synthetic" };
+  const record = createSessionRecord({ acpx: { session_options: { env } } });
+
+  await createFileSessionStore({ stateDir }).save(record);
+
+  const restored = await createFileSessionStore({ stateDir }).load(record.acpxRecordId);
+  assert.deepEqual(restored?.acpx?.session_options?.env, env);
+});
+
 test("createFileSessionStore supports concurrent saves in the same millisecond", async (t) => {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-runtime-store-concurrent-"));
   t.after(async () => {


### PR DESCRIPTION
Saving a session with ordinary environment names such as `INITIAL_AGENT_MODE` failed because the persisted-key validator treated the environment map as acpx-owned schema. Exempt keys only inside `acpx.session_options.env`, preserving exact environment-name casing while retaining validation on neighboring schema keys.

Adds a real file-store save/reload regression and policy-boundary test, configuration documentation, and an Unreleased note thanking @coding-ax. The transient runtime environment API requested in #517 remains a separate decision.

Validation: 991 tests and 146 coverage tests passed in `pnpm run check`; documentation checks passed. The built public file store failed before the fix and now saves/reloads the same valid record unchanged. Captured before/after output is posted in the proof comment. Local and committed-branch autoreview are clean through P2.

Exact-head CI: https://github.com/openclaw/acpx/actions/runs/33991210314 — success at `20e238ef5b22c467ce87e388da0cef50e18aec93`.
