### PR TITLE
fix(acp): default incoming messages to 64 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Breaking
 
+- ACP/transport: default incoming messages to a 64 MiB raw-byte limit instead of unlimited input; use `ACPX_MAX_ACP_MESSAGE_BYTES` to raise the limit or `0` to disable it. Overflow errors explain the override, and existing warm owners retain their startup setting.
+
 ### Fixes
 
 ## 0.15.0 - 2026-09-07

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -141,13 +141,25 @@ OpenClaw repo-local checkout (the canonical "override a built-in" example):
 
 ## Incoming message limits
 
-`ACPX_MAX_ACP_MESSAGE_BYTES` optionally limits each incoming ACP transport line
-to a non-negative safe integer number of bytes, excluding its final newline.
-Unset, empty, or zero preserves unlimited input. For example, set it to
-`8388608` to enforce an 8 MiB limit when starting a client or queue owner.
+Each incoming ACP transport line is limited to **64 MiB (67,108,864 bytes)** by
+default. `ACPX_MAX_ACP_MESSAGE_BYTES` overrides that limit with a non-negative
+safe integer number of bytes:
 
-The limit applies to complete messages and unfinished lines alike, regardless of
-how stdout chunks are split. This is an explicit maximum message size: choose a
-limit large enough for image and other structured responses. Overflow fails the
-connection with `ACP_MESSAGE_TOO_LARGE`, while invalid settings fail before an agent process is spawned.
-A warm owner keeps the setting with which its ACP connection was started.
+- Unset, empty, or whitespace-only: use the 64 MiB default.
+- Positive value: use that limit; for example, `134217728` allows 128 MiB.
+- `0`: explicitly disable the limit and allow unlimited input.
+
+The limit counts raw UTF-8 bytes before decoding, excluding the terminating LF
+but including a preceding CR and other whitespace. It applies to complete messages
+and unfinished lines alike, regardless of how stdout chunks are split. Multiple
+individually valid messages can arrive in a combined read larger than the limit.
+
+Choose a limit large enough for image and other structured responses. Overflow
+fails the connection with `ACP_MESSAGE_TOO_LARGE` and explains how to raise or
+disable the limit; invalid settings fail before an agent process is spawned.
+A warm owner keeps the setting with which its ACP connection was started, so
+restart it to pick up a new value or default.
+
+This is a per-message limit, not a process-memory or model-token budget; decoding
+and JSON parsing may use more memory than the serialized message size. It does
+not limit outgoing ACP prompts, queue requests, or shell output capture.

--- a/src/acp/ndjson-stream.ts
+++ b/src/acp/ndjson-stream.ts
@@ -3,14 +3,19 @@ import { AcpxOperationalError } from "../errors.js";
 import { shouldIgnoreNonJsonAgentOutputLine } from "./agent-command.js";
 import { isAcpMessageObject } from "./jsonrpc.js";
 
+export const DEFAULT_MAX_ACP_MESSAGE_BYTES = 64 * 1024 * 1024;
+
 export class AcpMessageLimitError extends AcpxOperationalError {
   constructor(limit: number) {
-    super(`ACP message exceeded ACPX_MAX_ACP_MESSAGE_BYTES (${limit} bytes)`, {
-      outputCode: "RUNTIME",
-      detailCode: "ACP_MESSAGE_TOO_LARGE",
-      origin: "acp",
-      retryable: false,
-    });
+    super(
+      `ACP message exceeded ACPX_MAX_ACP_MESSAGE_BYTES (${limit} bytes). Increase the limit or set it to 0 for unlimited input.`,
+      {
+        outputCode: "RUNTIME",
+        detailCode: "ACP_MESSAGE_TOO_LARGE",
+        origin: "acp",
+        retryable: false,
+      },
+    );
   }
 }
 
@@ -19,7 +24,7 @@ export function readMaxAcpMessageBytes(
 ): number | undefined {
   const value = raw?.trim();
   if (!value) {
-    return undefined;
+    return DEFAULT_MAX_ACP_MESSAGE_BYTES;
   }
   const bytes = Number(value);
   if (!/^\d+$/.test(value) || !Number.isSafeInteger(bytes)) {

--- a/test/ndjson-stream.test.ts
+++ b/test/ndjson-stream.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readMaxAcpMessageBytes, createNdJsonMessageStream } from "../src/acp/ndjson-stream.js";
+import {
+  DEFAULT_MAX_ACP_MESSAGE_BYTES,
+  AcpMessageLimitError,
+  readMaxAcpMessageBytes,
+  createNdJsonMessageStream,
+} from "../src/acp/ndjson-stream.js";
 
 function sinkWritable(): WritableStream<Uint8Array> {
   return new WritableStream<Uint8Array>({
@@ -32,13 +37,43 @@ async function readAll(readable: ReadableStream<unknown>): Promise<unknown[]> {
   return values;
 }
 
-test("ACP message limits are opt-in and validate configuration", () => {
-  assert.equal(readMaxAcpMessageBytes(""), undefined);
+test("ACP message limits default to 64 MiB and preserve explicit overrides", () => {
+  assert.equal(DEFAULT_MAX_ACP_MESSAGE_BYTES, 64 * 1024 * 1024);
+  assert.equal(readMaxAcpMessageBytes(""), DEFAULT_MAX_ACP_MESSAGE_BYTES);
+  assert.equal(readMaxAcpMessageBytes(" \t "), DEFAULT_MAX_ACP_MESSAGE_BYTES);
   assert.equal(readMaxAcpMessageBytes("0"), undefined);
+  assert.equal(readMaxAcpMessageBytes(" 0 "), undefined);
   assert.equal(readMaxAcpMessageBytes("1024"), 1024);
+  assert.equal(readMaxAcpMessageBytes("134217728"), 128 * 1024 * 1024);
   for (const raw of ["-1", "1.5", "NaN", "Infinity", "9007199254740992"]) {
     assert.throws(() => readMaxAcpMessageBytes(raw), /ACPX_MAX_ACP_MESSAGE_BYTES/);
   }
+});
+
+test("ACP message limit reads unset and configured environment values", () => {
+  const previous = process.env.ACPX_MAX_ACP_MESSAGE_BYTES;
+  try {
+    delete process.env.ACPX_MAX_ACP_MESSAGE_BYTES;
+    assert.equal(readMaxAcpMessageBytes(), DEFAULT_MAX_ACP_MESSAGE_BYTES);
+    process.env.ACPX_MAX_ACP_MESSAGE_BYTES = "0";
+    assert.equal(readMaxAcpMessageBytes(), undefined);
+    process.env.ACPX_MAX_ACP_MESSAGE_BYTES = "4096";
+    assert.equal(readMaxAcpMessageBytes(), 4096);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ACPX_MAX_ACP_MESSAGE_BYTES;
+    } else {
+      process.env.ACPX_MAX_ACP_MESSAGE_BYTES = previous;
+    }
+  }
+});
+
+test("ACP message limit errors explain how to raise or disable the limit", () => {
+  const error = new AcpMessageLimitError(DEFAULT_MAX_ACP_MESSAGE_BYTES);
+  assert.match(error.message, /67108864 bytes/);
+  assert.match(error.message, /Increase the limit or set it to 0/);
+  assert.equal(error.detailCode, "ACP_MESSAGE_TOO_LARGE");
+  assert.equal(error.retryable, false);
 });
 
 test("ACP limits reject complete and incomplete lines independently of chunk boundaries", async () => {
@@ -89,6 +124,7 @@ test("ACP default accepts complete frames above the former proposed 8 MiB ceilin
     "fixture",
     sinkWritable(),
     bytesFrom([bytes.subarray(0, 1024), bytes.subarray(1024)]),
+    readMaxAcpMessageBytes(""),
   );
   assert.deepEqual(await readAll(stream.readable), [{ id: 1, result: value }]);
 });


### PR DESCRIPTION
## Summary

Follow up on https://github.com/openclaw/acpx/pull/539 with the maintainer-approved **64 MiB default** for incoming ACP messages. The optional override remains available, including an explicit unlimited setting.

| `ACPX_MAX_ACP_MESSAGE_BYTES` | Behavior |
| --- | --- |
| Unset, empty, or whitespace-only | 64 MiB (67,108,864 bytes) |
| Positive safe integer | That many bytes |
| `0` | Unlimited |

The existing framing logic still counts raw UTF-8 bytes per line before decoding, excluding LF, independently of read fragmentation or batching. This does not change outgoing prompts, queue request limits, or shell capture limits. Existing warm owners keep their startup setting.

Overflow remains non-retryable with `ACP_MESSAGE_TOO_LARGE`; the message now explains how to raise or disable the limit. Documentation and Unreleased Breaking notes describe the new default and the distinction between message size and process memory.

## Verification

- `pnpm run build:test` plus `node --test dist-test/test/ndjson-stream.test.js dist-test/test/client.test.js`: 69 passed.
- `pnpm run check`: passed, with 1,032 passing tests and two native Windows-only skips on macOS; the separate 148-test flows/runtime coverage gate passed.
- `pnpm run check:docs`: passed.
- Isolated independent review: scoped-clean, no actionable P0–P2 findings.
- Built-CLI live process test, with an isolated home/workspace and a finite synthetic ACP agent response:
  - Small response with unset configuration: success.
  - 65 MiB response with unset configuration: rejected with the 64 MiB diagnostic and override guidance.
  - Same large response with a 128 MiB override: success.
  - Same large response with explicit `0`: success.
  - A subsequent ordinary response: success.

The live test exercised actual OS processes and production `dist/cli.js`; it did not use an external model provider or credentials. Its temporary state was removed. Unit coverage retains exact-boundary, fragmented/complete, UTF-8, and multi-message cases. Native Windows was not live-tested in this pass.
