### PR TITLE
refactor: remove unused state and stabilize queue test timing

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -28,7 +28,6 @@
     "eslint/no-self-compare": "error",
     "eslint/no-sequences": "error",
     "eslint/no-shadow": "off",
-    "eslint/no-underscore-dangle": ["error", { "allow": ["_meta"] }],
     "eslint/no-unmodified-loop-condition": "error",
     "eslint/no-useless-call": "error",
     "eslint/no-useless-computed-key": "error",

--- a/scripts/clean-dist-test.mjs
+++ b/scripts/clean-dist-test.mjs
@@ -1,9 +1,0 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const projectRoot = path.resolve(scriptDir, "..");
-const distTestDir = path.join(projectRoot, "dist-test");
-
-await fs.rm(distTestDir, { recursive: true, force: true });

--- a/src/cli/output/output.ts
+++ b/src/cli/output/output.ts
@@ -51,8 +51,6 @@ type OutputFormatterOptions = {
 
 type NormalizedToolStatus = ToolCallStatus | "unknown";
 
-type FormatterSection = "assistant" | "thought" | "tool" | "plan" | "client" | "done";
-
 type ToolRenderState = {
   id: string;
   title?: string;
@@ -761,7 +759,6 @@ class TextOutputFormatter implements OutputFormatter {
   private thoughtBuffer = "";
   private wroteAny = false;
   private atLineStart = true;
-  private section: FormatterSection | null = null;
 
   constructor(stdout: WritableLike, suppressReads: boolean) {
     this.stdout = stdout;
@@ -849,7 +846,7 @@ class TextOutputFormatter implements OutputFormatter {
   private renderPlanUpdate(
     entries: Extract<SessionNotification["update"], { sessionUpdate: "plan" }>["entries"],
   ): void {
-    this.beginSection("plan");
+    this.beginSection();
     this.writeLine(this.bold("[plan]"));
     for (const entry of entries) {
       this.writeLine(`  - [${entry.status}] ${entry.content}`);
@@ -858,13 +855,13 @@ class TextOutputFormatter implements OutputFormatter {
 
   private renderDone(stopReason: string): void {
     this.flushThoughtBuffer();
-    this.beginSection("done");
+    this.beginSection();
     this.writeLine(this.dim(`[done] ${stopReason}`));
   }
 
   onError(params: RenderableOutputError): void {
     this.flushThoughtBuffer();
-    this.beginSection("done");
+    this.beginSection();
     this.writeLine(this.formatAnsi(`[error] ${params.code}: ${params.message}`, "31"));
     for (const hint of getTextErrorRemediationHints(params)) {
       this.writeLine(this.dim(hint));
@@ -873,7 +870,7 @@ class TextOutputFormatter implements OutputFormatter {
 
   onClientOperation(operation: ClientOperation): void {
     this.flushThoughtBuffer();
-    this.beginSection("client");
+    this.beginSection();
 
     const normalizedStatus: NormalizedToolStatus =
       operation.status === "completed"
@@ -891,7 +888,7 @@ class TextOutputFormatter implements OutputFormatter {
 
   onPermissionEscalation(event: PermissionEscalationEvent): void {
     this.flushThoughtBuffer();
-    this.beginSection("client");
+    this.beginSection();
     this.writeLine(`${this.bold("[permission]")} ${event.message}`);
     const details = [
       `sessionId: ${event.sessionId}`,
@@ -927,21 +924,19 @@ class TextOutputFormatter implements OutputFormatter {
     this.write(`${line}\n`);
   }
 
-  private beginSection(next: Exclude<FormatterSection, "assistant">): void {
+  private beginSection(): void {
     if (!this.atLineStart) {
       this.write("\n");
     }
     if (this.wroteAny) {
       this.write("\n");
     }
-    this.section = next;
   }
 
   private writeAssistantChunk(text: string): void {
     if (!text) {
       return;
     }
-    this.section = "assistant";
     this.write(text);
   }
 
@@ -952,7 +947,7 @@ class TextOutputFormatter implements OutputFormatter {
       return;
     }
 
-    this.beginSection("thought");
+    this.beginSection();
     const [firstLine, ...restLines] = thought.split("\n");
     this.writeLine(this.dim(`[thinking] ${firstLine}`));
     for (const line of restLines) {
@@ -1045,7 +1040,7 @@ class TextOutputFormatter implements OutputFormatter {
     state: ToolRenderState,
     status: Exclude<NormalizedToolStatus, "completed" | "failed">,
   ): void {
-    this.beginSection("tool");
+    this.beginSection();
 
     const title = state.title ?? state.id;
     const label = status === "pending" ? "pending" : "running";
@@ -1064,7 +1059,7 @@ class TextOutputFormatter implements OutputFormatter {
   }
 
   private renderFinalToolState(state: ToolRenderState, status: "completed" | "failed"): void {
-    this.beginSection("tool");
+    this.beginSection();
 
     const title = state.title ?? state.id;
     const statusText = this.colorStatus(toStatusLabel(status), status);

--- a/src/flows/runtime.ts
+++ b/src/flows/runtime.ts
@@ -160,7 +160,6 @@ export class FlowRunner {
   private readonly authCredentials?;
   private readonly authPolicy?;
   private readonly fs?;
-  private readonly timeoutMs?;
   private readonly defaultNodeTimeoutMs;
   private readonly verbose?;
   private readonly suppressSdkConsoleErrors?;
@@ -185,7 +184,6 @@ export class FlowRunner {
     this.authCredentials = options.authCredentials;
     this.authPolicy = options.authPolicy;
     this.fs = options.fs;
-    this.timeoutMs = options.timeoutMs;
     this.defaultNodeTimeoutMs =
       options.defaultNodeTimeoutMs ?? options.timeoutMs ?? DEFAULT_FLOW_STEP_TIMEOUT_MS;
     this.verbose = options.verbose;

--- a/src/persisted-key-policy.ts
+++ b/src/persisted-key-policy.ts
@@ -34,14 +34,6 @@ function joinPath(path: string[]): string {
   return path.join(".");
 }
 
-function isAllowedKey(path: string[], key: string): boolean {
-  if (ZED_TAG_KEYS.has(key)) {
-    return true;
-  }
-
-  return false;
-}
-
 function shouldSkipKeyRule(path: string[]): boolean {
   return MAP_OBJECT_PATHS.has(joinPath(path));
 }
@@ -93,7 +85,7 @@ function collectKeyViolation(
   skipKeyRule: boolean,
   violations: string[],
 ): void {
-  if (!skipKeyRule && !SNAKE_CASE_KEY.test(key) && !isAllowedKey(path, key)) {
+  if (!skipKeyRule && !SNAKE_CASE_KEY.test(key) && !ZED_TAG_KEYS.has(key)) {
     violations.push(`${joinPath(path)}.${key}`.replace(/^\./, ""));
   }
 

--- a/src/runtime/engine/manager.ts
+++ b/src/runtime/engine/manager.ts
@@ -1267,7 +1267,7 @@ export class AcpRuntimeManager {
       } else {
         await this.applyPendingRuntimeTurnCancel(task, turn);
         const response = await this.runRuntimePrompt(task, turn, sessionId);
-        await this.saveCompletedRuntimeTurn(turn, response.stopReason);
+        await this.saveCompletedRuntimeTurn(turn);
         terminalResult = {
           status: response.stopReason === "cancelled" ? "cancelled" : "completed",
           ...(response.stopReason ? { stopReason: response.stopReason } : {}),
@@ -1670,10 +1670,7 @@ export class AcpRuntimeManager {
     return cancelled;
   }
 
-  private async saveCompletedRuntimeTurn(
-    turn: RunningRuntimeTurn,
-    _stopReason: string | undefined,
-  ): Promise<void> {
+  private async saveCompletedRuntimeTurn(turn: RunningRuntimeTurn): Promise<void> {
     turn.record.acpSessionId = turn.activeSessionId;
     reconcileAgentSessionId(turn.record, turn.record.agentSessionId);
     turn.record.protocolVersion = turn.client.initializeResult?.protocolVersion;

--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -824,7 +824,7 @@ function applySessionInfoUpdate(
 export function recordClientOperation(
   conversation: SessionConversation,
   state: SessionAcpxState | undefined,
-  operation: ClientOperation,
+  _operation: ClientOperation,
   timestamp = isoNow(),
 ): SessionAcpxState {
   const acpx = ensureAcpxState(state);

--- a/test/queue-ipc-server.test.ts
+++ b/test/queue-ipc-server.test.ts
@@ -252,51 +252,68 @@ test("SessionQueueOwner enqueues fire-and-forget prompts and rejects invalid own
   });
 });
 
-test("queue request limits retain unlimited input and reject oversized socket fragments", async () => {
-  await withTempHome(async () => {
-    for (const limit of [0, 1024]) {
-      const lease = await tryAcquireQueueOwnerLease(`request-limit-${limit}`);
-      assert(lease);
-      const owner = await SessionQueueOwner.start(
-        lease,
-        {
-          cancelPrompt: async () => false,
-          closeSession: async () => false,
-          setSessionMode: async () => {},
-          setSessionModel: async () => undefined,
-          setSessionConfigOption: async () => ({ configOptions: [] }),
-        },
-        { maxQueueDepth: 16, maxRequestBytes: limit },
-      );
-      const socket = await connectSocket(lease.socketPath);
-      try {
-        if (limit) {
-          const closed = new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(() => reject(new Error("oversized socket stayed open")), 2000);
-            socket.once("close", () => {
-              clearTimeout(timer);
-              resolve();
+test(
+  "queue request limits retain unlimited input and reject oversized socket fragments",
+  { timeout: 15_000 },
+  async () => {
+    await withTempHome(async () => {
+      for (const limit of [0, 1024]) {
+        const lease = await tryAcquireQueueOwnerLease(`request-limit-${limit}`);
+        assert(lease);
+        const owner = await SessionQueueOwner.start(
+          lease,
+          {
+            cancelPrompt: async () => false,
+            closeSession: async () => false,
+            setSessionMode: async () => {},
+            setSessionModel: async () => undefined,
+            setSessionConfigOption: async () => ({ configOptions: [] }),
+          },
+          { maxQueueDepth: 16, maxRequestBytes: limit },
+        );
+        const socket = await connectSocket(lease.socketPath);
+        try {
+          if (limit) {
+            const closed = new Promise<void>((resolve, reject) => {
+              const timer = setTimeout(
+                () => reject(new Error("oversized socket stayed open")),
+                2000,
+              );
+              socket.once("close", () => {
+                clearTimeout(timer);
+                resolve();
+              });
+              socket.on("error", () => {});
             });
-            socket.on("error", () => {});
-          });
-          socket.write("é".repeat(513));
-          await closed;
-          assert.equal(await owner.nextTask(10), undefined);
-        } else {
-          const lines = readline.createInterface({ input: socket });
-          const iterator = lines[Symbol.asyncIterator]();
-          socket.write(
-            `${JSON.stringify({ type: "submit_prompt", requestId: "large", message: "x".repeat(10 * 1024 * 1024 + 1), prompt: [{ type: "text", text: "small" }], permissionMode: "deny-all", waitForCompletion: false })}\n`,
-          );
-          assert.equal(((await nextJsonLine(iterator)) as { type: string }).type, "accepted");
-          assert.equal((await owner.nextTask(1000))?.requestId, "large");
-          lines.close();
+            socket.write("é".repeat(513));
+            await closed;
+            assert.equal(await owner.nextTask(10), undefined);
+          } else {
+            const lines = readline.createInterface({ input: socket });
+            const iterator = lines[Symbol.asyncIterator]();
+            // Start the acknowledgement deadline after the large upload drains.
+            await new Promise<void>((resolve, reject) => {
+              socket.write(
+                `${JSON.stringify({ type: "submit_prompt", requestId: "large", message: "x".repeat(10 * 1024 * 1024 + 1), prompt: [{ type: "text", text: "small" }], permissionMode: "deny-all", waitForCompletion: false })}\n`,
+                (error) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve();
+                  }
+                },
+              );
+            });
+            assert.equal(((await nextJsonLine(iterator)) as { type: string }).type, "accepted");
+            assert.equal((await owner.nextTask(1000))?.requestId, "large");
+            lines.close();
+          }
+        } finally {
+          socket.destroy();
+          await owner.close();
+          await releaseQueueOwnerLease(lease);
         }
-      } finally {
-        socket.destroy();
-        await owner.close();
-        await releaseQueueOwnerLease(lease);
       }
-    }
-  });
-});
+    });
+  },
+);

--- a/test/queue-test-helpers.ts
+++ b/test/queue-test-helpers.ts
@@ -162,8 +162,9 @@ export async function nextJsonLine(
   iterator: AsyncIterator<string>,
   timeoutMs = 2_000,
 ): Promise<unknown> {
+  let timer: ReturnType<typeof setTimeout>;
   const timeout = new Promise<never>((_resolve, reject) => {
-    setTimeout(() => reject(new Error("Timed out waiting for queue line")), timeoutMs);
+    timer = setTimeout(() => reject(new Error("Timed out waiting for queue line")), timeoutMs);
   });
 
   const next = (async () => {
@@ -174,5 +175,9 @@ export async function nextJsonLine(
     return JSON.parse(result.value);
   })();
 
-  return await Promise.race([next, timeout]);
+  try {
+    return await Promise.race([next, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
## What Problem This Solves

Unused runtime state and an obsolete cleanup script obscure the implementation. A queue test also races a 10 MiB upload against a two-second acknowledgment deadline, producing failures under full-suite load.

## User Impact

No product behavior or public interface changes. Contributors get compiler checks against unused code and a deterministic queue test that retains its large-payload and oversized-fragment assertions.

## Why This Change Was Made

Remove write-only formatter state, unused timeout storage and private parameters, an unreferenced cleanup script, and a duplicate lint rule. Preserve the exported conversation-operation signature. Enable TypeScript unused checks. Start the queue acknowledgment deadline after the write callback and clear helper timers when reads finish.

## Evidence

- `pnpm run check` passed: 1,043 passed, 2 existing platform skips; coverage suite 148 passed. Gated coverage: 95.10% lines/statements, 88.52% branches, 96.63% functions.
- Baseline full suite failed the existing queue deadline; the unchanged focused case passed in 1.50s. After the fix, the full suite's same payload/assertions passed in 1.40s.
- Built CLI: `node dist/cli.js --agent 'node dist-test/test/mock-agent.js' --format text exec 'echo phase-five-text'` printed `phase-five-text` and `[done] end_turn`, exit 0.
- Production Slophammer DRY: 0 candidates; dependency-boundary check: no findings.
- Isolated Codex autoreview at P0–P2: scoped-clean.
