### PR TITLE
docs: replace copied app guidance with acpx contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,132 +1,77 @@
-# Contributing to OpenClaw
+# Contributing to acpx
 
-> Note: This document was copied from [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md) on 2026-03-09.
+`acpx` is a lightweight CLI and embeddable client for the Agent Client Protocol.
+Read [VISION.md](VISION.md) before proposing a feature or changing a public
+interface. Bugs and focused fixes are welcome; discuss larger API or architecture
+changes in an [acpx issue](https://github.com/openclaw/acpx/issues) first.
 
-Welcome to the lobster tank! 🦞
+## Development
 
-## Quick Links
+Use the Node.js source-build versions and pnpm version listed in
+[AGENTS.md](AGENTS.md#repo). Install the locked dependencies, then run the CLI:
 
-- **GitHub:** https://github.com/openclaw/openclaw
-- **Vision:** [`VISION.md`](VISION.md)
-- **Discord:** https://discord.gg/qkhbAGHRBT
-- **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
-
-## Maintainers
-
-For the current maintainer list, check the original OpenClaw contributing guide:
-[openclaw/openclaw `CONTRIBUTING.md`](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md).
-
-## How to Contribute
-
-1. **Bugs & small fixes** → Open a PR!
-2. **New features / architecture** → Start a [GitHub Discussion](https://github.com/openclaw/openclaw/discussions) or ask in Discord first
-3. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)
-
-## Before You PR
-
-- Test locally with the smallest relevant `acpx` command or test
-- Run checks for your scope, usually `pnpm run check`
-- For non-trivial code changes, run the repo-local autoreview helper before
-  asking for review: `.agents/skills/autoreview/scripts/autoreview`
-- Ensure CI checks pass
-- Keep PRs focused (one thing per PR; do not mix unrelated concerns)
-- Keep built-in agent docs, examples, and links consistent with the existing docs structure.
-- Describe what & why
-- Reply to or resolve bot review conversations you addressed before asking for review again
-- **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
-
-## Review Conversations Are Author-Owned
-
-If a review bot leaves review conversations on your PR, you are expected to handle the follow-through:
-
-- Resolve the conversation yourself once the code or explanation fully addresses the bot's concern
-- Reply and leave it open only when you need maintainer or reviewer judgment
-- Do not leave "fixed" bot review conversations for maintainers to clean up for you
-
-This applies to both human-authored and AI-assisted PRs.
-
-## Control UI Decorators
-
-The Control UI uses Lit with **legacy** decorators (current Rollup parsing does not support
-`accessor` fields required for standard decorators). When adding reactive fields, keep the
-legacy style:
-
-```ts
-@state() foo = "bar";
-@property({ type: Number }) count = 0;
+```bash
+pnpm install --frozen-lockfile
+pnpm run dev -- --help
 ```
 
-The root `tsconfig.json` is configured for legacy decorators (`experimentalDecorators: true`)
-with `useDefineForClassFields: false`. Avoid flipping these unless you are also updating the UI
-build tooling to support standard decorators.
+The source is in `src/`, the Node test suite is in `test/`, and protocol
+conformance cases are in `conformance/`. The replay viewer and sample workflows
+live in `examples/flows/`. See [AGENTS.md](AGENTS.md) for commands, dependency
+boundaries, and repository policies.
 
-## AI/Vibe-Coded PRs Welcome! 🤖
+## Before opening a pull request
 
-Built with Codex, Claude, or other AI tools? **Awesome - just mark it!**
+Keep each PR focused on one problem. Explain the trigger, the resulting behavior,
+and why the change belongs in acpx. Use a conventional title such as `fix:`,
+`refactor:`, or `docs:`. Keep maintainer edits enabled so maintainers can help land
+the change.
 
-Please include in your PR:
+Start with the smallest relevant test while iterating. Before requesting review:
 
-- [ ] Mark as AI-assisted in the PR title or description
-- [ ] Note the degree of testing (untested / lightly tested / fully tested)
-- [ ] Include prompts or session logs if possible (super helpful!)
-- [ ] Confirm you understand what the code does
-- [ ] Resolve or reply to bot review conversations after you address them
+- For code, tests, scripts, package metadata, workflows, or `AGENTS.md`, run
+  `pnpm run check`.
+- For documentation changes, run `pnpm run check:docs`; run both commands when
+  changing code and docs together. The docs script checks the README, docs site,
+  and flow example guides. For other Markdown, also pass each changed file to
+  `pnpm exec oxfmt --check` and `pnpm exec markdownlint-cli2`.
+- For changes to CLI flags, run `pnpm run mutate` as well.
+- Exercise the built CLI or public runtime on the affected path and record the
+  commands and results in the PR. Bug fixes should include a regression test.
+- For non-trivial code changes, run the repository's isolated autoreview helper:
+  `.agents/skills/autoreview/scripts/autoreview`. Verify its findings and address
+  actionable problems before requesting review.
+- Ensure CI passes. For visual changes, include before/after screenshots using
+  synthetic data and check that the captures contain no secrets or private data.
 
-AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for. If you are using an LLM coding agent, instruct it to resolve bot review conversations it has addressed instead of leaving them for maintainers.
+The CLI, runtime exports, flags, configuration keys, session records, and output
+formats are compatibility surfaces. Preserve existing behavior during refactors;
+explain intentional behavior changes and update the relevant documentation.
+Maintainers add user-facing changelog entries when landing contributions.
 
-## Current Focus & Roadmap 🗺
+## Agent documentation
 
-We are currently prioritizing:
+Keep built-in agent documentation and examples consistent with
+[AGENTS.md](AGENTS.md#documentation-policy). A change to a built-in agent or its
+behavior must update both its `agents/{Agent}.md` guide and
+[`skills/acpx/SKILL.md`](skills/acpx/SKILL.md). Shared landing documentation should
+remain impartial and follow the repository's example ordering.
 
-- **Stability**: Fixing edge cases in channel connections (WhatsApp/Telegram).
-- **UX**: Improving the onboarding wizard and error messages.
-- **Skills**: For skill contributions, head to [ClawHub](https://clawhub.ai/) — the community hub for OpenClaw skills.
-- **Performance**: Optimizing token usage and compaction logic.
+## Review follow-through
 
-Check the [GitHub Issues](https://github.com/openclaw/openclaw/issues) for "good first issue" labels!
+Handle review conversations on your PR, including automated reviews. After
+addressing a finding, reply with the change or evidence and resolve the
+conversation. Leave it open when a maintainer or reviewer decision is still
+needed. AI-assisted contributions follow the same correctness, testing, and
+review expectations as other contributions.
 
-## Maintainers
+## Reporting bugs and vulnerabilities
 
-We're selectively expanding the maintainer team.
-If you're an experienced contributor who wants to help shape OpenClaw's direction — whether through code, docs, or community — we'd like to hear from you.
+File reproducible bugs in [acpx issues](https://github.com/openclaw/acpx/issues).
+Include the acpx version, Node.js version, operating system, adapter, command,
+expected behavior, and actual result. Remove credentials and private conversation
+content from logs and session files before sharing them.
 
-Being a maintainer is a responsibility, not an honorary title. We expect active, consistent involvement — triaging issues, reviewing PRs, and helping move the project forward.
-
-Still interested? Email contributing@openclaw.ai with:
-
-- Links to your PRs on OpenClaw (if you don't have any, start there first)
-- Links to open source projects you maintain or actively contribute to
-- Your GitHub, Discord, and X/Twitter handles
-- A brief intro: background, experience, and areas of interest
-- Languages you speak and where you're based
-- How much time you can realistically commit
-
-We welcome people across all skill sets — engineering, documentation, community management, and more.
-We review every human-only-written application carefully and add maintainers slowly and deliberately.
-Please allow a few weeks for a response.
-
-## Report a Vulnerability
-
-We take security reports seriously. Report vulnerabilities directly to the repository where the issue lives:
-
-- **Core CLI and gateway** — [openclaw/openclaw](https://github.com/openclaw/openclaw)
-- **macOS desktop app** — [openclaw/openclaw](https://github.com/openclaw/openclaw) (apps/macos)
-- **iOS app** — [openclaw/openclaw](https://github.com/openclaw/openclaw) (apps/ios)
-- **Android app** — [openclaw/openclaw](https://github.com/openclaw/openclaw) (apps/android)
-- **ClawHub** — [openclaw/clawhub](https://github.com/openclaw/clawhub)
-- **Trust and threat model** — [openclaw/trust](https://github.com/openclaw/trust)
-
-For issues that don't fit a specific repo, or if you're unsure, email **security@openclaw.ai** and we'll route it.
-
-### Required in Reports
-
-1. **Title**
-2. **Severity Assessment**
-3. **Impact**
-4. **Affected Component**
-5. **Technical Reproduction**
-6. **Demonstrated Impact**
-7. **Environment**
-8. **Remediation Advice**
-
-Reports without reproduction steps, demonstrated impact, and remediation advice will be deprioritized. Given the volume of AI-generated scanner findings, we must ensure we're receiving vetted reports from researchers who understand the issues.
+For security vulnerabilities, email **security@openclaw.ai** instead of opening a
+public issue. Include the affected acpx version, reproduction steps, demonstrated
+impact, and any proposed remediation.


### PR DESCRIPTION
## What Problem This Solves

The contributor guide describes OpenClaw's Lit UI, messaging channels, and onboarding work, sending acpx contributors to unrelated code and issue trackers.

## User Impact

Contributors get acpx-specific setup, validation, compatibility, review, and bug-reporting guidance. Product behavior is unchanged.

## Why This Change Was Made

Replace the copied application guide with the actual CLI/runtime workflow, linking AGENTS.md for detailed repository policy. Preserve maintainer edits, review follow-through, agent documentation synchronization, and private vulnerability reporting.

## Evidence

- `pnpm run check:docs` passed, including the generated docs-site build.
- `pnpm exec oxfmt --check CONTRIBUTING.md` and `pnpm exec markdownlint-cli2 CONTRIBUTING.md` passed; these explicitly cover the guide outside the docs script's file list.
- Isolated Codex autoreview at P0–P2: scoped-clean after correcting the docs-check scope and AGENTS.md validation exception.
- Built CLI smoke: `node dist/cli.js --help` displayed the documented command surface.
