### PR TITLE
feat(runtime): support transient agent environment overlays

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -213,3 +213,6 @@ Then `acpx ci-bot 'run sanity checks'` resolves through the registry without any
 - [Custom agents](custom-agents.md) — `--agent` escape hatch and unknown positional names.
 - [Permissions](permissions.md) — `defaultPermissions` and non-interactive policy.
 - [Output formats](output-formats.md) — `format` default and `--json-strict`.
+
+Embedded hosts can also supply a [transient runtime environment](runtime-environment.md)
+without persisting child-process settings in a session.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -1,0 +1,32 @@
+# Transient runtime environment
+
+Embedded clients can set `AcpRuntimeOptions.agentProcessEnv` to a map of strings
+for the agent children owned by that runtime. ACPX snapshots the map when
+`createAcpRuntime()` is called. Later mutations of the caller's map do not affect
+that runtime. The same overlay applies to probes, new sessions, controls and
+reconnections, including sessions loaded from an existing store.
+
+Precedence is protected authentication values, then `agentProcessEnv`, then
+persisted `sessionOptions.env`, then the inherited process environment. Windows
+uses the same case-insensitive collision handling as session environment values.
+The overlay does not change the parent process environment.
+
+This is trusted embedding-host configuration: executable, loader and other
+process settings can change what the child runs. ACPX does not sanitize arbitrary
+environment variables. Existing credential protection remains in effect.
+Invalid environment entries are rejected without echoing their values.
+
+ACPX does not copy the overlay into session records, events, status or diagnostics.
+An adapter can still echo its own environment into output; this option cannot
+prevent that. A new runtime must supply its own overlay, and a previously saved
+session environment retains its existing persistence behavior.
+
+```ts
+const runtime = createAcpRuntime({
+  cwd,
+  sessionStore,
+  agentRegistry,
+  permissionMode: "approve-reads",
+  agentProcessEnv: { ADAPTER_EXECUTABLE: "/opt/agent/bin/agent" },
+});
+```

--- a/src/acp/auth-env.ts
+++ b/src/acp/auth-env.ts
@@ -79,10 +79,27 @@ function promotePrefixedAuthEnvironment(env: NodeJS.ProcessEnv): Set<string> {
   return protectedKeys;
 }
 
+function validateAgentProcessEnv(agentProcessEnv: Record<string, string> | undefined): void {
+  for (const [key, value] of Object.entries(agentProcessEnv ?? {})) {
+    if (
+      typeof value !== "string" ||
+      key.includes("=") ||
+      key.includes("\u0000") ||
+      value.includes("\u0000")
+    ) {
+      throw new Error(
+        "Invalid agentProcessEnv: environment entries cannot contain NUL or names with '='",
+      );
+    }
+  }
+}
+
 function buildAgentEnvironment(
   authCredentials: Record<string, string> | undefined,
   sessionEnv: Record<string, string> | undefined,
+  agentProcessEnv: Record<string, string> | undefined,
 ): NodeJS.ProcessEnv {
+  validateAgentProcessEnv(agentProcessEnv);
   const env: NodeJS.ProcessEnv = { ...process.env };
   const protectedAuthEnvKeys = promotePrefixedAuthEnvironment(env);
   if (authCredentials) {
@@ -92,8 +109,8 @@ function buildAgentEnvironment(
     }
   }
 
-  if (sessionEnv) {
-    for (const [key, value] of Object.entries(sessionEnv)) {
+  for (const overlay of [sessionEnv, agentProcessEnv]) {
+    for (const [key, value] of Object.entries(overlay ?? {})) {
       if (typeof value !== "string" || protectedAuthEnvKeys.has(protectedEnvKey(key))) {
         continue;
       }
@@ -172,6 +189,7 @@ export function buildAgentSpawnOptions(
   cwd: string,
   authCredentials: Record<string, string> | undefined,
   sessionEnv?: Record<string, string>,
+  agentProcessEnv?: Record<string, string>,
 ): {
   cwd: string;
   env: NodeJS.ProcessEnv;
@@ -180,7 +198,7 @@ export function buildAgentSpawnOptions(
 } {
   return {
     cwd,
-    env: buildAgentEnvironment(authCredentials, sessionEnv),
+    env: buildAgentEnvironment(authCredentials, sessionEnv, agentProcessEnv),
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   };

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -634,6 +634,7 @@ export class AcpClient {
     this.options = {
       ...options,
       cwd: asAbsoluteCwd(options.cwd),
+      agentProcessEnv: options.agentProcessEnv ? { ...options.agentProcessEnv } : undefined,
       authPolicy: options.authPolicy ?? "skip",
       permissionPolicy: snapshotPermissionPolicy(options.permissionPolicy),
       elicitationModes: normalizeElicitationModes(options.elicitationModes),
@@ -881,6 +882,7 @@ export class AcpClient {
         this.options.cwd,
         this.options.authCredentials,
         this.options.sessionOptions?.env,
+        this.options.agentProcessEnv,
       ),
     };
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -151,7 +151,11 @@ export class AcpxRuntime implements AcpxRuntimeLike {
         details?: unknown[];
       }>;
     },
-  ) {}
+  ) {
+    if (options.agentProcessEnv) {
+      this.options = { ...options, agentProcessEnv: { ...options.agentProcessEnv } };
+    }
+  }
 
   isHealthy(): boolean {
     return this.healthy;

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -602,7 +602,8 @@ export class AcpRuntimeManager {
   ) {}
 
   private createClient(options: ConstructorParameters<typeof AcpClient>[0]): AcpClient {
-    return this.deps.clientFactory?.(options) ?? new AcpClient(options);
+    const clientOptions = { ...options, agentProcessEnv: this.options.agentProcessEnv };
+    return this.deps.clientFactory?.(clientOptions) ?? new AcpClient(clientOptions);
   }
 
   private createSessionOwner(input: {

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -352,6 +352,8 @@ export interface AcpAgentRegistry {
 
 export type AcpRuntimeOptions = {
   cwd: string;
+  /** Trusted child-only environment, snapshotted at construction and never persisted. */
+  agentProcessEnv?: Record<string, string>;
   sessionStore: AcpSessionStore;
   agentRegistry: AcpAgentRegistry;
   mcpServers?: McpServer[];

--- a/src/runtime/public/probe.ts
+++ b/src/runtime/public/probe.ts
@@ -117,6 +117,7 @@ function createProbeClient(
   const clientOptions = {
     ...agentCommand,
     cwd: options.cwd,
+    agentProcessEnv: options.agentProcessEnv,
     mcpServers: [...(options.mcpServers ?? [])],
     permissionMode: options.permissionMode,
     nonInteractivePermissions: options.nonInteractivePermissions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,8 @@ export interface OutputFormatter {
 export type AcpClientOptions = {
   agentCommand: string;
   agentArgv?: string[];
+  /** Trusted child-only environment overlay; never persisted as session options. */
+  agentProcessEnv?: Record<string, string>;
   cwd: string;
   mcpServers?: McpServer[];
   permissionMode: PermissionMode;

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -219,6 +219,7 @@ test("AcpRuntimeManager closes an incompatible persistent owner before replacing
 
 test("AcpRuntimeManager creates and resumes sessions through the client", async () => {
   const store = new InMemorySessionStore();
+  const agentProcessEnv = { ACPX_TEST_RUNTIME_OVERLAY: "runtime-only" };
   const permissionPolicy = {
     autoApprove: ["read"],
     escalate: ["execute"],
@@ -286,7 +287,12 @@ test("AcpRuntimeManager creates and resumes sessions through the client", async 
   });
   const constructedOptions: Array<Record<string, unknown>> = [];
   const manager = new AcpRuntimeManager(
-    createRuntimeOptions({ cwd: "/workspace", sessionStore: store, permissionPolicy }),
+    createRuntimeOptions({
+      cwd: "/workspace",
+      sessionStore: store,
+      permissionPolicy,
+      agentProcessEnv,
+    }),
     {
       clientFactory: (options) => {
         constructedOptions.push(options);
@@ -323,6 +329,12 @@ test("AcpRuntimeManager creates and resumes sessions through the client", async 
     ["model"],
   );
   assert.equal(constructedOptions.length, 2);
+  assert.deepEqual(
+    constructedOptions.map((options) => options.agentProcessEnv),
+    [agentProcessEnv, agentProcessEnv],
+  );
+  assert.equal(JSON.stringify(created).includes("runtime-only"), false);
+  assert.equal(JSON.stringify(resumed).includes("runtime-only"), false);
   assert.deepEqual(
     constructedOptions.map((options) => options.permissionPolicy),
     [permissionPolicy, permissionPolicy],

--- a/test/runtime-probe.test.ts
+++ b/test/runtime-probe.test.ts
@@ -11,6 +11,7 @@ import { createRuntimeOptions, InMemorySessionStore } from "./runtime-test-helpe
 test("probeRuntime uses the default agent override and reports protocol details", async () => {
   const store = new InMemorySessionStore();
   const constructed: Array<Record<string, unknown>> = [];
+  const agentProcessEnv = { ACPX_TEST_RUNTIME_OVERLAY: "probe-only" };
   const permissionPolicy = {
     autoApprove: ["read", "search"],
     escalate: ["execute"],
@@ -21,6 +22,7 @@ test("probeRuntime uses the default agent override and reports protocol details"
       cwd: "/workspace",
       sessionStore: store,
       permissionPolicy,
+      agentProcessEnv,
       agentRegistry: createAgentRegistry({
         overrides: {
           claude: "broken-claude-acp",
@@ -43,6 +45,7 @@ test("probeRuntime uses the default agent override and reports protocol details"
   assert.equal(report.ok, true);
   assert.equal(constructed[0]?.agentCommand, "codex-override --acp");
   assert.deepEqual(constructed[0]?.permissionPolicy, permissionPolicy);
+  assert.deepEqual(constructed[0]?.agentProcessEnv, agentProcessEnv);
   assert.deepEqual(report.details, [
     "agent=codex",
     "command=codex-override --acp",

--- a/test/runtime-test-helpers.ts
+++ b/test/runtime-test-helpers.ts
@@ -147,6 +147,7 @@ export function createRuntimeOptions(params: {
   sessionStore: AcpSessionStore;
   agentRegistry?: AcpAgentRegistry;
   permissionPolicy?: AcpRuntimeOptions["permissionPolicy"];
+  agentProcessEnv?: AcpRuntimeOptions["agentProcessEnv"];
   timeoutMs?: number;
 }): AcpRuntimeOptions {
   return {
@@ -163,5 +164,6 @@ export function createRuntimeOptions(params: {
     },
     permissionMode: "approve-reads",
     permissionPolicy: params.permissionPolicy,
+    agentProcessEnv: params.agentProcessEnv,
   };
 }

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -711,3 +711,29 @@ test("createRuntimeStore is an alias for the file-backed session store", async (
 
   assert.equal(loaded?.acpSessionId, "alias-sid");
 });
+
+test("AcpxRuntime snapshots transient child environment for manager and probes", async () => {
+  const agentProcessEnv = { ACPX_TEST_RUNTIME_OVERLAY: "construction-value" };
+  const observed: unknown[] = [];
+  const runtime = new AcpxRuntime(
+    {
+      cwd: process.cwd(),
+      sessionStore: createFileSessionStore({
+        stateDir: path.join(os.tmpdir(), "unused-env-store"),
+      }),
+      agentRegistry: createAgentRegistry(),
+      permissionMode: "deny-all",
+      agentProcessEnv,
+    },
+    {
+      probeRunner: async (options) => {
+        observed.push(options.agentProcessEnv);
+        return { ok: true, message: "synthetic probe" };
+      },
+    },
+  );
+  agentProcessEnv.ACPX_TEST_RUNTIME_OVERLAY = "mutated-value";
+  await runtime.doctor();
+  assert.deepEqual(observed, [{ ACPX_TEST_RUNTIME_OVERLAY: "construction-value" }]);
+  assert.equal(process.env.ACPX_TEST_RUNTIME_OVERLAY, undefined);
+});

--- a/test/spawn-options.test.ts
+++ b/test/spawn-options.test.ts
@@ -57,6 +57,53 @@ test("buildAgentSpawnOptions leaves the agent env untouched when no session env 
   assert.equal(options.env.ACPX_TEST_SESSION_ENV_INJECTED, undefined);
 });
 
+test("runtime environment overrides session values without changing protected credentials or parent", () => {
+  const options = buildAgentSpawnOptions(
+    os.tmpdir(),
+    { "runtime-token": "synthetic-credential" },
+    { ACPX_TEST_RUNTIME_OVERLAY: "session", RUNTIME_TOKEN: "session-credential" },
+    {
+      ACPX_TEST_RUNTIME_OVERLAY: "runtime",
+      RUNTIME_TOKEN: "runtime-credential",
+      ACPX_AUTH_RUNTIME_TOKEN: "runtime-prefixed",
+    },
+  );
+  assert.equal(options.env.ACPX_TEST_RUNTIME_OVERLAY, "runtime");
+  assert.equal(options.env.RUNTIME_TOKEN, "synthetic-credential");
+  assert.equal(options.env.ACPX_AUTH_RUNTIME_TOKEN, "synthetic-credential");
+  assert.equal(process.env.ACPX_TEST_RUNTIME_OVERLAY, undefined);
+});
+
+test("runtime environment uses Windows case collision and credential protection rules", () => {
+  withPlatform("win32", () => {
+    const options = buildAgentSpawnOptions(
+      os.tmpdir(),
+      { "runtime-token": "synthetic-credential" },
+      { ACPX_TEST_RUNTIME_OVERLAY: "session" },
+      { acpx_test_runtime_overlay: "runtime", runtime_token: "override" },
+    );
+    assert.equal(options.env.ACPX_TEST_RUNTIME_OVERLAY, undefined);
+    assert.equal(options.env.acpx_test_runtime_overlay, "runtime");
+    assert.equal(options.env.RUNTIME_TOKEN, "synthetic-credential");
+    assert.equal(options.env.runtime_token, undefined);
+  });
+});
+
+test("invalid runtime environment fails without echoing the supplied value", () => {
+  assert.throws(
+    () =>
+      buildAgentSpawnOptions(os.tmpdir(), undefined, undefined, {
+        VALID_NAME: "private-marker\u0000",
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Invalid agentProcessEnv/);
+      assert.equal(error.message.includes("private-marker"), false);
+      return true;
+    },
+  );
+});
+
 test("spawned agent child process receives session env with parent-override precedence", async () => {
   const script =
     "process.stdout.write(JSON.stringify({injected:process.env.ACPX_TEST_E2E_INJECTED,parent:process.env.ACPX_TEST_E2E_PARENT}))";


### PR DESCRIPTION
Embedded hosts need child-process settings that last for one runtime without changing `process.env` or saving machine-specific paths into session records. Add optional `agentProcessEnv`, snapshotted at runtime construction and forwarded through the shared client builder and independent probe path.

The overlay uses existing credential protection and Windows environment-name handling. Protected authentication values win, then runtime values, saved session values, and inherited environment. Invalid entries fail before spawn without echoing values. Adapter output remains adapter-owned and may itself contain anything the adapter chooses to emit.

Fixes #517. Thanks @taras and @coding-ax for the concrete embedding use cases. Changelog credit is in the consolidated notes PR.

Validation: format, typecheck, lint, package/viewer builds and docs checks passed; the full Node 26 suite passed 1,005 tests with two skips, and all 148 coverage tests passed. Isolated branch autoreview is clean through P2. CI passed on `8045e6474f9ffe99e5fefd70e801280f4e9b77a5`: https://github.com/openclaw/acpx/actions/runs/34100628378. Local Node 24 viewer tests intermittently timed out or retained a worker even after a fresh-temp retry; Node 26 and CI both completed. A separate host imported built `dist/runtime.js`. The live host observes three real child starts: probe and first session receive the immutable runtime overlay; a new runtime reconnects using the original saved session value. Store inspection and parent-environment assertions confirm no overlay persistence or parent mutation.


For this batch, maintainer direction is to keep all changelog edits in https://github.com/openclaw/acpx/pull/554 and land that PR last. This overrides the normal per-PR changelog placement rule; the consolidated section includes the feature and contributor credit.

Fresh copied output from a build of the exact head (`8045e6474f9ffe99e5fefd70e801280f4e9b77a5`) extracted with `git archive`. The child environment values below are synthetic; the runtime host asserted the observed values, recursively checked the session store, and checked the parent environment.

```json
{"probe":"runtime overlay","firstSession":"construction snapshot","reconnect":"saved session value","persistedOverlay":false,"parentChanged":false,"childStarts":3,"childEnvironments":[{"overlay":"runtime-only-proof-value"},{"overlay":"runtime-only-proof-value"},{"overlay":"saved-session-value"}]}
```
