### PR TITLE
fix(ci): align Crabbox root volume with runner image

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,8 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  # The promoted AWS runner image requires at least a 400 GiB root volume.
+  rootGB: 400
 sync:
   delete: true
   checksum: false


### PR DESCRIPTION
## Summary

Replace the stale `aws.rootGB: 160` override with `400`, the observed minimum required by the promoted AWS runner snapshot. Add a short comment explaining the constraint. AWS was rejecting lease creation with `InvalidBlockDeviceMapping` before any Linux command could run.

Crabbox 0.48.1 already defaults to 400 GiB, but this repository override took precedence. `CRABBOX_AWS_ROOT_GB=400` is a supported task-local workaround; fixing the repository default avoids requiring it on every run. Omitting the field would expose inherited user configuration rather than automatically sizing from the image. Provider `aws`, profile `acpx-check`, region/capacity policy, hydration configuration, and credential boundaries are unchanged.

This is an internal validation configuration fix, not an acpx runtime behavior change.

## Validation

- `pnpm run check`: passed; 999 tests passed, two skipped, and all 147 targeted coverage tests passed.
- `pnpm run mutate`: passed; mutation score 91.05%, above the existing 80% gate.
- `pnpm run conformance:run -- --case acp.v1.initialize.handshake`: passed.
- All three configured Slophammer CI commands passed: rules listing, DRY check, and the direct dependency-boundary check.
- Final `pnpm run format:check` and `git diff --check`: passed.
- Independent isolated Codex review: no actionable P0–P2 findings.

### Fresh Linux CLI/process proof

A fresh lease using the unchanged AWS/profile routing and the corrected repository configuration completed successfully. The guest reported a 429,496,729,600-byte root disk (400 GiB). With Node 24.20.0 and pnpm 11.25.0, the proof installed the frozen lockfile, built the CLI and tests, and ran:

```sh
timeout --signal=TERM --kill-after=10s 60s node --test --test-reporter=tap --test-name-pattern '^integration: terminal (lifecycle create/output/wait/release|kill leaves no orphan sleep process)$' dist-test/test/integration.test.js
```

Both real CLI/process tests passed in 2.34 seconds, with zero failures or skips. The overall proof script had a ten-minute deadline and the lease a thirty-minute TTL. Broker records confirm release and completed cleanup for all task-owned leases.

The initial allocation failure is not counted as live proof. A separate attempt successfully provisioned but stopped before tests because Crabbox 0.48.1's local hydration interpreter rejects `pnpm/action-setup@v6.0.10`. The successful proof explicitly used `--no-hydrate` plus the documented repository toolchain setup; it does not claim to validate hydration. No provider switch or cloud-credential escalation was used.

### Captured provisioning, execution, and cleanup evidence

Successful task-owned lease: `cbx_01ab80a39942` (`quick-crayfish-ebf8`), recorded run `run_abe12d04c714`. The tested working-tree content is identical to PR head `5e726f0283c76624336205095b6045b594712e2b`; only the Git commit was created afterward. The reported original failure was `InvalidBlockDeviceMapping`: a 160 GB requested volume was smaller than the snapshot's required minimum of 400 GB. That historical failure was not re-run or presented as successful proof.

The following are non-contiguous excerpts from the captured successful run. IP addresses, image identifiers, private endpoints, and local paths are omitted or redacted; no credentials or agent transcripts are included.

```text
{
  "provider": "aws",
  "profile": "acpx-check",
  "target": "linux",
  "rootGB": 400
}
recording run run_abe12d04c714
leased cbx_01ab80a39942 slug=quick-crayfish-ebf8 server=0 type=c7a.8xlarge ip=[redacted] via coordinator
image selected id=[redacted] source=promoted kind=aws-ami region=eu-west-1 promoted_at=2026-08-01T08:35:02.840Z
CRABBOX_PHASE:linux-environment
Linux 7.0.0-1009-aws x86_64 GNU/Linux
NAME                 SIZE TYPE MOUNTPOINTS
nvme0n1      429496729600 disk
├─nvme0n1p1  428306578944 part /
CRABBOX_PHASE:toolchain
v24.20.0
11.25.0
CRABBOX_PHASE:cli-process-proof
0.14.0
TAP version 13
# Subtest: integration: terminal lifecycle create/output/wait/release
ok 1 - integration: terminal lifecycle create/output/wait/release
# Subtest: integration: terminal kill leaves no orphan sleep process
ok 2 - integration: terminal kill leaves no orphan sleep process
1..2
# tests 2
# suites 0
# pass 2
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2335.099482
CRABBOX_PHASE:proof-complete
```

The recorded broker run state was queried after execution:

```json
{
  "id": "run_abe12d04c714",
  "state": "succeeded",
  "phase": "succeeded",
  "exitCode": 0,
  "startedAt": "2026-09-07T00:32:17.073Z",
  "endedAt": "2026-09-07T00:36:44.422Z"
}
```

Initial release acknowledgement reported cleanup pending, so it was not treated as completed cleanup. A subsequent stop and inspect confirmed:

```json
{
  "id": "cbx_01ab80a39942",
  "provider": "aws",
  "state": "released",
  "cleanupStatus": "complete",
  "ready": false
}
```

The active AWS lease list filtered to task-owned IDs then returned `[]`.

Hosted validation on the exact PR head also passed: [CI run 34074769374](https://github.com/openclaw/acpx/actions/runs/34074769374), including Test, Mutation, Conformance Smoke, and Slophammer. CodeQL analyses passed; Docs was correctly skipped for this configuration-only change.
