### PR TITLE
test: add npm-pack release boundary for plan entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
           - name: Mutation
             node_version: 22
             command: pnpm run mutate
+          - name: Release boundary
+            node_version: 22
+            command: pnpm run test:release-boundary
           - name: Slophammer
             command: |
               pnpm dlx slophammer-ts@latest rules --format text

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:changed": "pnpm run test:coverage",
     "test:coverage": "pnpm run build && pnpm run build:test && node --test dist-test/test/*.test.js && c8 --all --check-coverage --lines 85 --branches 85 --functions 85 --statements 85 --include 'dist-test/src/flows/authoring.js' --include 'dist-test/src/flows/decision.js' --include 'dist-test/src/flows/definition.js' --include 'dist-test/src/flows/json.js' --include 'dist-test/src/flows/schema.js' --include 'dist-test/src/flows/store.js' --include 'dist-test/src/runtime/public/**/*.js' --include 'dist-test/src/runtime/engine/manager.js' --include 'dist-test/src/runtime/engine/status.js' --exclude 'dist-test/test/**/*.js' --exclude 'dist/**/*.js' node --test dist-test/test/flows.test.js dist-test/test/flows-store.test.js dist-test/test/runtime.test.js dist-test/test/runtime-events.test.js dist-test/test/runtime-manager.test.js dist-test/test/runtime-probe.test.js",
     "test:live": "pnpm run build:test && node --test dist-test/test/cursor-live.integration.js",
+    "test:release-boundary": "node ./scripts/release-plan-boundary.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:tsc": "tsc --noEmit",
     "viewer": "tsx examples/flows/replay-viewer/server.ts",

--- a/scripts/release-plan-boundary.mjs
+++ b/scripts/release-plan-boundary.mjs
@@ -1,0 +1,133 @@
+/**
+ * Release-boundary test: the published acpx tarball must deliver structured
+ * plan entries end to end. Packs this repo (npm pack runs prepack, like the
+ * release workflow), installs the tarball into an empty directory with
+ * production npm (like a consumer), then drives a real
+ * createAcpRuntime/startTurn against a fixture ACP agent that emits a plan
+ * notification with entries.
+ *
+ * Unit tests exercise src/ directly; this is the only check that proves the
+ * shipped dist/ carries the plan projection.
+ *
+ * Usage: node ./scripts/release-plan-boundary.mjs [--keep-stage]
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const KEEP = process.argv.includes("--keep-stage");
+
+function sh(cmd, args, options) {
+  return execFileSync(cmd, args, { stdio: "pipe", encoding: "utf8", timeout: 600_000, ...options });
+}
+
+const stage = mkdtempSync(join(tmpdir(), "acpx-release-plan-"));
+const cleanup = () => {
+  if (!KEEP) {
+    rmSync(stage, { recursive: true, force: true });
+  }
+};
+process.on("exit", cleanup);
+
+const tarball = sh("npm", ["pack", "--pack-destination", stage], { cwd: REPO })
+  .trim()
+  .split("\n")
+  .pop()
+  .trim();
+const tarballPath = join(stage, tarball);
+console.log(`packed: ${tarballPath}`);
+
+const installDir = join(stage, "install");
+mkdirSync(installDir, { recursive: true });
+sh("npm", ["init", "-y"], { cwd: installDir });
+sh("npm", ["install", tarballPath, "--omit=dev", "--no-audit", "--no-fund"], { cwd: installDir });
+console.log("tarball installed (production tree)");
+
+writeFileSync(
+  join(installDir, "plan-agent.mjs"),
+  `import { createInterface } from "node:readline";
+const write = (m) => process.stdout.write(JSON.stringify(m) + "\\n");
+const respond = (id, result) => write({ jsonrpc: "2.0", id, result });
+const notify = (sessionId, update) =>
+  write({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update } });
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+const timer = setTimeout(() => process.exit(0), 120_000);
+rl.on("line", (line) => {
+  timer.refresh();
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+  if (!msg || typeof msg.method !== "string") return;
+  const { id, method, params } = msg;
+  if (method === "initialize") {
+    respond(id, { protocolVersion: 1, authMethods: [], agentCapabilities: { promptCapabilities: {}, sessionCapabilities: { new: {}, load: {}, close: {}, cancel: {} } } });
+  } else if (method === "session/new") {
+    respond(id, { sessionId: "boundary-sid" });
+  } else if (method === "session/prompt") {
+    const sid = params?.sessionId ?? "boundary-sid";
+    notify(sid, { sessionUpdate: "plan", entries: [
+      { content: "write the file", status: "in_progress", priority: "high" },
+      { content: "verify", status: "pending", priority: "low" },
+    ] });
+    notify(sid, { sessionUpdate: "plan", entries: [] });
+    notify(sid, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "done" } });
+    respond(id, { stopReason: "end_turn" });
+  } else if (id !== undefined) {
+    respond(id, {});
+  }
+});
+`,
+);
+
+writeFileSync(
+  join(installDir, "plan-driver.mjs"),
+  `const acpx = await import("acpx/runtime");
+const dir = process.cwd();
+const runtime = acpx.createAcpRuntime({
+  cwd: dir,
+  sessionStore: acpx.createRuntimeStore({ stateDir: dir + "/state" }),
+  agentRegistry: acpx.createAgentRegistry({ overrides: { proof: ["node", dir + "/plan-agent.mjs"] } }),
+  permissionMode: "approve-all",
+});
+const handle = await runtime.ensureSession({ sessionKey: "boundary", agent: "proof", mode: "persistent", cwd: dir });
+const turn = runtime.startTurn({ handle, text: "hello" });
+await turn.promptStarted;
+for await (const event of turn.events) {
+  if (event.type === "status" && event.tag === "plan") console.log(JSON.stringify(event));
+}
+await turn.result;
+`,
+);
+
+const out = sh("node", ["plan-driver.mjs"], { cwd: installDir });
+const plans = out
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .map((line) => JSON.parse(line));
+const populated = plans.filter((e) => Array.isArray(e.entries) && e.entries.length === 2);
+const cleared = plans.filter((e) => Array.isArray(e.entries) && e.entries.length === 0);
+if (populated.length === 0) {
+  console.error("FAIL: no populated plan snapshot in release-tree turn events.");
+  console.error(out);
+  process.exit(1);
+}
+if (cleared.length === 0) {
+  console.error("FAIL: no explicit-empty plan replacement in release-tree turn events.");
+  console.error(out);
+  process.exit(1);
+}
+const first = populated[0].entries[0];
+if (
+  first.content !== "write the file" ||
+  first.status !== "in_progress" ||
+  first.priority !== "high"
+) {
+  console.error("FAIL: plan entries malformed in release-tree turn events.");
+  console.error(out);
+  process.exit(1);
+}
+console.log(
+  "PASS: release tarball delivers structured plan snapshots (populated + explicit empty).",
+);


### PR DESCRIPTION
Follow-up to #562 (merged): the only check that proves the shipped dist/ carries the plan projection.

## What

- `scripts/release-plan-boundary.mjs` (+ `test:release-boundary` script): `npm pack` this repo (runs prepack, like release) → install tarball into an empty dir with production npm (like a consumer) → real `createAcpRuntime/startTurn` against a fixture ACP agent emitting populated + explicitly-empty plan notifications → assert structured snapshots come through the release-tree event stream, exit 1 otherwise.
- CI matrix entry `Release boundary` alongside the other runtime gates.

Unit tests exercise src/ directly; this guards the pack/publish path (e.g. a missing dist rebuild or a flattened event shape would fail here while unit tests stay green).

## Verification

- Local: PASS (exit 0) — release tarball delivers populated + explicit-empty plan snapshots.
- `format:check`, `lint` clean. Test-only change, no changelog entry per repo guidelines.

Assisted by an AI coding agent.