### PR TITLE
fix(runtime): resolve prompt readiness after transport write

### DIFF
--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -94,6 +94,12 @@ acpx codex --no-wait 'and propose 1 minimal fix'
 
 `Ctrl+C` while waiting on a queued or running prompt sends ACP `session/cancel` first, waits briefly for the cancelled completion, and falls back to a force-kill only if the agent does not respond. See [Session control](session-control.md) for the explicit `cancel` command.
 
+## Embedded runtime readiness
+
+For applications using `acpx/runtime`, `AcpRuntimeTurn.promptStarted` resolves only after the writable ACP transport accepts that turn's prompt request. It remains pending under transport backpressure and rejects if submission or the write fails.
+
+Readiness does not mean the agent has finished processing the prompt. Await `turn.result` for the turn outcome after persistence and cleanup have settled.
+
 ## Timeouts
 
 `--timeout <seconds>` caps how long `acpx` will wait for an agent response. It applies to:
@@ -114,8 +120,8 @@ If the timeout fires, `acpx` exits with code `3` and the agent process is cancel
 `--model <id>` requests a specific model:
 
 ```bash
-acpx --model claude-sonnet-4-6 claude 'do the thing'
 acpx --model gpt-5.4 codex exec 'one-shot summary'
+acpx --model claude-sonnet-4-6 claude 'do the thing'
 ```
 
 Behavior varies by adapter:

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -396,6 +396,7 @@ type ActivePromptState = {
   sessionId: string;
   requestId?: JsonRpcId;
   promise?: Promise<PromptResponse>;
+  onRequestWritten?: () => Promise<void> | void;
   elicitationHandler?: AcpElicitationHandler;
   elicitationController: AbortController;
 };
@@ -1077,9 +1078,12 @@ export class AcpClient {
     const onAcpMessage = () => this.eventHandlers.onAcpMessage;
     const onAcpOutputMessage = () => this.eventHandlers.onAcpOutputMessage;
     const elicitationRequestIds = new Set<JsonRpcId>();
-    const bindPromptOwner = (owner: { requestId: JsonRpcId; sessionId: string }): void => {
+    const bindPromptOwner = (owner: { requestId: JsonRpcId; sessionId: string }) =>
       this.bindPromptOwner(owner);
-    };
+    const onPromptRequestWritten = (
+      active: ActivePromptState,
+      owner: { requestId: JsonRpcId; sessionId: string },
+    ) => this.onPromptRequestWritten(active, owner);
 
     const shouldSuppressInboundReplaySessionUpdate = (message: AnyMessage): boolean => {
       return this.suppressReplaySessionUpdateMessages && isSessionUpdateNotification(message);
@@ -1124,9 +1128,7 @@ export class AcpClient {
     const writable = new WritableStream<AnyMessage>({
       async write(message) {
         const promptOwner = promptRequestOwner(message);
-        if (promptOwner) {
-          bindPromptOwner(promptOwner);
-        }
+        const activePrompt = promptOwner ? bindPromptOwner(promptOwner) : undefined;
         const id = responseId(message);
         const sensitive = id !== undefined && elicitationRequestIds.delete(id);
         if (!sensitive) {
@@ -1138,6 +1140,9 @@ export class AcpClient {
           await writer.write(message);
         } finally {
           writer.releaseLock();
+        }
+        if (activePrompt && promptOwner) {
+          onPromptRequestWritten(activePrompt, promptOwner);
         }
       },
     });
@@ -1268,7 +1273,7 @@ export class AcpClient {
   async prompt(
     sessionId: string,
     prompt: PromptInput | string,
-    onRequestStarted?: () => Promise<void> | void,
+    onRequestWritten?: () => Promise<void> | void,
     onElicitation?: AcpElicitationHandler,
   ): Promise<PromptResponse> {
     const connection = this.getConnection();
@@ -1277,18 +1282,15 @@ export class AcpClient {
       ? installSdkConsoleErrorSuppression()
       : undefined;
 
-    const activePrompt = this.beginActivePrompt(sessionId, onElicitation);
+    const activePrompt = this.beginActivePrompt(sessionId, onRequestWritten, onElicitation);
 
     let promptPromise: Promise<PromptResponse>;
     try {
-      promptPromise = this.runConnectionRequest(
-        () =>
-          connection.prompt({
-            sessionId,
-            prompt: normalizedPrompt,
-          }),
-        onRequestStarted,
-        () => !connection.signal?.aborted,
+      promptPromise = this.runConnectionRequest(() =>
+        connection.prompt({
+          sessionId,
+          prompt: normalizedPrompt,
+        }),
       );
     } catch (error) {
       this.clearActivePrompt(activePrompt);
@@ -1314,12 +1316,14 @@ export class AcpClient {
 
   private beginActivePrompt(
     sessionId: string,
+    onRequestWritten: (() => Promise<void> | void) | undefined,
     elicitationHandler: AcpElicitationHandler | undefined,
   ): ActivePromptState {
     const previous = this.activePrompt;
     this.cancellingSessionIds.delete(sessionId);
     const active: ActivePromptState = {
       sessionId,
+      onRequestWritten,
       elicitationHandler,
       elicitationController: new AbortController(),
     };
@@ -1329,12 +1333,30 @@ export class AcpClient {
     return active;
   }
 
-  private bindPromptOwner(owner: { requestId: JsonRpcId; sessionId: string }): void {
+  private bindPromptOwner(owner: {
+    requestId: JsonRpcId;
+    sessionId: string;
+  }): ActivePromptState | undefined {
     const active = this.pendingPromptOwners.find((candidate) => {
       return candidate.requestId === undefined && candidate.sessionId === owner.sessionId;
     });
     if (active) {
       active.requestId = owner.requestId;
+    }
+    return active;
+  }
+
+  private onPromptRequestWritten(
+    active: ActivePromptState,
+    owner: { requestId: JsonRpcId; sessionId: string },
+  ): void {
+    if (active.requestId !== owner.requestId || active.sessionId !== owner.sessionId) {
+      return;
+    }
+    try {
+      void Promise.resolve(active.onRequestWritten?.()).catch(() => {});
+    } catch {
+      // Readiness observation must not own a request accepted by the transport.
     }
   }
 
@@ -2224,11 +2246,7 @@ export class AcpClient {
     return error;
   }
 
-  private async runConnectionRequest<T>(
-    run: () => Promise<T>,
-    onRequestStarted?: () => Promise<void> | void,
-    canStartRequest: () => boolean = () => true,
-  ): Promise<T> {
+  private async runConnectionRequest<T>(run: () => Promise<T>): Promise<T> {
     return await new Promise<T>((resolve, reject) => {
       const pending: PendingConnectionRequest = {
         settled: false,
@@ -2250,16 +2268,7 @@ export class AcpClient {
           if (pending.settled) {
             return { started: false as const };
           }
-          const requestCanStart = canStartRequest();
-          const request = run();
-          if (requestCanStart) {
-            try {
-              void Promise.resolve(onRequestStarted?.()).catch(() => {});
-            } catch {
-              // Readiness observation must not own a request that was already submitted.
-            }
-          }
-          return { started: true as const, value: await request };
+          return { started: true as const, value: await run() };
         })
         .then(
           (outcome) => {

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -1285,7 +1285,7 @@ export class AcpRuntimeManager {
         timeoutMs: task.input.timeoutMs ?? this.options.timeoutMs,
         conversation: turn.conversation,
         promptMessageId: turn.promptMessageId,
-        onPromptRequestStarted: () => task.promptStarted.resolve(),
+        onPromptRequestWritten: () => task.promptStarted.resolve(),
         onElicitation: task.input.onElicitation,
       });
     } finally {

--- a/src/runtime/engine/prompt-turn.ts
+++ b/src/runtime/engine/prompt-turn.ts
@@ -17,7 +17,7 @@ type PromptTurnClient = {
   prompt: (
     sessionId: string,
     prompt: PromptInput | string,
-    onRequestStarted?: () => Promise<void> | void,
+    onRequestWritten?: () => Promise<void> | void,
     onElicitation?: AcpElicitationHandler,
   ) => Promise<{ stopReason: RunPromptResult["stopReason"]; usage?: unknown }>;
   waitForSessionUpdatesIdle?: (options?: { idleMs?: number; timeoutMs?: number }) => Promise<void>;
@@ -30,7 +30,7 @@ export async function runPromptTurn(params: {
   timeoutMs?: number;
   conversation: SessionConversation;
   promptMessageId?: string;
-  onPromptRequestStarted?: () => Promise<void> | void;
+  onPromptRequestWritten?: () => Promise<void> | void;
   onPromptStarted?: () => Promise<void> | void;
   onElicitation?: AcpElicitationHandler;
 }): Promise<{ stopReason: RunPromptResult["stopReason"]; source: "rpc" | "session" }> {
@@ -38,7 +38,7 @@ export async function runPromptTurn(params: {
     const promptPromise = params.client.prompt(
       params.sessionId,
       params.prompt,
-      params.onPromptRequestStarted,
+      params.onPromptRequestWritten,
       params.onElicitation,
     );
     await params.onPromptStarted?.();

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -297,7 +297,7 @@ export type AcpRuntimeTurnResult =
 
 export interface AcpRuntimeTurn {
   readonly requestId: string;
-  /** Resolves after `connection.prompt()` returns its request promise. */
+  /** Resolves after the underlying writable transport accepts the prompt request. */
   readonly promptStarted: Promise<void>;
   readonly events: AsyncIterable<AcpRuntimeEvent>;
   /**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import test from "node:test";
-import type { RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
+import type {
+  AnyMessage,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
 import {
   AcpClient,
   buildAgentSpawnOptions,
@@ -35,6 +39,20 @@ test("parseAcpJsonMessageLine preserves object-shaped protocol values", () => {
 });
 
 type ClientInternals = {
+  createTappedStream?: (base: {
+    readable: ReadableStream<AnyMessage>;
+    writable: WritableStream<AnyMessage>;
+  }) => {
+    readable: ReadableStream<AnyMessage>;
+    writable: WritableStream<AnyMessage>;
+  };
+  createConnection?: (
+    stream: {
+      readable: ReadableStream<AnyMessage>;
+      writable: WritableStream<AnyMessage>;
+    },
+    launch: { devinAcp: boolean },
+  ) => unknown;
   selectAuthMethod?: (methods: Array<{ id: string }>) =>
     | {
         methodId: string;
@@ -1204,6 +1222,140 @@ test("AcpClient lifecycle snapshot and cancel helpers reflect active prompt stat
   assert.deepEqual(cancelled, { stopReason: "cancelled" });
 });
 
+test("AcpClient reports prompt readiness only after the transport accepts the request", async () => {
+  const writeEntered = createDeferred<AnyMessage>();
+  const releaseWrite = createDeferred<void>();
+  const requestWritten = createDeferred<void>();
+  const agentToClient = new TransformStream<AnyMessage>();
+  const client = makeClient();
+  connectClientToStream(client, {
+    readable: agentToClient.readable,
+    writable: new WritableStream<AnyMessage>({
+      async write(message) {
+        writeEntered.resolve(message);
+        await releaseWrite.promise;
+      },
+    }),
+  });
+
+  let readinessCalls = 0;
+  const prompt = client.prompt("session-write-ready", "hello", () => {
+    readinessCalls += 1;
+    requestWritten.resolve();
+  });
+  const request = await writeEntered.promise;
+
+  assert.equal(readinessCalls, 0);
+  releaseWrite.resolve();
+  await requestWritten.promise;
+  assert.equal(readinessCalls, 1);
+
+  await writeAgentMessage(agentToClient.writable, promptResponseFor(request));
+  assert.deepEqual(await prompt, { stopReason: "end_turn" });
+});
+
+test("AcpClient rejects a failed prompt write without reporting readiness", async () => {
+  const writeEntered = createDeferred<void>();
+  const failWrite = createDeferred<void>();
+  const agentToClient = new TransformStream<AnyMessage>();
+  const client = makeClient();
+  connectClientToStream(client, {
+    readable: agentToClient.readable,
+    writable: new WritableStream<AnyMessage>({
+      async write() {
+        writeEntered.resolve();
+        await failWrite.promise;
+      },
+    }),
+  });
+
+  let readinessCalls = 0;
+  const prompt = client.prompt("session-write-failed", "hello", () => {
+    readinessCalls += 1;
+  });
+
+  await writeEntered.promise;
+  failWrite.reject(new Error("transport write failed"));
+  await assert.rejects(prompt, /transport write failed/);
+  assert.equal(readinessCalls, 0);
+});
+
+test("AcpClient keeps accepted prompts alive when the readiness observer throws", async () => {
+  const writeEntered = createDeferred<AnyMessage>();
+  const agentToClient = new TransformStream<AnyMessage>();
+  const client = makeClient();
+  connectClientToStream(client, {
+    readable: agentToClient.readable,
+    writable: new WritableStream<AnyMessage>({
+      write(message) {
+        writeEntered.resolve(message);
+      },
+    }),
+  });
+
+  const prompt = client.prompt("session-observer-failed", "hello", () => {
+    throw new Error("observer failed");
+  });
+  const request = await writeEntered.promise;
+  await writeAgentMessage(agentToClient.writable, promptResponseFor(request));
+
+  assert.deepEqual(await prompt, { stopReason: "end_turn" });
+});
+
+test("AcpClient keeps a queued prompt unready until its own transport write succeeds", async () => {
+  const firstWriteEntered = createDeferred<AnyMessage>();
+  const secondWriteEntered = createDeferred<AnyMessage>();
+  const releaseFirstWrite = createDeferred<void>();
+  const releaseSecondWrite = createDeferred<void>();
+  const firstRequestWritten = createDeferred<void>();
+  const secondRequestWritten = createDeferred<void>();
+  const agentToClient = new TransformStream<AnyMessage>();
+  const client = makeClient();
+  let writeCount = 0;
+  connectClientToStream(client, {
+    readable: agentToClient.readable,
+    writable: new WritableStream<AnyMessage>({
+      async write(message) {
+        writeCount += 1;
+        if (writeCount === 1) {
+          firstWriteEntered.resolve(message);
+          await releaseFirstWrite.promise;
+          return;
+        }
+        secondWriteEntered.resolve(message);
+        await releaseSecondWrite.promise;
+      },
+    }),
+  });
+
+  let secondReadinessCalls = 0;
+  const firstPrompt = client.prompt("session-queued", "first", () => {
+    firstRequestWritten.resolve();
+  });
+  const secondPrompt = client.prompt("session-queued", "second", () => {
+    secondReadinessCalls += 1;
+    secondRequestWritten.resolve();
+  });
+
+  const firstRequest = await firstWriteEntered.promise;
+  assert.equal(writeCount, 1);
+  assert.equal(secondReadinessCalls, 0);
+
+  releaseFirstWrite.resolve();
+  await firstRequestWritten.promise;
+  const secondRequest = await secondWriteEntered.promise;
+  assert.equal(secondReadinessCalls, 0);
+
+  await writeAgentMessage(agentToClient.writable, promptResponseFor(firstRequest));
+  releaseSecondWrite.resolve();
+  await secondRequestWritten.promise;
+  assert.equal(secondReadinessCalls, 1);
+  await writeAgentMessage(agentToClient.writable, promptResponseFor(secondRequest));
+
+  assert.deepEqual(await firstPrompt, { stopReason: "end_turn" });
+  assert.deepEqual(await secondPrompt, { stopReason: "end_turn" });
+});
+
 test("AcpClient rejects rich prompt content not advertised by promptCapabilities", async () => {
   const client = makeClient();
   const internals = asInternals(client);
@@ -1259,38 +1411,31 @@ test("AcpClient sends audio prompts when the agent advertises audio support", as
   assert.deepEqual(capturedPrompt, [{ type: "audio", mimeType: "audio/wav", data: "UklGRg==" }]);
 });
 
-test("AcpClient reports prompt start only after the connection request exists", async () => {
+test("AcpClient does not infer prompt readiness from connection promise creation", async () => {
   const client = makeClient();
   const internals = asInternals(client);
-  const calls: string[] = [];
   let resolvePrompt!: (value: { stopReason: "end_turn" }) => void;
   const promptResponse = new Promise<{ stopReason: "end_turn" }>((resolve) => {
     resolvePrompt = resolve;
   });
-  let reportStarted!: () => void;
-  const started = new Promise<void>((resolve) => {
-    reportStarted = resolve;
-  });
+  let reported = false;
   internals.connection = {
-    prompt: () => {
-      calls.push("prompt");
-      return promptResponse;
-    },
+    prompt: () => promptResponse,
   };
 
   const pending = client.prompt("session-start", "hello", () => {
-    calls.push("started");
-    reportStarted();
+    reported = true;
   });
-  await started;
+  await Promise.resolve();
 
-  assert.deepEqual(calls, ["prompt", "started"]);
+  assert.equal(reported, false);
   assert.equal(client.hasActivePrompt(), true);
   resolvePrompt({ stopReason: "end_turn" });
   assert.deepEqual(await pending, { stopReason: "end_turn" });
+  assert.equal(reported, false);
 });
 
-test("AcpClient does not report prompt start when request creation throws", async () => {
+test("AcpClient does not report prompt readiness when request creation throws", async () => {
   const client = makeClient();
   const internals = asInternals(client);
   let reported = false;
@@ -1310,7 +1455,7 @@ test("AcpClient does not report prompt start when request creation throws", asyn
   assert.equal(reported, false);
 });
 
-test("AcpClient does not report prompt start when the connection is already closed", async () => {
+test("AcpClient does not report prompt readiness when the connection is already closed", async () => {
   const client = makeClient();
   const internals = asInternals(client);
   let reported = false;
@@ -1353,7 +1498,7 @@ test("AcpClient does not submit a prompt after agent exit settles the queued req
   assert.equal(reported, false);
 });
 
-test("AcpClient reports prompt start when the connection closes while creating the request", async () => {
+test("AcpClient does not report prompt readiness when the connection closes during request creation", async () => {
   const client = makeClient();
   const internals = asInternals(client);
   const connection = new AbortController();
@@ -1370,24 +1515,7 @@ test("AcpClient reports prompt start when the connection closes while creating t
     reported = true;
   });
 
-  assert.equal(reported, true);
-});
-
-test("AcpClient prompt completion does not depend on prompt start observers", async () => {
-  const client = makeClient();
-  const internals = asInternals(client);
-  internals.connection = {
-    prompt: async () => ({ stopReason: "end_turn" }),
-  };
-
-  await assert.doesNotReject(
-    client.prompt("session-start-observer-failure", "hello", async () => {
-      throw new Error("observer failed");
-    }),
-  );
-  await assert.doesNotReject(
-    client.prompt("session-start-observer-pending", "hello", () => new Promise<void>(() => {})),
-  );
+  assert.equal(reported, false);
 });
 
 test("AcpClient prompt rejects when the agent disconnects mid-prompt", async () => {
@@ -1519,6 +1647,58 @@ function makeClient(
 
 function asInternals(client: AcpClient): ClientInternals {
   return client as unknown as ClientInternals;
+}
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function connectClientToStream(
+  client: AcpClient,
+  base: {
+    readable: ReadableStream<AnyMessage>;
+    writable: WritableStream<AnyMessage>;
+  },
+): void {
+  const internals = asInternals(client);
+  const tapped = internals.createTappedStream?.(base);
+  assert(tapped);
+  const connection = internals.createConnection?.(tapped, { devinAcp: false });
+  assert(connection);
+  internals.connection = connection;
+}
+
+function promptResponseFor(request: AnyMessage): AnyMessage {
+  assert("id" in request);
+  return {
+    jsonrpc: "2.0",
+    id: request.id,
+    result: { stopReason: "end_turn" },
+  };
+}
+
+async function writeAgentMessage(
+  writable: WritableStream<AnyMessage>,
+  message: AnyMessage,
+): Promise<void> {
+  const writer = writable.getWriter();
+  try {
+    await writer.write(message);
+  } finally {
+    writer.releaseLock();
+  }
 }
 
 function makePermissionRequest(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -5543,10 +5543,10 @@ test("runPromptTurn: request readiness does not replace the awaited prompt lifec
     prompt: async (
       _sessionId: string,
       _prompt: PromptInput | string,
-      onRequestStarted?: () => Promise<void> | void,
+      onRequestWritten?: () => Promise<void> | void,
     ) => {
       calls.push("prompt");
-      await onRequestStarted?.();
+      await onRequestWritten?.();
       return { stopReason: "end_turn" as const };
     },
   };
@@ -5557,8 +5557,8 @@ test("runPromptTurn: request readiness does not replace the awaited prompt lifec
     sessionId: "session-prompt-barrier",
     prompt: "hello",
     conversation,
-    onPromptRequestStarted: () => {
-      calls.push("request-started");
+    onPromptRequestWritten: () => {
+      calls.push("request-written");
     },
     onPromptStarted: async () => {
       calls.push("lifecycle-started");
@@ -5568,11 +5568,11 @@ test("runPromptTurn: request readiness does not replace the awaited prompt lifec
   });
 
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
-  assert.deepEqual(calls, ["prompt", "request-started", "lifecycle-started"]);
+  assert.deepEqual(calls, ["prompt", "request-written", "lifecycle-started"]);
 
   releaseLifecycleBarrier();
   await pending;
-  assert.deepEqual(calls, ["prompt", "request-started", "lifecycle-started", "lifecycle-released"]);
+  assert.deepEqual(calls, ["prompt", "request-written", "lifecycle-started", "lifecycle-released"]);
 });
 
 test("runPromptTurn: prompt response usage is recorded after usage update drain", async () => {

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -79,7 +79,7 @@ type FakeClient = {
   prompt: (
     sessionId: string,
     input: unknown,
-    onRequestStarted?: () => Promise<void> | void,
+    onRequestWritten?: () => Promise<void> | void,
   ) => Promise<{
     stopReason: string;
     usage?: Record<string, unknown>;
@@ -605,9 +605,9 @@ test("AcpRuntimeManager resolves promptStarted while the submitted prompt is pen
           prompt: async (
             _sessionId: string,
             _input: unknown,
-            onRequestStarted?: () => Promise<void> | void,
+            onRequestWritten?: () => Promise<void> | void,
           ) => {
-            await onRequestStarted?.();
+            await onRequestWritten?.();
             return await promptResponse;
           },
           requestCancelActivePrompt: async () => false,
@@ -677,6 +677,53 @@ test("AcpRuntimeManager rejects promptStarted when the turn fails before submiss
   });
 
   await assert.rejects(turn.promptStarted, /connect failed/);
+  assert.equal((await turn.result).status, "failed");
+});
+
+test("AcpRuntimeManager rejects promptStarted when the prompt transport write fails", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "prompt-write-failed-session",
+    acpSessionId: "prompt-write-failed-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () =>
+        ({
+          start: async () => {},
+          close: async () => {},
+          createSession: async () => ({ sessionId: "unused" }),
+          loadSession: async () => ({ agentSessionId: "unused" }),
+          hasReusableSession: () => true,
+          supportsLoadSession: () => true,
+          supportsResumeSession: () => false,
+          loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+          getAgentLifecycleSnapshot: () => ({ running: true }),
+          prompt: async () => {
+            throw new Error("transport write failed");
+          },
+          requestCancelActivePrompt: async () => false,
+          hasActivePrompt: () => false,
+          setSessionMode: async () => {},
+          setSessionConfigOption: async () => {},
+          clearEventHandlers: () => {},
+          setEventHandlers: () => {},
+        }) as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("prompt-write-failed-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-prompt-write-failed",
+  });
+
+  await assert.rejects(turn.promptStarted, /transport write failed/);
   assert.equal((await turn.result).status, "failed");
 });
 
@@ -790,9 +837,9 @@ test("AcpRuntimeManager keeps promptStarted resolved when submission later fails
           prompt: async (
             _sessionId: string,
             _input: unknown,
-            onRequestStarted?: () => Promise<void> | void,
+            onRequestWritten?: () => Promise<void> | void,
           ) => {
-            await onRequestStarted?.();
+            await onRequestWritten?.();
             throw new Error("prompt failed after submission");
           },
           requestCancelActivePrompt: async () => false,


### PR DESCRIPTION
`promptStarted` could resolve while the ACP child's input pipe was still blocked because the SDK returns the prompt-response promise before completing its outbound write. Bind each prompt to its exact outgoing request and resolve readiness only after the writable transport accepts it. Failed writes reject readiness; observer failures cannot take ownership of an accepted request.

This preserves Vincent Koc's implementation from https://github.com/openclaw/acpx/pull/540, refreshes it against current main, and includes changelog and commit credit. The original reported maintainer edits disabled, so preparation uses an owned branch. The original #540 can be closed as superseded after an authorized landing.

A real built-runtime probe with a paused child pipe and a 6 MiB prompt demonstrates readiness changing from early to pending until the write completes, while still resolving before the final response. Captured before/after output is posted in the proof comment.

Validation: 993 tests plus 146 coverage tests and documentation checks passed. Local and branch autoreview are clean through P2. Exact-head CI succeeded at `493e5aa2d57698b1cfcf824f76f86a25b5586a63`: https://github.com/openclaw/acpx/actions/runs/33992362045.
