### PR TITLE
fix(replay): preserve message identities across transcript projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Replay viewer: preserve user-message identities across repeated transcript projection so idle polling does not emit spurious patches.
 - Tooling: prevent malformed TOML configuration from hanging documentation lint by overriding the vulnerable `smol-toml` pin with 1.7.2 (GHSA-7w5x-hrqm-74c2).
 
 ## 0.15.1 - 2026-09-07

--- a/docs/2026-03-31-flow-replay-live-transport.md
+++ b/docs/2026-03-31-flow-replay-live-transport.md
@@ -64,6 +64,9 @@ re-decided during coding:
 - The server computes patches from **semantic viewer state**, not by patching
   storage files directly.
 - The on-disk bundle format stays unchanged in this work.
+- Replaying an unchanged bundle preserves message identities. Projected user
+  messages derive their identity from the session bundle and event sequence;
+  message identities already present in a persisted checkpoint stay unchanged.
 
 ## Goals
 

--- a/examples/flows/replay-viewer/server/live-run-state.ts
+++ b/examples/flows/replay-viewer/server/live-run-state.ts
@@ -162,10 +162,13 @@ function replayBundledSession(
       continue;
     }
 
+    // Replaying unchanged events must not create fresh identities on every poll.
+    const messageId = `replay:${sessionId}:${event.seq}`;
+
     const prompt = extractPromptFromMessage(event.message as AcpJsonRpcMessage);
     if (prompt) {
       const messageStart = conversation.messages.length;
-      recordPromptSubmission(conversation, prompt, event.at);
+      recordPromptSubmission(conversation, prompt, event.at, messageId);
       promptText = promptToDisplayText(prompt);
       liveTurn = {
         sessionId,
@@ -192,7 +195,7 @@ function replayBundledSession(
       };
     }
 
-    acpxState = recordSessionUpdate(conversation, acpxState, notification, event.at);
+    acpxState = recordSessionUpdate(conversation, acpxState, notification, event.at, messageId);
     liveTurn.eventEndSeq = event.seq;
     liveTurn.messageEnd = Math.max(liveTurn.messageStart, conversation.messages.length - 1);
   }

--- a/src/session/conversation-model.ts
+++ b/src/session/conversation-model.ts
@@ -601,6 +601,7 @@ export function recordPromptSubmission(
   conversation: SessionConversation,
   prompt: PromptInput | string,
   timestamp = isoNow(),
+  messageId?: string,
 ): string | undefined {
   const normalizedPrompt = typeof prompt === "string" ? textPrompt(prompt) : prompt;
   const userContent = normalizedPrompt
@@ -610,7 +611,7 @@ export function recordPromptSubmission(
     return undefined;
   }
 
-  const promptMessageId = nextUserMessageId();
+  const promptMessageId = messageId ?? nextUserMessageId();
   conversation.messages.push({
     User: {
       id: promptMessageId,
@@ -660,11 +661,12 @@ export function recordSessionUpdate(
   state: SessionAcpxState | undefined,
   notification: SessionNotification,
   timestamp = isoNow(),
+  userMessageId?: string,
 ): SessionAcpxState {
   const acpx = ensureAcpxState(state);
 
   const update: SessionUpdate = notification.update;
-  applySessionUpdate(conversation, acpx, update);
+  applySessionUpdate(conversation, acpx, update, userMessageId);
 
   updateConversationTimestamp(conversation, timestamp);
   trimConversationForRuntime(conversation);
@@ -692,21 +694,23 @@ function applySessionUpdate(
   conversation: SessionConversation,
   acpx: SessionAcpxState,
   update: SessionUpdate,
+  userMessageId?: string,
 ): void {
   const handler = SESSION_UPDATE_HANDLERS[update.sessionUpdate];
-  handler?.(conversation, acpx, update);
+  handler?.(conversation, acpx, update, userMessageId);
 }
 
 type SessionUpdateHandler = (
   conversation: SessionConversation,
   acpx: SessionAcpxState,
   update: SessionUpdate,
+  userMessageId?: string,
 ) => void;
 
 const SESSION_UPDATE_HANDLERS: Record<string, SessionUpdateHandler> = {
-  user_message_chunk: (conversation, _acpx, update) => {
+  user_message_chunk: (conversation, _acpx, update, userMessageId) => {
     if (update.sessionUpdate === "user_message_chunk") {
-      appendUserMessageChunk(conversation, update.content);
+      appendUserMessageChunk(conversation, update.content, userMessageId);
     }
   },
   agent_message_chunk: (conversation, _acpx, update) => {
@@ -759,14 +763,18 @@ const SESSION_UPDATE_HANDLERS: Record<string, SessionUpdateHandler> = {
   },
 };
 
-function appendUserMessageChunk(conversation: SessionConversation, content: ContentBlock): void {
+function appendUserMessageChunk(
+  conversation: SessionConversation,
+  content: ContentBlock,
+  messageId?: string,
+): void {
   const userContent = contentToUserContent(content);
   if (!userContent) {
     return;
   }
   conversation.messages.push({
     User: {
-      id: nextUserMessageId(),
+      id: messageId ?? nextUserMessageId(),
       content: [userContent],
     },
   });

--- a/test/replay-viewer-live-sync.test.ts
+++ b/test/replay-viewer-live-sync.test.ts
@@ -329,6 +329,62 @@ test("replay viewer streams selected-run ACP text as JSON Patch+ append updates"
   }
 });
 
+for (const sourceType of ["prompt", "user_message_chunk"] as const) {
+  test(`replay projection keeps ${sourceType} identities stable across reads and checkpoints`, async (t) => {
+    const runsDir = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-replay-identities-"));
+    t.after(() => fs.rm(runsDir, { recursive: true, force: true }));
+    const runId = "stable-identities";
+    const sessionId = "main-bundle";
+    await writeLiveSessionRunBundle(runsDir, {
+      runId,
+      sessionId,
+      promptText: "hello",
+      initialAgentText: "hel",
+    });
+    const sessionDir = path.join(runsDir, runId, "sessions", sessionId);
+    if (sourceType === "user_message_chunk") {
+      const eventsFile = path.join(sessionDir, "events.ndjson");
+      const events = (await fs.readFile(eventsFile, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as FlowBundledSessionEvent);
+      events[0].message = {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "agent-session",
+          update: {
+            sessionUpdate: "user_message_chunk",
+            content: { type: "text", text: "hello" },
+          },
+        },
+      };
+      await fs.writeFile(
+        eventsFile,
+        `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+      );
+    }
+
+    const source = createFilesystemRunSource(runsDir);
+    const first = await source.getRunState(runId);
+    assert.deepEqual(await source.getRunState(runId), first);
+
+    await appendLiveSessionChunk(runsDir, runId, sessionId, 3, "lo");
+    const grown = await source.getRunState(runId);
+    assert.deepEqual(await source.getRunState(runId), grown);
+    const firstUser = first.sessions[sessionId].record.messages?.[0];
+    assert.deepEqual(grown.sessions[sessionId].record.messages?.[0], firstUser);
+
+    const checkpoint = structuredClone(grown.sessions[sessionId].record);
+    const checkpointUser = checkpoint.messages?.[0] as { User: { id: string } };
+    checkpointUser.User.id = "persisted-user-id";
+    await fs.writeFile(path.join(sessionDir, "record.json"), JSON.stringify(checkpoint));
+    const restored = await source.getRunState(runId);
+    assert.deepEqual(restored.sessions[sessionId].record.messages?.[0], checkpointUser);
+    assert.deepEqual(await source.getRunState(runId), restored);
+  });
+}
+
 function createMessageInbox(socket: WebSocket) {
   const backlog: ReplayServerMessage[] = [];
   const waiters: Array<{


### PR DESCRIPTION
## What Problem This Solves

The replay viewer emits message-ID changes while a session bundle is idle because each transcript projection creates new random user IDs.

## User Impact

Repeated reads of unchanged history produce no patches. New text still streams normally, and existing checkpoint IDs remain authoritative.

## Why This Change Was Made

Separate identity allocation from conversation projection: live writers keep UUID defaults, while replay assigns IDs from the session bundle and event sequence for post-checkpoint messages. Both prompt submissions and inbound user-message chunks use the same policy. No wire or stored-bundle schema changes.

## Evidence

- Two regression cases failed before the fix, differing only in random user IDs. They now pass and cover repeated reads, transcript growth, and persisted checkpoint IDs.
- 15 focused replay/conversation tests passed.
- A standalone built-server proof used actual HTTP/WebSocket transport and filesystem bundles: `{"polls":11,"idlePatches":0,"appendedMarker":true,"stableUserIds":true}`. The server remained quiet during unchanged reads, then emitted the expected text append.
- Isolated P0–P2 Codex autoreview: scoped-clean.

- `pnpm run check` passed: 1,046 tests passed, two existing platform skips; 148 coverage tests passed. Documentation checks also passed.
