### PR TITLE
feat: surface normalized ACP plan entries on runtime status events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Changes
 
+- Runtime/embedding: surface normalized ACP plan entries on status events and explicit empty snapshots that clear stale plans. Thanks @gadzan.
 - Dependencies: update Zod, React and its types, Vite, and lint-staged; retain the 48-hour release-age policy.
 - Dependencies: refresh Node types, Oxfmt, and Oxlint; align source builds and CI with pnpm 11.26.0. Thanks @dependabot.
 - Source builds: document Node 22.22.1 as the minimum Node 22 development version required by lint-staged; published CLI installs still support Node 22.13 and newer.

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -160,3 +160,17 @@ runtime completion results, including queued prompts. An absent field stays
 absent, and an explicit `null` stays `null`. Nested values are opaque,
 adapter-defined data; ACPX does not authenticate them or treat them as proof of
 model identity or configuration. Raw JSON output retains the original ACP response.
+
+## Embedded runtime plans
+
+The `acpx/runtime` turn stream exposes ACP plan notifications as `status` events
+with `tag: "plan"`. The existing text summary remains available. The optional
+`entries` field contains normalized `AcpRuntimePlanEntry` objects with `content`,
+`status` (`pending`, `in_progress`, or `completed`), and a valid advertised
+`priority` (`high`, `medium`, or `low`) when present.
+
+Each `entries` array replaces the previous plan; `entries: []` clears it. An
+omitted field supplies no structured snapshot. Entries with blank content or
+invalid status are skipped, and invalid priorities are omitted. Legacy updates
+without valid statuses can still produce a text summary. CLI JSON output
+continues to expose the original ACP payload.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -69,6 +69,7 @@ export type {
   AcpTextDeltaOriginMeta,
   AcpRuntimeHandle,
   AcpRuntimeOptions,
+  AcpRuntimePlanEntry,
   AcpRuntimePromptMode,
   AcpRuntimeSessionMode,
   AcpRuntimeSessionModels,

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -262,7 +262,9 @@ export type AcpRuntimeEvent =
       /**
        * Populated on `plan` events. Normalized view of the ACP `entries`
        * payload — content plus execution status per entry, priority only
-       * when valid. Malformed entries are skipped, never fabricated.
+       * when valid. Malformed entries are skipped, never fabricated. An
+       * empty array is an explicit replacement: the agent cleared its
+       * plan and hosts should drop any previously displayed list.
        */
       entries?: AcpRuntimePlanEntry[];
     }

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -152,10 +152,8 @@ export type AcpRuntimeAvailableCommand = {
 };
 
 /**
- * One entry of the agent's ACP `plan` (its live todo list). The agent
- * re-sends the WHOLE list on each update, so consumers REPLACE rather
- * than append. `priority` is omitted when the agent did not advertise a
- * valid one — never fabricated.
+ * An entry in an ACP plan snapshot. Each update replaces the previous list.
+ * Priority is omitted unless the agent advertises a valid value.
  */
 export type AcpRuntimePlanEntry = {
   content: string;
@@ -260,11 +258,8 @@ export type AcpRuntimeEvent =
        */
       availableCommands?: AcpRuntimeAvailableCommand[];
       /**
-       * Populated on `plan` events. Normalized view of the ACP `entries`
-       * payload — content plus execution status per entry, priority only
-       * when valid. Malformed entries are skipped, never fabricated. An
-       * empty array is an explicit replacement: the agent cleared its
-       * plan and hosts should drop any previously displayed list.
+       * Normalized entries on `plan` events; malformed entries are skipped.
+       * Replace the displayed plan when present, including clearing it for [].
        */
       entries?: AcpRuntimePlanEntry[];
     }

--- a/src/runtime/public/contract.ts
+++ b/src/runtime/public/contract.ts
@@ -152,6 +152,18 @@ export type AcpRuntimeAvailableCommand = {
 };
 
 /**
+ * One entry of the agent's ACP `plan` (its live todo list). The agent
+ * re-sends the WHOLE list on each update, so consumers REPLACE rather
+ * than append. `priority` is omitted when the agent did not advertise a
+ * valid one — never fabricated.
+ */
+export type AcpRuntimePlanEntry = {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+  priority?: "high" | "medium" | "low";
+};
+
+/**
  * Session-level usage roll-up surfaced through `getStatus()`. The
  * reducer persists the breakdowns onto the session record; this type
  * exposes them on the runtime contract.
@@ -247,6 +259,12 @@ export type AcpRuntimeEvent =
        * non-null `input` schema.
        */
       availableCommands?: AcpRuntimeAvailableCommand[];
+      /**
+       * Populated on `plan` events. Normalized view of the ACP `entries`
+       * payload — content plus execution status per entry, priority only
+       * when valid. Malformed entries are skipped, never fabricated.
+       */
+      entries?: AcpRuntimePlanEntry[];
     }
   | {
       type: "tool_call";

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -77,7 +77,6 @@ const STATUS_TEXT_RESOLVERS: Partial<Record<AcpSessionUpdateTag, StatusTextResol
   current_mode_update: currentModeStatusText,
   config_option_update: configOptionStatusText,
   session_info_update: sessionInfoStatusText,
-  plan: planStatusText,
 };
 
 function availableCommandsStatusText(payload: Record<string, unknown>): string {
@@ -118,22 +117,22 @@ function planStatusText(payload: Record<string, unknown>): string | null {
   return content ? `plan: ${content}` : null;
 }
 
-const PLAN_ENTRY_STATUSES = new Set(["pending", "in_progress", "completed"]);
+function isPlanEntryStatus(value: string): value is AcpRuntimePlanEntry["status"] {
+  return value === "pending" || value === "in_progress" || value === "completed";
+}
 
-const PLAN_ENTRY_PRIORITIES = new Set(["high", "medium", "low"]);
+function isPlanEntryPriority(value: string): value is NonNullable<AcpRuntimePlanEntry["priority"]> {
+  return value === "high" || value === "medium" || value === "low";
+}
 
 function planUpdateEvent(payload: Record<string, unknown>): AcpRuntimeEvent | null {
   const raw = payload.entries;
   const entries = normalizePlanEntries(raw);
   if (Array.isArray(raw) && raw.length === 0) {
-    // Explicit empty replacement: the agent cleared its plan. Publish the
-    // snapshot so hosts drop a previously displayed list (ACP replacement
-    // semantics) instead of leaving it stale.
+    // An explicit empty snapshot clears the host's previous plan.
     return { type: "status", text: "plan updated", tag: "plan", entries: [] };
   }
-  // The snapshot is independent of the legacy summary: when leading entries
-  // are malformed, fall back to the first usable entry instead of dropping
-  // the whole update.
+  // Preserve legacy summaries, including entries without a valid status.
   const text =
     planStatusText(payload) ?? (entries.length > 0 ? `plan: ${entries[0]?.content}` : null);
   if (!text) {
@@ -167,16 +166,14 @@ function normalizePlanEntry(value: unknown): AcpRuntimePlanEntry | undefined {
   }
   const content = asTrimmedString(value.content);
   const status = asTrimmedString(value.status);
-  if (!content || !PLAN_ENTRY_STATUSES.has(status)) {
+  if (!content || !isPlanEntryStatus(status)) {
     return undefined;
   }
   const priority = asTrimmedString(value.priority);
   return {
     content,
-    status: status as AcpRuntimePlanEntry["status"],
-    ...(PLAN_ENTRY_PRIORITIES.has(priority)
-      ? { priority: priority as AcpRuntimePlanEntry["priority"] }
-      : {}),
+    status,
+    ...(isPlanEntryPriority(priority) ? { priority } : {}),
   };
 }
 

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -123,11 +123,22 @@ const PLAN_ENTRY_STATUSES = new Set(["pending", "in_progress", "completed"]);
 const PLAN_ENTRY_PRIORITIES = new Set(["high", "medium", "low"]);
 
 function planUpdateEvent(payload: Record<string, unknown>): AcpRuntimeEvent | null {
-  const text = planStatusText(payload);
+  const raw = payload.entries;
+  const entries = normalizePlanEntries(raw);
+  if (Array.isArray(raw) && raw.length === 0) {
+    // Explicit empty replacement: the agent cleared its plan. Publish the
+    // snapshot so hosts drop a previously displayed list (ACP replacement
+    // semantics) instead of leaving it stale.
+    return { type: "status", text: "plan updated", tag: "plan", entries: [] };
+  }
+  // The snapshot is independent of the legacy summary: when leading entries
+  // are malformed, fall back to the first usable entry instead of dropping
+  // the whole update.
+  const text =
+    planStatusText(payload) ?? (entries.length > 0 ? `plan: ${entries[0]?.content}` : null);
   if (!text) {
     return null;
   }
-  const entries = normalizePlanEntries(payload.entries);
   return {
     type: "status",
     text,

--- a/src/runtime/public/events.ts
+++ b/src/runtime/public/events.ts
@@ -2,6 +2,7 @@ import type { ToolCallContent, ToolCallLocation, ToolKind } from "@agentclientpr
 import type {
   AcpRuntimeAvailableCommand,
   AcpRuntimeEvent,
+  AcpRuntimePlanEntry,
   AcpRuntimeUsageBreakdown,
   AcpRuntimeUsageCost,
   AcpSessionUpdateTag,
@@ -115,6 +116,57 @@ function planStatusText(payload: Record<string, unknown>): string | null {
   const first = entries.find((entry) => isRecord(entry));
   const content = asTrimmedString(first?.content);
   return content ? `plan: ${content}` : null;
+}
+
+const PLAN_ENTRY_STATUSES = new Set(["pending", "in_progress", "completed"]);
+
+const PLAN_ENTRY_PRIORITIES = new Set(["high", "medium", "low"]);
+
+function planUpdateEvent(payload: Record<string, unknown>): AcpRuntimeEvent | null {
+  const text = planStatusText(payload);
+  if (!text) {
+    return null;
+  }
+  const entries = normalizePlanEntries(payload.entries);
+  return {
+    type: "status",
+    text,
+    tag: "plan",
+    ...(entries.length > 0 ? { entries } : {}),
+  };
+}
+
+function normalizePlanEntries(value: unknown): AcpRuntimePlanEntry[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const entries: AcpRuntimePlanEntry[] = [];
+  for (const entry of value) {
+    const normalized = normalizePlanEntry(entry);
+    if (normalized) {
+      entries.push(normalized);
+    }
+  }
+  return entries;
+}
+
+function normalizePlanEntry(value: unknown): AcpRuntimePlanEntry | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const content = asTrimmedString(value.content);
+  const status = asTrimmedString(value.status);
+  if (!content || !PLAN_ENTRY_STATUSES.has(status)) {
+    return undefined;
+  }
+  const priority = asTrimmedString(value.priority);
+  return {
+    content,
+    status: status as AcpRuntimePlanEntry["status"],
+    ...(PLAN_ENTRY_PRIORITIES.has(priority)
+      ? { priority: priority as AcpRuntimePlanEntry["priority"] }
+      : {}),
+  };
 }
 
 /**
@@ -493,7 +545,7 @@ const PROMPT_EVENT_PARSERS: Record<string, PromptEventParser> = {
   current_mode_update: (payload) => statusUpdateEvent("current_mode_update", payload),
   config_option_update: (payload) => statusUpdateEvent("config_option_update", payload),
   session_info_update: (payload) => statusUpdateEvent("session_info_update", payload),
-  plan: (payload) => statusUpdateEvent("plan", payload),
+  plan: planUpdateEvent,
   client_operation: clientOperationEvent,
   update: updateStatusEvent,
   done: () => null,

--- a/test/runtime-events.test.ts
+++ b/test/runtime-events.test.ts
@@ -357,7 +357,12 @@ test("parsePromptEventLine ignores unsupported structured payloads and treats ra
     type: "status",
     text: "operation",
   });
-  assert.equal(parsePromptEventLine(JSON.stringify({ type: "plan", entries: [] })), null);
+  assert.deepEqual(parsePromptEventLine(JSON.stringify({ type: "plan", entries: [] })), {
+    type: "status",
+    text: "plan updated",
+    tag: "plan",
+    entries: [],
+  });
   assert.deepEqual(parsePromptEventLine(JSON.stringify(["not", "an", "object"])), {
     type: "status",
     text: '["not","an","object"]',
@@ -942,6 +947,35 @@ test("parsePromptEventLine surfaces structured plan entries", () => {
       type: "status",
       text: "plan: status-less still narrates",
       tag: "plan",
+    },
+  );
+});
+
+test("parsePromptEventLine preserves explicit empty plan replacements", () => {
+  assert.deepEqual(parsePromptEventLine(JSON.stringify({ sessionUpdate: "plan", entries: [] })), {
+    type: "status",
+    text: "plan updated",
+    tag: "plan",
+    entries: [],
+  });
+});
+
+test("parsePromptEventLine recovers plan snapshots with malformed leading entries", () => {
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        sessionUpdate: "plan",
+        entries: [
+          { content: "  ", status: "pending" },
+          { content: "usable step", status: "in_progress", priority: "high" },
+        ],
+      }),
+    ),
+    {
+      type: "status",
+      text: "plan: usable step",
+      tag: "plan",
+      entries: [{ content: "usable step", status: "in_progress", priority: "high" }],
     },
   );
 });

--- a/test/runtime-events.test.ts
+++ b/test/runtime-events.test.ts
@@ -861,3 +861,87 @@ test("parsePromptEventLine preserves origin on agent_thought_chunk", () => {
     },
   );
 });
+
+test("parsePromptEventLine surfaces structured plan entries", () => {
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        sessionUpdate: "plan",
+        entries: [
+          { content: "first step", status: "in_progress", priority: "high" },
+          { content: "second step", status: "pending" },
+        ],
+      }),
+    ),
+    {
+      type: "status",
+      text: "plan: first step",
+      tag: "plan",
+      entries: [
+        { content: "first step", status: "in_progress", priority: "high" },
+        { content: "second step", status: "pending" },
+      ],
+    },
+  );
+
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "s1",
+          update: {
+            sessionUpdate: "plan",
+            entries: [{ content: "enveloped", status: "completed", priority: "low" }],
+          },
+        },
+      }),
+    ),
+    {
+      type: "status",
+      text: "plan: enveloped",
+      tag: "plan",
+      entries: [{ content: "enveloped", status: "completed", priority: "low" }],
+    },
+  );
+
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        sessionUpdate: "plan",
+        entries: [
+          { content: "kept", status: "completed", priority: "urgent" },
+          null,
+          "skip",
+          { content: "  ", status: "pending" },
+          { content: "dropped", status: "bogus" },
+          { content: "also kept", status: "pending", priority: "low" },
+        ],
+      }),
+    ),
+    {
+      type: "status",
+      text: "plan: kept",
+      tag: "plan",
+      entries: [
+        { content: "kept", status: "completed" },
+        { content: "also kept", status: "pending", priority: "low" },
+      ],
+    },
+  );
+
+  assert.deepEqual(
+    parsePromptEventLine(
+      JSON.stringify({
+        sessionUpdate: "plan",
+        entries: [{ content: "status-less still narrates" }],
+      }),
+    ),
+    {
+      type: "status",
+      text: "plan: status-less still narrates",
+      tag: "plan",
+    },
+  );
+});

--- a/test/runtime-manager.test.ts
+++ b/test/runtime-manager.test.ts
@@ -610,6 +610,83 @@ test("AcpRuntimeManager streams runtime events and saves updated status", async 
   assert.equal(saved?.protocolVersion, 1);
 });
 
+test("AcpRuntimeManager surfaces structured plan snapshots through turn events", async () => {
+  const record = makeSessionRecord({
+    acpxRecordId: "plan-session",
+    acpSessionId: "plan-sid",
+    agentCommand: "codex --acp",
+    cwd: "/workspace",
+  });
+  const store = new InMemorySessionStore([record]);
+  let handlers: FakeClientHandlers = {};
+  const client: FakeClient = {
+    start: async () => {},
+    close: async () => {},
+    createSession: async () => ({ sessionId: "unused" }),
+    loadSession: async () => ({ agentSessionId: "unused" }),
+    hasReusableSession: (sessionId) => sessionId === "plan-sid",
+    supportsLoadSession: () => true,
+    supportsResumeSession: () => false,
+    loadSessionWithOptions: async () => ({ agentSessionId: "unused" }),
+    getAgentLifecycleSnapshot: () => ({ running: true }),
+    prompt: async () => {
+      handlers.onSessionUpdate?.({
+        sessionId: "plan-sid",
+        update: {
+          sessionUpdate: "plan",
+          entries: [
+            { content: "first step", status: "in_progress", priority: "high" },
+            { content: "second step", status: "pending", priority: "low" },
+          ],
+        },
+      });
+      handlers.onSessionUpdate?.({
+        sessionId: "plan-sid",
+        update: { sessionUpdate: "plan", entries: [] },
+      });
+      return { stopReason: "end_turn" };
+    },
+    requestCancelActivePrompt: async () => false,
+    hasActivePrompt: () => false,
+    setSessionMode: async () => {},
+    setSessionConfigOption: async () => {},
+    clearEventHandlers: () => {
+      handlers = {};
+    },
+    setEventHandlers: (nextHandlers) => {
+      handlers = nextHandlers;
+    },
+  };
+  const manager = new AcpRuntimeManager(
+    createRuntimeOptions({ cwd: "/workspace", sessionStore: store }),
+    {
+      clientFactory: () => client as never,
+    },
+  );
+
+  const turn = manager.startTurn({
+    handle: createHandle("plan-session"),
+    text: "hello",
+    mode: "prompt",
+    sessionMode: "persistent",
+    requestId: "req-plan",
+  });
+  const { events } = await collectTurn(turn);
+
+  assert.deepEqual(events, [
+    {
+      type: "status",
+      text: "plan: first step",
+      tag: "plan",
+      entries: [
+        { content: "first step", status: "in_progress", priority: "high" },
+        { content: "second step", status: "pending", priority: "low" },
+      ],
+    },
+    { type: "status", text: "plan updated", tag: "plan", entries: [] },
+  ]);
+});
+
 test("AcpRuntimeManager resolves promptStarted while the submitted prompt is pending", async () => {
   const record = makeSessionRecord({
     acpxRecordId: "prompt-started-session",


### PR DESCRIPTION
## What Problem This Solves

Embedding hosts received only the first text fragment of an ACP plan. They lost per-entry status and could keep a stale list after the agent cleared its plan.

## User Impact

`acpx/runtime` now preserves normalized plan entries on the existing `status` event alongside its text summary. Each array replaces the prior plan; an explicit empty array clears it. The additive `AcpRuntimePlanEntry` export includes content, status and valid advertised priority. Existing text summaries and CLI wire JSON are preserved.

## Why This Change Was Made

The runtime parser discarded the structured payload in `planStatusText` / `statusUpdateEvent`. A dedicated plan parser follows the existing structured-command event pattern. It validates entries, omits invalid priorities, preserves legacy status-less text, and handles empty snapshots independently of summary generation. Maintainer repairs rebased this contribution, replaced enum casts with narrowing guards, removed the obsolete plan resolver route, and documented snapshot semantics. Thanks @gadzan.

## Evidence

- Four parser assertions fail against pre-change production code. All 86 focused event/manager tests pass after the change; contributor coverage is retained.
- Actual upstream `codex-acp` 1.7.0 over stdio JSON-RPC, driven through built `dist/runtime.js`, received only synthetic steps. Before the change, the public consumer received two text-only plan events and no clearing event.
- After the change, the public consumer received exactly these three snapshots, followed by successful completion and final reply `ACPX_PLAN_OK`:

```json
{"type":"status","text":"plan: Synthetic first step","tag":"plan","entries":[{"content":"Synthetic first step","status":"in_progress","priority":"medium"},{"content":"Synthetic second step","status":"pending","priority":"medium"}]}
{"type":"status","text":"plan: Synthetic first step","tag":"plan","entries":[{"content":"Synthetic first step","status":"completed","priority":"medium"},{"content":"Synthetic second step","status":"completed","priority":"medium"}]}
{"type":"status","text":"plan updated","tag":"plan","entries":[]}
```

- Isolated Codex autoreview: scoped-clean at P0–P2 for the full contributor change and maintainer repairs.
- Unreleased uses the maintainer-requested most-interesting-first ordering for this maintenance sweep.
- Final rebased head `a5349c3d43da37136dae693b4fbf12e98e435706`: `pnpm run check` passed (1,054 tests, two existing Windows-only skips; coverage 152/152), and `pnpm run check:docs` passed. Repeated upstream live proof on this built head passed. The reviewed production/test/doc diff is byte-for-byte unchanged by rebase.
