### PR TITLE
fix(acp): add opt-in terminal output retention ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- ACP/terminal: clamp agent-supplied `outputByteLimit` to a 16 MiB host ceiling so a huge requested retention cannot grow host memory without bound. `0` still stores nothing, and the default remains 64 KiB. Thanks @SebTardif.
+
 ## 0.15.0 - 2026-09-07
 
 **Highlights:** Embedding hosts gain process lifecycle admission and transient child environments; optional limits bound shell output and ACP/queue input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
-- ACP/terminal: clamp agent-supplied `outputByteLimit` to a 16 MiB host ceiling so a huge requested retention cannot grow host memory without bound. `0` still stores nothing, and the default remains 64 KiB. Thanks @SebTardif.
-
 ## 0.15.0 - 2026-09-07
 
 **Highlights:** Embedding hosts gain process lifecycle admission and transient child environments; optional limits bound shell output and ACP/queue input.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -638,6 +638,7 @@ Related runtime behavior:
 - session storage path is derived from OS home directory (`~/.acpx/sessions`)
 - child processes inherit the current environment by default
 - Windows terminal kill and release requests fail if process cleanup cannot finish after escalation. The terminal remains available for a cleanup retry; restore a working `taskkill` command before retrying.
+- ACP `terminal/create` honors agent `outputByteLimit` up to a 16 MiB host ceiling. `0` still stores nothing. The default when omitted remains 64 KiB.
 
 ## Practical examples
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -638,7 +638,7 @@ Related runtime behavior:
 - session storage path is derived from OS home directory (`~/.acpx/sessions`)
 - child processes inherit the current environment by default
 - Windows terminal kill and release requests fail if process cleanup cannot finish after escalation. The terminal remains available for a cleanup retry; restore a working `taskkill` command before retrying.
-- ACP `terminal/create` honors agent `outputByteLimit` up to a 16 MiB host ceiling. `0` still stores nothing. The default when omitted remains 64 KiB.
+- ACP `terminal/create` honors agent `outputByteLimit`; `0` stores nothing and the default when omitted is 64 KiB. Hosts can opt into an additional per-terminal retention ceiling with `ACPX_TERMINAL_MAX_OUTPUT_BYTES` (for example, `16777216` for 16 MiB). Unset, empty, or zero disables only the host ceiling, preserving the agent limit and default. Positive values must be safe integers. The smaller limit applies to combined stdout and stderr, retaining the newest UTF-8 output and reporting `truncated: true` when exceeded. This bounds retained output per terminal, not total process memory. Each ACP client snapshots the setting at construction; restart warm queue owners to change it.
 
 ## Practical examples
 

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -27,6 +27,8 @@ import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } 
 import { PROCESS_HELPER_TIMEOUT_MS, runTimedExecFile } from "./client-process.js";
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
+// Host ceiling for agent-supplied terminal/create outputByteLimit. 0 still stores nothing.
+export const MAX_TERMINAL_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024;
 const DEFAULT_KILL_GRACE_MS = 1_500;
 
 type ManagedTerminal = {
@@ -103,6 +105,12 @@ export function buildTerminalSpawnOptions(
     platform,
     resolvedEnv ?? process.env,
   ) as TerminalSpawnOptions;
+}
+
+function resolveTerminalOutputByteLimit(requested: number | null | undefined): number {
+  const raw = requested ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES;
+  const rounded = Number.isFinite(raw) ? Math.round(raw) : MAX_TERMINAL_OUTPUT_LIMIT_BYTES;
+  return Math.min(MAX_TERMINAL_OUTPUT_LIMIT_BYTES, Math.max(0, rounded));
 }
 
 function trimToUtf8Boundary(buffer: Buffer, limit: number): Buffer {
@@ -209,10 +217,7 @@ export class TerminalManager {
         throw new PermissionDeniedError("Permission denied for terminal/create");
       }
 
-      const outputByteLimit = Math.max(
-        0,
-        Math.round(params.outputByteLimit ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES),
-      );
+      const outputByteLimit = resolveTerminalOutputByteLimit(params.outputByteLimit);
       const { proc, spawnCommand } = await spawnTerminalProcess(params, this.cwd);
 
       let resolveExit: (response: WaitForTerminalExitResponse) => void = () => {};

--- a/src/acp/terminal-manager.ts
+++ b/src/acp/terminal-manager.ts
@@ -27,8 +27,6 @@ import type { ClientOperation, NonInteractivePermissionPolicy, PermissionMode } 
 import { PROCESS_HELPER_TIMEOUT_MS, runTimedExecFile } from "./client-process.js";
 
 const DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES = 64 * 1024;
-// Host ceiling for agent-supplied terminal/create outputByteLimit. 0 still stores nothing.
-export const MAX_TERMINAL_OUTPUT_LIMIT_BYTES = 16 * 1024 * 1024;
 const DEFAULT_KILL_GRACE_MS = 1_500;
 
 type ManagedTerminal = {
@@ -107,10 +105,18 @@ export function buildTerminalSpawnOptions(
   ) as TerminalSpawnOptions;
 }
 
-function resolveTerminalOutputByteLimit(requested: number | null | undefined): number {
-  const raw = requested ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES;
-  const rounded = Number.isFinite(raw) ? Math.round(raw) : MAX_TERMINAL_OUTPUT_LIMIT_BYTES;
-  return Math.min(MAX_TERMINAL_OUTPUT_LIMIT_BYTES, Math.max(0, rounded));
+function readTerminalOutputCeiling(): number | undefined {
+  const raw = process.env.ACPX_TERMINAL_MAX_OUTPUT_BYTES?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const bytes = Number(raw);
+  if (!/^\d+$/.test(raw) || !Number.isSafeInteger(bytes)) {
+    throw new Error(
+      "ACPX_TERMINAL_MAX_OUTPUT_BYTES must be a non-negative safe integer; zero disables the host ceiling",
+    );
+  }
+  return bytes === 0 ? undefined : bytes;
 }
 
 function trimToUtf8Boundary(buffer: Buffer, limit: number): Buffer {
@@ -177,9 +183,11 @@ export class TerminalManager {
   private readonly confirmExecute: (commandLine: string) => Promise<boolean>;
   private readonly killGraceMs: number;
   private readonly processHelperTimeoutMs: number;
+  private readonly outputCeilingBytes: number | undefined;
   private readonly terminals = new Map<string, ManagedTerminal>();
 
   constructor(options: TerminalManagerOptions) {
+    this.outputCeilingBytes = readTerminalOutputCeiling();
     this.cwd = options.cwd;
     this.permissionMode = options.permissionMode;
     this.nonInteractivePermissions = options.nonInteractivePermissions ?? "deny";
@@ -217,7 +225,14 @@ export class TerminalManager {
         throw new PermissionDeniedError("Permission denied for terminal/create");
       }
 
-      const outputByteLimit = resolveTerminalOutputByteLimit(params.outputByteLimit);
+      const requestedLimit = Math.max(
+        0,
+        Math.round(params.outputByteLimit ?? DEFAULT_TERMINAL_OUTPUT_LIMIT_BYTES),
+      );
+      const outputByteLimit = Math.min(
+        requestedLimit,
+        this.outputCeilingBytes ?? Number.POSITIVE_INFINITY,
+      );
       const { proc, spawnCommand } = await spawnTerminalProcess(params, this.cwd);
 
       let resolveExit: (response: WaitForTerminalExitResponse) => void = () => {};

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { TerminalManager } from "../src/acp/terminal-manager.js";
+import { MAX_TERMINAL_OUTPUT_LIMIT_BYTES, TerminalManager } from "../src/acp/terminal-manager.js";
 import { PermissionPromptUnavailableError } from "../src/errors.js";
 
 function getManagedStdio(
@@ -71,6 +71,157 @@ test("terminal manager create/output/wait/release lifecycle", async () => {
       /Unknown terminal/,
     );
   } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager clamps huge outputByteLimit and retains only the host ceiling", async () => {
+  const hostCeilingBytes = MAX_TERMINAL_OUTPUT_LIMIT_BYTES;
+  const floodBytes = hostCeilingBytes + 64 * 1024;
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  const manager = new TerminalManager({
+    cwd: tmp,
+    permissionMode: "approve-all",
+  });
+  let terminalId: string | undefined;
+  try {
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+      outputByteLimit: Number.MAX_SAFE_INTEGER,
+    });
+    terminalId = created.terminalId;
+
+    const stdio = getManagedStdio(manager, created.terminalId);
+    stdio.stdout.emit("data", Buffer.alloc(floodBytes, 0x61));
+
+    const outputResult = await manager.terminalOutput({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    const retainedBytes = Buffer.byteLength(outputResult.output, "utf8");
+    assert.equal(retainedBytes, hostCeilingBytes);
+    assert.equal(outputResult.truncated, true);
+    assert.match(outputResult.output, /^a+$/);
+  } finally {
+    if (terminalId) {
+      await manager.releaseTerminal({
+        sessionId: "session-1",
+        terminalId,
+      });
+    }
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager stores nothing when outputByteLimit is 0", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  const manager = new TerminalManager({
+    cwd: tmp,
+    permissionMode: "approve-all",
+  });
+  let terminalId: string | undefined;
+  try {
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+      outputByteLimit: 0,
+    });
+    terminalId = created.terminalId;
+
+    const stdio = getManagedStdio(manager, created.terminalId);
+    stdio.stdout.emit("data", Buffer.from("should-not-be-retained"));
+
+    const outputResult = await manager.terminalOutput({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    assert.equal(outputResult.output, "");
+    assert.equal(outputResult.truncated, true);
+  } finally {
+    if (terminalId) {
+      await manager.releaseTerminal({
+        sessionId: "session-1",
+        terminalId,
+      });
+    }
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager honors an agent outputByteLimit below the host ceiling", async () => {
+  const requestedLimitBytes = 128;
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  const manager = new TerminalManager({
+    cwd: tmp,
+    permissionMode: "approve-all",
+  });
+  let terminalId: string | undefined;
+  try {
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+      outputByteLimit: requestedLimitBytes,
+    });
+    terminalId = created.terminalId;
+
+    const stdio = getManagedStdio(manager, created.terminalId);
+    stdio.stdout.emit("data", Buffer.alloc(requestedLimitBytes + 64, 0x63));
+
+    const outputResult = await manager.terminalOutput({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    assert.equal(Buffer.byteLength(outputResult.output, "utf8"), requestedLimitBytes);
+    assert.equal(outputResult.truncated, true);
+    assert.match(outputResult.output, /^c+$/);
+  } finally {
+    if (terminalId) {
+      await manager.releaseTerminal({
+        sessionId: "session-1",
+        terminalId,
+      });
+    }
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("terminal manager default output retention stays 64 KiB", async () => {
+  const defaultLimitBytes = 64 * 1024;
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
+  const manager = new TerminalManager({
+    cwd: tmp,
+    permissionMode: "approve-all",
+  });
+  let terminalId: string | undefined;
+  try {
+    const created = await manager.createTerminal({
+      sessionId: "session-1",
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+    });
+    terminalId = created.terminalId;
+
+    const stdio = getManagedStdio(manager, created.terminalId);
+    stdio.stdout.emit("data", Buffer.alloc(defaultLimitBytes + 32, 0x62));
+
+    const outputResult = await manager.terminalOutput({
+      sessionId: "session-1",
+      terminalId: created.terminalId,
+    });
+    assert.equal(Buffer.byteLength(outputResult.output, "utf8"), defaultLimitBytes);
+    assert.equal(outputResult.truncated, true);
+    assert.match(outputResult.output, /^b+$/);
+  } finally {
+    if (terminalId) {
+      await manager.releaseTerminal({
+        sessionId: "session-1",
+        terminalId,
+      });
+    }
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { MAX_TERMINAL_OUTPUT_LIMIT_BYTES, TerminalManager } from "../src/acp/terminal-manager.js";
+import { TerminalManager } from "../src/acp/terminal-manager.js";
 import { PermissionPromptUnavailableError } from "../src/errors.js";
 
 function getManagedStdio(
@@ -75,154 +75,116 @@ test("terminal manager create/output/wait/release lifecycle", async () => {
   }
 });
 
-test("terminal manager clamps huge outputByteLimit and retains only the host ceiling", async () => {
-  const hostCeilingBytes = MAX_TERMINAL_OUTPUT_LIMIT_BYTES;
-  const floodBytes = hostCeilingBytes + 64 * 1024;
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
-  const manager = new TerminalManager({
-    cwd: tmp,
-    permissionMode: "approve-all",
-  });
-  let terminalId: string | undefined;
+function createManagerWithOutputCeiling(raw: string | undefined): TerminalManager {
+  const previous = process.env.ACPX_TERMINAL_MAX_OUTPUT_BYTES;
   try {
-    const created = await manager.createTerminal({
-      sessionId: "session-1",
-      command: process.execPath,
-      args: ["-e", "setInterval(() => {}, 1000)"],
-      outputByteLimit: Number.MAX_SAFE_INTEGER,
-    });
-    terminalId = created.terminalId;
-
-    const stdio = getManagedStdio(manager, created.terminalId);
-    stdio.stdout.emit("data", Buffer.alloc(floodBytes, 0x61));
-
-    const outputResult = await manager.terminalOutput({
-      sessionId: "session-1",
-      terminalId: created.terminalId,
-    });
-    const retainedBytes = Buffer.byteLength(outputResult.output, "utf8");
-    assert.equal(retainedBytes, hostCeilingBytes);
-    assert.equal(outputResult.truncated, true);
-    assert.match(outputResult.output, /^a+$/);
-  } finally {
-    if (terminalId) {
-      await manager.releaseTerminal({
-        sessionId: "session-1",
-        terminalId,
-      });
+    if (raw === undefined) {
+      delete process.env.ACPX_TERMINAL_MAX_OUTPUT_BYTES;
+    } else {
+      process.env.ACPX_TERMINAL_MAX_OUTPUT_BYTES = raw;
     }
-    await fs.rm(tmp, { recursive: true, force: true });
+    return new TerminalManager({ cwd: os.tmpdir(), permissionMode: "approve-all" });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ACPX_TERMINAL_MAX_OUTPUT_BYTES;
+    } else {
+      process.env.ACPX_TERMINAL_MAX_OUTPUT_BYTES = previous;
+    }
+  }
+}
+
+test("terminal manager rejects invalid host ceilings before launching commands", () => {
+  for (const raw of ["-1", "1.5", "Infinity", "NaN", "1e3", "0x10", "9007199254740992"]) {
+    assert.throws(() => createManagerWithOutputCeiling(raw), /ACPX_TERMINAL_MAX_OUTPUT_BYTES/);
   }
 });
 
-test("terminal manager stores nothing when outputByteLimit is 0", async () => {
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
-  const manager = new TerminalManager({
-    cwd: tmp,
-    permissionMode: "approve-all",
+for (const scenario of [
+  {
+    name: "unset host ceiling preserves large requests",
+    host: undefined,
+    requested: Number.MAX_SAFE_INTEGER,
+    bytes: 16 * 1024 * 1024 + 1,
+    retained: 16 * 1024 * 1024 + 1,
+  },
+  {
+    name: "zero host ceiling preserves requests",
+    host: "0",
+    requested: 100_000,
+    bytes: 90_000,
+    retained: 90_000,
+  },
+  {
+    name: "empty host ceiling preserves requests",
+    host: " ",
+    requested: 100_000,
+    bytes: 90_000,
+    retained: 90_000,
+  },
+  {
+    name: "host ceiling clamps huge requests",
+    host: " 128 ",
+    requested: Number.MAX_SAFE_INTEGER,
+    bytes: 192,
+    retained: 128,
+  },
+  { name: "agent zero stores nothing", host: "128", requested: 0, bytes: 32, retained: 0 },
+  { name: "smaller agent limit wins", host: "128", requested: 64, bytes: 192, retained: 64 },
+  {
+    name: "omitted agent limit remains 64 KiB",
+    host: "100000",
+    requested: undefined,
+    bytes: 70_000,
+    retained: 64 * 1024,
+  },
+  {
+    name: "smaller host ceiling clamps the default",
+    host: "128",
+    requested: undefined,
+    bytes: 192,
+    retained: 128,
+  },
+]) {
+  test(`terminal manager ${scenario.name}`, async () => {
+    // Restoring the environment before create also proves client-lifetime snapshotting.
+    const manager = createManagerWithOutputCeiling(scenario.host);
+    try {
+      const { terminalId } = await manager.createTerminal({
+        sessionId: "session-1",
+        command: process.execPath,
+        args: ["-e", "setInterval(() => {}, 1000)"],
+        outputByteLimit: scenario.requested,
+      });
+      const stdio = getManagedStdio(manager, terminalId);
+      stdio.stdout.emit("data", Buffer.alloc(scenario.bytes - 1, 0x61));
+      stdio.stderr.emit("data", Buffer.from("z"));
+      const output = await manager.terminalOutput({ sessionId: "session-1", terminalId });
+      assert.equal(Buffer.byteLength(output.output), scenario.retained);
+      assert.equal(output.truncated, scenario.bytes > scenario.retained);
+      assert.equal(output.output, scenario.retained ? "a".repeat(scenario.retained - 1) + "z" : "");
+    } finally {
+      await manager.shutdown();
+    }
   });
-  let terminalId: string | undefined;
+}
+
+test("terminal host ceiling preserves the UTF-8 suffix across stdout and stderr", async () => {
+  const manager = createManagerWithOutputCeiling("5");
   try {
-    const created = await manager.createTerminal({
+    const { terminalId } = await manager.createTerminal({
       sessionId: "session-1",
       command: process.execPath,
       args: ["-e", "setInterval(() => {}, 1000)"],
-      outputByteLimit: 0,
+      outputByteLimit: 1000,
     });
-    terminalId = created.terminalId;
-
-    const stdio = getManagedStdio(manager, created.terminalId);
-    stdio.stdout.emit("data", Buffer.from("should-not-be-retained"));
-
-    const outputResult = await manager.terminalOutput({
-      sessionId: "session-1",
-      terminalId: created.terminalId,
-    });
-    assert.equal(outputResult.output, "");
-    assert.equal(outputResult.truncated, true);
+    const stdio = getManagedStdio(manager, terminalId);
+    stdio.stdout.emit("data", Buffer.from("aé"));
+    stdio.stderr.emit("data", Buffer.from("🙂"));
+    const output = await manager.terminalOutput({ sessionId: "session-1", terminalId });
+    assert.equal(output.output, "🙂");
+    assert.equal(output.truncated, true);
   } finally {
-    if (terminalId) {
-      await manager.releaseTerminal({
-        sessionId: "session-1",
-        terminalId,
-      });
-    }
-    await fs.rm(tmp, { recursive: true, force: true });
-  }
-});
-
-test("terminal manager honors an agent outputByteLimit below the host ceiling", async () => {
-  const requestedLimitBytes = 128;
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
-  const manager = new TerminalManager({
-    cwd: tmp,
-    permissionMode: "approve-all",
-  });
-  let terminalId: string | undefined;
-  try {
-    const created = await manager.createTerminal({
-      sessionId: "session-1",
-      command: process.execPath,
-      args: ["-e", "setInterval(() => {}, 1000)"],
-      outputByteLimit: requestedLimitBytes,
-    });
-    terminalId = created.terminalId;
-
-    const stdio = getManagedStdio(manager, created.terminalId);
-    stdio.stdout.emit("data", Buffer.alloc(requestedLimitBytes + 64, 0x63));
-
-    const outputResult = await manager.terminalOutput({
-      sessionId: "session-1",
-      terminalId: created.terminalId,
-    });
-    assert.equal(Buffer.byteLength(outputResult.output, "utf8"), requestedLimitBytes);
-    assert.equal(outputResult.truncated, true);
-    assert.match(outputResult.output, /^c+$/);
-  } finally {
-    if (terminalId) {
-      await manager.releaseTerminal({
-        sessionId: "session-1",
-        terminalId,
-      });
-    }
-    await fs.rm(tmp, { recursive: true, force: true });
-  }
-});
-
-test("terminal manager default output retention stays 64 KiB", async () => {
-  const defaultLimitBytes = 64 * 1024;
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-terminal-test-"));
-  const manager = new TerminalManager({
-    cwd: tmp,
-    permissionMode: "approve-all",
-  });
-  let terminalId: string | undefined;
-  try {
-    const created = await manager.createTerminal({
-      sessionId: "session-1",
-      command: process.execPath,
-      args: ["-e", "setInterval(() => {}, 1000)"],
-    });
-    terminalId = created.terminalId;
-
-    const stdio = getManagedStdio(manager, created.terminalId);
-    stdio.stdout.emit("data", Buffer.alloc(defaultLimitBytes + 32, 0x62));
-
-    const outputResult = await manager.terminalOutput({
-      sessionId: "session-1",
-      terminalId: created.terminalId,
-    });
-    assert.equal(Buffer.byteLength(outputResult.output, "utf8"), defaultLimitBytes);
-    assert.equal(outputResult.truncated, true);
-    assert.match(outputResult.output, /^b+$/);
-  } finally {
-    if (terminalId) {
-      await manager.releaseTerminal({
-        sessionId: "session-1",
-        terminalId,
-      });
-    }
-    await fs.rm(tmp, { recursive: true, force: true });
+    await manager.shutdown();
   }
 });
 


### PR DESCRIPTION
ACP terminal retention currently trusts the agent-supplied `outputByteLimit`. A large requested limit can retain correspondingly large combined stdout and stderr, and the host has no independent ceiling.

Adds the optional `ACPX_TERMINAL_MAX_OUTPUT_BYTES` host ceiling, snapshotted when each ACP client is constructed. Unset, blank, or zero preserves existing behavior. A positive safe integer bounds retained output per terminal; the smaller host/agent limit wins. The existing omitted-request default is 64 KiB, and an agent request of zero still retains nothing. Truncation preserves the newest UTF-8 suffix and reports `truncated: true`. This is a per-terminal retention control, not a total process-memory bound.

The maintainer repair preserves compatibility instead of introducing the original unconditional 16 MiB ceiling. Credit to @SebTardif for the report, production-path evidence, and original implementation. All changelog notes are consolidated in https://github.com/openclaw/acpx/pull/557, which should merge after this PR.

Validation: `pnpm run check` passed (1,042 passed, two skipped; 148 coverage tests passed), `pnpm run check:docs` passed, and all 32 terminal tests passed. Four new focused regression cases fail against the main implementation and pass with this change. Local Codex autoreview is clean through P2 against the intended opt-in contract.

The real built CLI completed seven synthetic ACP terminal/create → wait → output → release cases with real child processes. With a huge agent request and 16,842,752 bytes written, an unset host ceiling retained all bytes; setting the host ceiling to 16,777,216 retained exactly that amount with truncation reported. Zero-host, smaller-agent, zero-agent, omitted-agent, and capped-default cases also passed, including combined stdout/stderr and successful child exits. No out-of-memory crash or third-party provider interaction is claimed.
