### PR TITLE
test(flows): preserve shell cleanup fixture paths

### DIFF
--- a/test/flows-shell.test.ts
+++ b/test/flows-shell.test.ts
@@ -206,7 +206,9 @@ test("runShellAction does not crash the host when the child exits before reading
 
 for (const detached of [false, true]) {
   test(`shell abort stops descendants after wrapper exit (detached=${detached})`, async (t) => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-shell-tree-"));
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "acpx-shell-tree space & $dollar 'quote'-"),
+    );
     const pidFile = path.join(dir, "descendant.pid");
     const controller = new AbortController();
     const descendant = `process.on('SIGTERM',()=>{});require('node:fs').writeFileSync(${JSON.stringify(pidFile)},String(process.pid));setInterval(()=>{},1000)`;
@@ -214,7 +216,15 @@ for (const detached of [false, true]) {
     const wrapperFile = path.join(dir, "wrapper.cjs");
     await fs.writeFile(wrapperFile, wrapper);
     const pending = runShellAction(
-      { command: process.execPath, args: [wrapperFile], shell: true, timeoutMs: 0 },
+      {
+        command:
+          process.platform === "win32"
+            ? '"%ACPX_TEST_NODE%" "%ACPX_TEST_WRAPPER%"'
+            : '"$ACPX_TEST_NODE" "$ACPX_TEST_WRAPPER"',
+        env: { ACPX_TEST_NODE: process.execPath, ACPX_TEST_WRAPPER: wrapperFile },
+        shell: true,
+        timeoutMs: 0,
+      },
       { signal: controller.signal },
     );
     const rejected = assert.rejects(pending, TimeoutError);


### PR DESCRIPTION
Related: https://github.com/openclaw/acpx/security/code-scanning/12

## What Problem This Solves

Resolves a problem where the shell-descendant cleanup tests fail before starting their descendant when the temporary directory contains spaces or shell metacharacters. Passing the wrapper path as an argument with `shell: true` lets Node concatenate it into shell source without quoting.

## Why This Change Was Made

The existing fixture now launches fixed, platform-specific shell text with the executable and wrapper paths supplied through quoted environment variables. Its temporary directory includes spaces, an ampersand, a dollar sign, and single quotes so ordinary runs exercise argument preservation.

Both detached cases, `shell: true`, `timeoutMs: 0`, and the descendant-cleanup assertions remain unchanged. Only `test/flows-shell.test.ts` changes; there are no runtime, dependency, configuration, or CodeQL rule changes.

The linked alert led to this separate fixture finding. This patch does not claim that the alert's reported `JSON.stringify` expression is unsafe or that the alert has been dismissed.

## User Impact

More reliable contributor test execution from nontrivial temporary paths. No product runtime behavior changes.

## Evidence

Local proof used macOS and Node 26.7.0, starting from main at `d1ec6e87b72f649f54e9288903d05cca1a9b776c`.

- **Red:** both real descendant-cleanup cases failed under a space-containing temporary root. Node reported `MODULE_NOT_FOUND` for the path truncated at its first space.
- **Green:** the complete compiled shell test file passed **22/22** tests, including both detached cases and cleanup assertions.
- **Hostile paths:** both cases passed **2/2** with the Node executable and temporary root containing spaces and shell metacharacters.
- Declared-version `oxfmt` and targeted type-aware `oxlint` passed. `git diff --check` passed.
- Independent P0-P2 autoreview reported no actionable findings. The scoped patch and recorded red/green evidence were also independently inspected during coordination.

Local limitations, kept separate from passing proof:

- `pnpm run check` was invoked once and stopped before running checks with `ERR_PNPM_UNSAFE_MODULES_DIR`: pnpm attempted dependency reconciliation, and its guard refused to replace the symlinked shared install. The guard was not bypassed; shared dependencies were not reconciled.
- Separately, `node_modules/.bin/tsc -p tsconfig.test.json` reported `TS2339` in `test/mock-agent.ts`: the existing shared SDK lacks `completeElicitation`. It emitted the JavaScript used for the passing compiled shell suite, but compilation itself did **not** pass.
- A direct source-loader attempt (`node --import tsx --test test/flows-shell.test.ts`) failed **7/22** cases because its separately spawned children imported noncompiled `.js` files. That attempt is not green evidence.
- Windows execution was not performed locally.

### Exact-Head Hosted Validation

Head: `939d7345f00ee2d1c4b0ed4ad07afc8e99ce3927`.

- [CI run 34075936573](https://github.com/openclaw/acpx/actions/runs/34075936573) passed scope, Format, Typecheck, Lint, Build, Conformance Smoke, Test, Mutation, and Slophammer. Docs was skipped by scope.
- The [full Test and coverage job](https://github.com/openclaw/acpx/actions/runs/34075936573/job/101601947718) passed. Maintainer log inspection confirmed both changed descendant-cleanup cases executed, for `detached: false` and `detached: true`.
- [CodeQL run 34075936021](https://github.com/openclaw/acpx/actions/runs/34075936021) passed actions, JavaScript/TypeScript, and Python analysis; the aggregate CodeQL check also passed.
- [ClawSweeper's final review](https://github.com/openclaw/acpx/pull/551#issuecomment-5564179138) covers this exact head, reports no findings, and lists no before-merge action. The maintainer inspected and approved the patch, reproduction, and review.

The hosted clean-install results are distinct from the local limitations above. No unchanged local full-check retry or additional review cycle was needed.

AI-assisted implementation; scoped code and behavior proof reviewed.

<!-- Punchcard-Session: quiet-willow-harbor-2r -->
