### PR TITLE
fix(acp): select model controls ahead of provider selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Repo: https://github.com/openclaw/acpx
 
 ### Fixes
 
+- Model selection: prefer the actual model control when an adapter also groups provider controls under the model category, while retaining custom model controls and legacy fallback. Thanks @wtfsayo.
 - Replay viewer: preserve user-message identities across repeated transcript projection so idle polling does not emit spurious patches.
 - Tooling: prevent malformed TOML configuration from hanging documentation lint by overriding the vulnerable `smol-toml` pin with 1.7.2 (GHSA-7w5x-hrqm-74c2).
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -129,6 +129,12 @@ All global options:
 
 Permission flags are mutually exclusive. Using more than one of `--approve-all`, `--approve-reads`, `--deny-all` is a usage error.
 
+For model configuration, acpx prefers a valid select control with both
+`category: "model"` and `id: "model"`. Otherwise it uses the first valid
+model-category control, including custom IDs, then the legacy `id: "model"`
+fallback. This keeps provider selectors in the same category from taking over
+the actual model control.
+
 ### Global option examples
 
 ```bash

--- a/src/acp/model-support.ts
+++ b/src/acp/model-support.ts
@@ -124,10 +124,8 @@ function isModelSelectOption(option: Record<string, unknown>): boolean {
   return option.type === "select" && (option.category === "model" || option.id === "model");
 }
 
-function parseModelConfigOption(value: unknown): SessionModelState | undefined {
-  const option = asRecord(value);
+function parseModelConfigOption(option: Record<string, unknown>): SessionModelState | undefined {
   if (
-    !option ||
     !isModelSelectOption(option) ||
     typeof option.id !== "string" ||
     typeof option.currentValue !== "string"
@@ -144,18 +142,36 @@ function parseModelConfigOption(value: unknown): SessionModelState | undefined {
     : undefined;
 }
 
+function modelConfigPriority(option: Record<string, unknown>): number {
+  if (option.category !== "model") {
+    return 0;
+  }
+  return option.id === "model" ? 2 : 1;
+}
+
 export function modelStateFromConfigOptions(configOptions: unknown): SessionModelState | undefined {
   if (!Array.isArray(configOptions)) {
     return undefined;
   }
 
+  let selected: SessionModelState | undefined;
+  let selectedPriority = -1;
   for (const value of configOptions) {
-    const models = parseModelConfigOption(value);
-    if (models) {
-      return models;
+    const option = asRecord(value);
+    if (!option) {
+      continue;
+    }
+    const models = parseModelConfigOption(option);
+    if (!models) {
+      continue;
+    }
+    const priority = modelConfigPriority(option);
+    if (priority > selectedPriority) {
+      selected = models;
+      selectedPriority = priority;
     }
   }
-  return undefined;
+  return selected;
 }
 
 export function modelStateFromLegacyResponse(response: unknown): SessionModelState | undefined {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1917,6 +1917,37 @@ test("integration: sessions new --model fails when the model config update fails
   });
 });
 
+test("integration: model selection targets the model control when provider shares its category", async () => {
+  await withTempHome(async (homeDir) => {
+    const result = await runCli(
+      [
+        "--agent",
+        `${MOCK_AGENT_COMMAND} --advertise-model-provider`,
+        "--cwd",
+        homeDir,
+        "--format",
+        "json",
+        "--model",
+        "smart-model",
+        "exec",
+        "echo selected-model",
+      ],
+      homeDir,
+    );
+    assert.equal(result.code, 0, result.stderr);
+    const messages = parseJsonRpcOutputLines(result.stdout);
+    const modelRequests = messages.filter(
+      (message) => message.method === "session/set_config_option",
+    );
+    assert.equal(modelRequests.length, 1);
+    assert.partialDeepStrictEqual(modelRequests[0].params, {
+      configId: "model",
+      value: "smart-model",
+    });
+    assert.match(result.stdout, /selected-model/);
+  });
+});
+
 test("integration: set model routes through the advertised config option and succeeds", async () => {
   await withTempHome(async (homeDir) => {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "acpx-integration-cwd-"));

--- a/test/mock-agent.ts
+++ b/test/mock-agent.ts
@@ -31,6 +31,7 @@ import {
   type ResumeSessionRequest,
   type ResumeSessionResponse,
   type SessionId,
+  type SessionConfigOption,
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
   type SetSessionModeRequest,
@@ -67,6 +68,7 @@ type MockAgentOptions = {
   setSessionModelInvalidParams: boolean;
   advertiseConfigOptions: boolean;
   advertiseModels: boolean;
+  advertiseModelProvider: boolean;
   advertiseLegacyModels: boolean;
   advertiseCommandsAfterNew: boolean;
   modelConfigId: string;
@@ -390,6 +392,7 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
   let setSessionModelInvalidParams = false;
   let advertiseConfigOptions = false;
   let advertiseModels = false;
+  let advertiseModelProvider = false;
   let advertiseLegacyModels = false;
   let advertiseCommandsAfterNew = false;
   let modelConfigId = "model";
@@ -464,6 +467,12 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
 
     if (token === "--advertise-models") {
       advertiseModels = true;
+      continue;
+    }
+
+    if (token === "--advertise-model-provider") {
+      advertiseModels = true;
+      advertiseModelProvider = true;
       continue;
     }
 
@@ -620,6 +629,7 @@ function parseMockAgentOptions(argv: string[]): MockAgentOptions {
     setSessionModelInvalidParams,
     advertiseConfigOptions,
     advertiseModels,
+    advertiseModelProvider,
     advertiseLegacyModels,
     advertiseCommandsAfterNew,
     modelConfigId,
@@ -719,6 +729,7 @@ function buildConfigOptions(
   modelConfigId: string,
   omitModelId?: string,
   currentModelId = state.modelId,
+  includeProvider = false,
 ): SetSessionConfigOptionResponse["configOptions"] {
   const reasoningEffort =
     typeof state.configValues.reasoning_effort === "string"
@@ -734,6 +745,18 @@ function buildConfigOptions(
   ].filter((option) => option.value !== omitModelId);
 
   return [
+    ...(includeProvider
+      ? [
+          {
+            id: "provider",
+            name: "Provider",
+            type: "select",
+            category: "model",
+            currentValue: "fixture-provider",
+            options: [{ value: "fixture-provider", name: "Fixture Provider" }],
+          } satisfies SessionConfigOption,
+        ]
+      : []),
     {
       id: "mode",
       name: "Session Mode",
@@ -838,6 +861,8 @@ class MockAgent implements Agent {
         this.sessions.get(sessionId) ?? createSessionState(false),
         this.options.modelConfigId,
         this.options.omitReconnectModelId,
+        undefined,
+        this.options.advertiseModelProvider,
       );
     }
 
@@ -919,6 +944,9 @@ class MockAgent implements Agent {
       response.configOptions = buildConfigOptions(
         this.sessions.get(sessionId) ?? createSessionState(false),
         this.options.modelConfigId,
+        undefined,
+        undefined,
+        this.options.advertiseModelProvider,
       );
     }
 
@@ -1110,6 +1138,7 @@ class MockAgent implements Agent {
         this.options.modelConfigId,
         this.options.omitReconnectModelId,
         this.options.reportModelAs,
+        this.options.advertiseModelProvider,
       ),
     };
   }

--- a/test/model-support.test.ts
+++ b/test/model-support.test.ts
@@ -3,9 +3,68 @@ import test from "node:test";
 import {
   assertRequestedModelSupported,
   isRequestedModelUnsupportedError,
+  modelStateFromConfigOptions,
   REQUESTED_MODEL_UNSUPPORTED_ERROR_CODE,
   RequestedModelUnsupportedError,
 } from "../src/acp/model-support.js";
+
+function modelSelect(id: string, category?: string) {
+  return {
+    id,
+    name: id,
+    type: "select",
+    category,
+    currentValue: `${id}-first`,
+    options: [{ value: `${id}-first`, name: `${id} first` }],
+  };
+}
+
+test("model config selection distinguishes a categorized model from provider controls", () => {
+  const provider = modelSelect("provider", "model");
+  const model = modelSelect("model", "model");
+  for (const options of [
+    [provider, model],
+    [model, provider],
+  ]) {
+    assert.deepEqual(modelStateFromConfigOptions(options), {
+      configId: "model",
+      currentModelId: "model-first",
+      availableModels: [{ modelId: "model-first", name: "model first" }],
+    });
+  }
+});
+
+test("model config selection preserves categorized custom controls ahead of legacy ids", () => {
+  const custom = modelSelect("llm", "model");
+  for (const category of [undefined, "mode"]) {
+    const legacy = modelSelect("model", category);
+    for (const options of [
+      [legacy, custom],
+      [custom, legacy],
+    ]) {
+      assert.equal(modelStateFromConfigOptions(options)?.configId, "llm");
+    }
+  }
+  assert.equal(modelStateFromConfigOptions([modelSelect("model")])?.configId, "model");
+  assert.equal(
+    modelStateFromConfigOptions([custom, modelSelect("other", "model")])?.configId,
+    "llm",
+  );
+});
+
+test("model config selection skips malformed preferred controls and retains grouped models", () => {
+  const custom = modelSelect("llm", "model");
+  const malformed = { ...modelSelect("model", "model"), options: null };
+  assert.equal(modelStateFromConfigOptions([malformed, custom])?.configId, "llm");
+  const grouped = {
+    ...modelSelect("model", "model"),
+    options: [{ group: "group", name: "Group", options: modelSelect("model").options }],
+  };
+  assert.equal(modelStateFromConfigOptions([custom, grouped])?.configId, "model");
+  assert.deepEqual(modelStateFromConfigOptions([custom, grouped])?.availableModels, [
+    { modelId: "model-first", name: "model first" },
+  ]);
+});
 
 test("Claude ACP model validation warns for unadvertised selectors", () => {
   const warning = assertRequestedModelSupported({


### PR DESCRIPTION
Related: https://github.com/openclaw/acpx/pull/561

## What Problem This Solves

`--model` can reject a valid model—or target a provider selector—when an adapter advertises provider and model controls in the same model category.

## User Impact

acpx selects the categorized `model` control when present, preserves custom categorized controls, and retains legacy ID-based fallback. Provider configuration stays separate from model selection.

## Why This Change Was Made

The parser previously returned the first valid candidate. Rank validated candidates using both existing signals: categorized `model`, other model-category controls, then legacy `id=model`. Stable ties and grouped-option parsing remain intact. This isolates the generic parser defect reported by @wtfsayo from the separate profile and startup-model proposals.

## Evidence

- Three parser regressions failed before the fix; all ten model-support tests now pass. Cases cover both control orders, custom/legacy precedence, malformed candidates, and grouped options.
- The real-process CLI regression failed before and passed after.
- Built CLI before: `--model smart-model` failed with `Available models: fixture-provider`. The same command afterward sent exactly one `session/set_config_option` with `configId=model`, `value=smart-model`, and completed with `end_turn`.
- Isolated P0–P2 Codex autoreview: scoped-clean.
- Release notes follow the maintainer-requested most-interesting-first order for this maintenance sweep.
- `pnpm run check`: 1,050 passed, two existing skips; coverage suite 148/148 passed. `pnpm run check:docs`: format, lint, and site build passed.
