### PR TITLE
chore: refresh tooling and consolidate release notes

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
     - crabbox
     - openclaw
     - acpx
+    - blacksmith-16vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           submodules: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
+        uses: pnpm/action-setup@v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
@@ -163,7 +163,7 @@ jobs:
           submodules: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
+        uses: pnpm/action-setup@v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
+        uses: pnpm/action-setup@v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
@@ -114,7 +114,7 @@ jobs:
           submodules: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.10
+        uses: pnpm/action-setup@v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
@@ -145,14 +145,14 @@ jobs:
           REPORT="conformance-artifacts/${{ matrix.id }}-report.json"
           if [ ! -f "$REPORT" ]; then
             node - <<'NODE'
-            const fs = require("node:fs");
-            const lines = [
-              "### Adapter Smoke: ${{ matrix.id }}",
-              "",
-              "- Result: report not produced (adapter failed before report write)",
-            ];
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
-            NODE
+          const fs = require("node:fs");
+          const lines = [
+            "### Adapter Smoke: ${{ matrix.id }}",
+            "",
+            "- Result: report not produced (adapter failed before report write)",
+          ];
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
+          NODE
             exit 0
           fi
           node - <<'NODE'

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.10
+      - uses: pnpm/action-setup@v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6.0.10
+      - uses: pnpm/action-setup@v6.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ Repo: https://github.com/openclaw/acpx
 
 ## Unreleased
 
-### Changes
+**Highlights:** Embedding hosts gain process lifecycle admission and transient child environments; optional limits bound shell output and ACP/queue input.
 
+- Runtime/embedding: expose optional correlated process lifecycle hooks with awaited launch admission and best-effort failure and exit observers. Thanks @MertBasar0.
+- Runtime/embedding: add a snapshotted child-only environment overlay for probes and session reconnects without persisting host settings or overriding protected authentication. Thanks @taras and @coding-ax.
+- ACP/results: preserve optional opaque prompt-response metadata in direct, queued, compare, and embedded-runtime results. Thanks @superbiche.
 - Agents/built-ins: add MiniMax Code through its native `mcode acp` server, with structured launch arguments and setup/lifecycle guidance. Thanks @hetaoBackend.
-
-### Breaking
-
-### Fixes
+- Flows: add optional per-stream shell capture limits with UTF-8 byte accounting and complete process-tree cleanup, retaining unlimited capture by default. Thanks @SebTardif.
+- ACP/transport: add an optional raw-byte message limit with clear overflow errors, preserving unlimited input by default and consistent handling across chunk boundaries. Thanks @SebTardif.
+- Queue: add an optional incoming request limit with client-side size diagnostics and raw-peer rejection, preserving large requests by default. Thanks @SebTardif.
 
 ## 0.14.0 - 2026-09-05
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "elkjs": "^0.12.0",
     "fast-json-patch": "^3.1.1",
     "husky": "^9.1.7",
-    "lint-staged": "^17.4.1",
+    "lint-staged": "^17.5.0",
     "markdownlint-cli2": "^0.23.2",
     "oxfmt": "^0.66.0",
     "oxlint": "^1.81.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.4.1
-        version: 17.4.1
+        specifier: ^17.5.0
+        version: 17.5.0
       markdownlint-cli2:
         specifier: ^0.23.2
         version: 0.23.2(supports-color@7.2.0)
@@ -2207,8 +2207,8 @@ packages:
   linkify-it@6.1.0:
     resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
 
-  lint-staged@17.4.1:
-    resolution: {integrity: sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==}
+  lint-staged@17.5.0:
+    resolution: {integrity: sha512-ah2qsNtvKP1+Ak4rAvEEIvcXDLjjbr/xmxCvlequxqEOFYk0qINcZcRxD3Ic8wRn7/oQ8+wC9s0DfDrdMVCRFg==}
     engines: {node: '>=22.22.1'}
     hasBin: true
 
@@ -2659,10 +2659,6 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
-
-  tinyexec@1.3.0:
-    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
-    engines: {node: '>=18'}
 
   tinyexec@1.3.1:
     resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
@@ -4521,11 +4517,11 @@ snapshots:
     dependencies:
       uc.micro: 3.0.0
 
-  lint-staged@17.4.1:
+  lint-staged@17.5.0:
     dependencies:
       picomatch: 4.0.7
       string-argv: 0.3.2
-      tinyexec: 1.3.0
+      tinyexec: 1.3.1
     optionalDependencies:
       yaml: 2.9.0
 
@@ -5152,8 +5148,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-
-  tinyexec@1.3.0: {}
 
   tinyexec@1.3.1: {}
 


### PR DESCRIPTION
Consolidate the next release's user-facing notes in one Unreleased section, ordered by user impact, so the independently prepared feature PRs can land without changelog conflicts. Land this PR last, after #531, #537, #539, #546, #552 and #553. Recommend 0.15.0 for the additive embedding capabilities.

Refresh lint-staged 17.4.1 → 17.5.0 and pnpm/action-setup 6.0.10 → 6.1.0 while keeping pnpm 11.25.0. Both updates meet the repository's two-day release-age policy. The Actions pass also found an invalid indented heredoc terminator in the optional adapter summary; correcting it restores both missing-report and successful-report summaries. Add the existing Blacksmith runner label to actionlint configuration.

Validation: the full source check passed with 1,022 tests (two skips) and 148 coverage tests; docs and formatting passed; the built CLI completed an ACP fixture prompt; lint-staged 17.5.0 ran the real commit hook. Actionlint passes. The extracted adapter summary failed `bash -n` before the fix, then passed syntax validation and real executions for both report paths. Isolated branch review is clean through P2. Exact head: `09e6ecda5c74f8d27e6ef1dd50f619eef5a46da0`. CI: https://github.com/openclaw/acpx/actions/runs/34110632493.

This PR follows the maintainer direction to keep changelog changes in this final PR. It makes no publication or package-format changes. The existing Nix packaging problem remains separate: the production-only shrinkwrap experiment did not satisfy clean-root npm ci, and npm 12 omits legacy shrinkwrap when packing.

Rebased independently onto `836580394b6e675321b6924b1f3dc79287fb1aca`; both commits are patch-equivalent to their reviewed predecessors. The real pre-commit hook processed the actual staged notes patch in an isolated checkout with lint-staged 17.5.0, formatted two matching files and completed the build without changing the patch. The refreshed proof comment includes copied hook output. Contributor `Co-authored-by` credit remains exclusively in #553; this notes PR retains changelog thanks.
